### PR TITLE
Add main and section options to select content

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     { "name": "toshiya44"},
     { "name": "dreamer2908"},
     { "name": "GallusMax"},
-    { "name": "Hogesyx"}
+    { "name": "Hogesyx"},
+    { "name": "snnsnn"}
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -100,6 +100,8 @@
                     <td>
                         <select id="selectContentTag">
                             <option value="body" selected>&lt;body&gt;</option>
+                            <option value="main">&lt;main&gt;</option>
+                            <option value="section">&lt;section&gt;</option>
                             <option value="div">&lt;div&gt;</option>
                             <option value="article">&lt;article&gt;</option>
                         </select>

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ Credits
 * Parser for German Project Gutenberg by GallusMax
 * Hogesyx
 * Asif Mahmood
+* snnsnn
 
 ## How to use with Baka-Tsuki:
 * Browse to a Baka-Tsuki web page that has the full text of a story.


### PR DESCRIPTION
This commit expands "selectContentTag" options in user interface with two additional option, main and section. It is not uncommon for website to put main content in main or section tags.

* [x] Have you updated the "contributors" section of packages.json with yuor name? (and ideally email, so I can contact you easily.)
* [x] Have you updated the "Credits" setion of readme.md with your name?
* [x] Are you committing to the ExperimentalTab branch?