### PR TITLE
Add main and section options to selectable content tags

### DIFF
--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -100,6 +100,8 @@
                     <td>
                         <select id="selectContentTag">
                             <option value="body" selected>&lt;body&gt;</option>
+                            <option value="main">&lt;main&gt;</option>
+                            <option value="section">&lt;section&gt;</option>
                             <option value="div">&lt;div&gt;</option>
                             <option value="article">&lt;article&gt;</option>
                         </select>


### PR DESCRIPTION
This commit expands "selectContentTag" options in user interface with two additional option, main and section. It is not uncommon for websites to put main content in main or section tags.