### PR TITLE
Updated extractTitleImpl to discard the title acronym

### DIFF
--- a/plugin/js/parsers/QidianParser.js
+++ b/plugin/js/parsers/QidianParser.js
@@ -37,7 +37,7 @@ class QidianParser extends Parser{
 
     // title of the story
     extractTitleImpl(dom) {
-        return dom.querySelector("h2");
+        return dom.querySelector("h2").childNodes[0];
     };
 
     extractAuthor(dom) {


### PR DESCRIPTION
webnovel.com shows acronym of a book/series beside its title.

![image](https://user-images.githubusercontent.com/31449072/47101376-cd09c480-d231-11e8-8964-eace8feb824c.png)

The parser extracts the acronym along with the title which I find annoying. I've updated the `extractTitleImpl` function to discard the acronym and return only the title.