### PR TITLE
Parse author name from a series page at wuxiaworld.co

### DIFF
--- a/plugin/js/parsers/WuxiaworldCoParser.js
+++ b/plugin/js/parsers/WuxiaworldCoParser.js
@@ -23,6 +23,10 @@ class WuxiaworldCoParser extends Parser{
         return dom.querySelector("div#info h1");
     };
 
+    extractAuthor(dom) {
+        return dom.querySelector("div#info p").textContent.substring(7);
+    }
+
     findChapterTitle(dom) {
         return dom.querySelector("div.bookname h1");
     }


### PR DESCRIPTION
Author's name is not being parsed in the current version and the default value `<unknown>` is being used. I've implemented the extractAuthor function in the WuxiaworldCoParser.js