### PR TITLE
Qidian parser extractAuthor function

### DIFF
--- a/plugin/js/parsers/QidianParser.js
+++ b/plugin/js/parsers/QidianParser.js
@@ -43,7 +43,6 @@ class QidianParser extends Parser{
     extractAuthor(dom) {
         let element = dom.querySelector("address p strong");
         if (element !== null) {
-            console.log(element.nextSibling.textContent);
             return element.nextSibling.textContent;
         }
         return super.extractAuthor(dom);

--- a/plugin/js/parsers/QidianParser.js
+++ b/plugin/js/parsers/QidianParser.js
@@ -41,17 +41,10 @@ class QidianParser extends Parser{
     };
 
     extractAuthor(dom) {
-        let element = dom.querySelector("address");
+        let element = dom.querySelector("address p strong");
         if (element !== null) {
-            element = util.getElement(element, "p", p => p.textContent.startsWith("Author"));
-            if (element !== null) {
-                let author = element.textContent;
-                let strong = element.querySelector("strong");
-                if (strong !== null) {
-                    author = author.substring(strong.textContent.length);
-                }
-                return author;
-            }
+            console.log(element.nextSibling.textContent);
+            return element.nextSibling.textContent;
         }
         return super.extractAuthor(dom);
     }


### PR DESCRIPTION
The current parser fails to extract author's name and falls back to default parser, returning `<unknown>`. This might be due to changes of the layout.

I've modified the extractAuthor function to properly parse the author's name.