### PR TITLE
Modified title parsing of QidianParser to discard title acronym

### DIFF
--- a/plugin/js/parsers/QidianParser.js
+++ b/plugin/js/parsers/QidianParser.js
@@ -37,7 +37,7 @@ class QidianParser extends Parser{
 
     // title of the story
     extractTitleImpl(dom) {
-        return dom.querySelector("h2");
+        return dom.querySelector("h2").childNodes[0];
     };
 
     extractAuthor(dom) {


### PR DESCRIPTION
webnovel.com shows a title acronym alongside the title of a book. The QidianParser considers the acronym as a part of the title which I find annoying. I have modified the `extractTitleImpl` function to appropriately discard the acronym from the title.