### PR TITLE
Fixed extractAuthor function of QidianParser.js

### DIFF
--- a/plugin/js/parsers/QidianParser.js
+++ b/plugin/js/parsers/QidianParser.js
@@ -41,17 +41,9 @@ class QidianParser extends Parser{
     };
 
     extractAuthor(dom) {
-        let element = dom.querySelector("address");
+        let element = dom.querySelector("address p strong");
         if (element !== null) {
-            element = util.getElement(element, "p", p => p.textContent.startsWith("Author"));
-            if (element !== null) {
-                let author = element.textContent;
-                let strong = element.querySelector("strong");
-                if (strong !== null) {
-                    author = author.substring(strong.textContent.length);
-                }
-                return author;
-            }
+            return element.nextSibling.textContent;
         }
         return super.extractAuthor(dom);
     }


### PR DESCRIPTION
QidianParser does not parse author's name and returns `<unknown>`. I've updated the extractAuthor function to properly parse author's name.