### PR TITLE
Remove blank elements

### DIFF
--- a/plugin/js/parsers/BakaTsukiParser.js
+++ b/plugin/js/parsers/BakaTsukiParser.js
@@ -182,9 +182,8 @@ BakaTsukiParser.prototype.stripGalleryBox = function (element) {
     }
 }
 
-// discard blank divs and page created when moving elements
+// discard blank divs created when moving elements
 BakaTsukiParser.prototype.stripBlankElements = function(element){
-	util.removeElements(util.getElements(element, "p", e => (e.innerHTML.replace(/\s/g, "") == "")));
 	util.removeElements(util.getElements(element, "div", e => (e.innerHTML.replace(/\s/g, "") == "")));
 }
 

--- a/plugin/js/parsers/BakaTsukiParser.js
+++ b/plugin/js/parsers/BakaTsukiParser.js
@@ -86,6 +86,7 @@ BakaTsukiParser.prototype.epubItemSupplier = function () {
     let content = that.findContent(that.firstPageDom).cloneNode(true);
     that.removeUnwantedElementsFromContentElement(content);
     that.processImages(content, that.images);
+    that.stripBlankElements(content);
     let epubItems = that.splitContentIntoSections(content, that.firstPageDom.baseURI);
     that.fixupFootnotes(epubItems);
     return new BakaTsukiEpubItemSupplier(that, epubItems, that.images, that.coverImageInfo);
@@ -116,7 +117,7 @@ BakaTsukiParser.prototype.removeUnwantedElementsFromContentElement = function (e
     util.removeElements(util.getElements(element, "br"));
 
     // discard table of contents (will generate one from tags later)
-    util.removeElements(that.getElements(element, "div", e => (e.className === "toc")));
+    util.removeElements(that.getElements(element, "div", e => (e.id === "toc")));
 
     util.removeComments(element);
     that.removeUnwantedTable(element);
@@ -179,6 +180,12 @@ BakaTsukiParser.prototype.stripGalleryBox = function (element) {
     for(let gallery of galleries) {
         util.removeNode(gallery);
     }
+}
+
+// discard blank divs and page created when moving elements
+BakaTsukiParser.prototype.stripBlankElements = function(element){
+	util.removeElements(util.getElements(element, "p", e => (e.innerHTML.replace(/\s/g, "") == "")));
+	util.removeElements(util.getElements(element, "div", e => (e.innerHTML.replace(/\s/g, "") == "")));
 }
 
 BakaTsukiParser.prototype.stripWidthStyle = function (element) {

--- a/unitTest/UtestBakaTsukiParser.js
+++ b/unitTest/UtestBakaTsukiParser.js
@@ -20,7 +20,7 @@ function getTestDom() {
         "<x>" +
            "<!-- comment 1 -->" +
            "<h1>T1</h1>" +
-           "<div class=\"toc\"></div>" +
+           "<div id=\"toc\"></div>" +
            "<!-- comment 2 -->" +
            "<script>\"use strict\"</script>" +
            "<h2>T1.1</h2>" +


### PR DESCRIPTION
Fixes #27 & #24 
Was supposed to fix #28 by fixing #24 however because the epub readers also treat the novel illustrations as all one page even though pressing down gives you a new image (dafuq) this is unfixable without causing a crap ton of discrepancies between epub readers.

The best way to get rid of the blank page would be to simply add content to it.