### PR TITLE
fanfiction.net more info (+WLPublishingParser minor fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     { "name": "snnsnn"},
     { "name": "Tom Goetz"},
     { "name": "Sergii Pravdzivyi"}
+    { "name": "JimmXinu"}
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/js/parsers/FanFictionParser.js
+++ b/plugin/js/parsers/FanFictionParser.js
@@ -56,8 +56,33 @@ class FanFictionParser extends Parser {
         return this.extractTextFromProfile(dom, "a");
     }
 
+    populateInfoDiv(infoDiv, dom) {
+        let sanitize = new Sanitize();
+        // keep data-xutime for outside processing because locale time is local
+        sanitize.attributesForTag.set("span",["data-xutime"])
+        for(let n of this.getInformationEpubItemChildNodes(dom).filter(n => n != null)) {
+            let clone = n.cloneNode(true);
+            this.cleanInformationNode(clone);
+            if (clone != null) {
+                // convert dates to avoid '19hours ago'
+                for(let s of clone.querySelectorAll('span[data-xutime]')) {
+                    let time = new Date(1000*s.getAttribute("data-xutime"));
+                    s.textContent = time.toLocaleString();
+                }
+                // fix relative url links.
+                for(let a of clone.querySelectorAll('a[href]')) {
+                    a.href = new URL(a['href'], dom.baseURI).href
+                }
+                infoDiv.appendChild(sanitize.clean(clone));
+            }
+        }
+        // this "page" doesn't go through image collector, so strip images
+        util.removeChildElementsMatchingCss(infoDiv, "img");
+    }
+
     getInformationEpubItemChildNodes(dom) {
-        return [...dom.querySelectorAll("div#profile_top")];
+        return [...dom.querySelectorAll("div#pre_story_links"),
+                ...dom.querySelectorAll("div#profile_top")];
     }
 
     cleanInformationNode(node) {

--- a/plugin/js/parsers/FanFictionParser.js
+++ b/plugin/js/parsers/FanFictionParser.js
@@ -73,6 +73,10 @@ class FanFictionParser extends Parser {
                 for(let a of clone.querySelectorAll('a[href]')) {
                     a.href = new URL(a['href'], dom.baseURI).href
                 }
+                // Fix for > from CSS
+                for(let s of clone.querySelectorAll('span.icon-chevron-right')) {
+                    s.textContent = ' > '
+                }
                 infoDiv.appendChild(sanitize.clean(clone));
             }
         }

--- a/plugin/js/parsers/WLPublishingParser.js
+++ b/plugin/js/parsers/WLPublishingParser.js
@@ -9,7 +9,7 @@ parserFactory.register("scifistories.com", () => new WLPublishingParser());
 parserFactory.register("storiesonline.net", () => new WLPublishingParser());
 
 parserFactory.registerManualSelect(
-    "Default",
+    "WLPublishing",
     function() { return new WLPublishingParser() }
 );
 


### PR DESCRIPTION
The Information page for fanfiction.net had three problems:
- The 'category' or 'fandom', such as 'Books > Harry Potter' or 'Cartoons > Young Justice' wasn't being included.  Now included.
- Published/Updated times of '19m ago' or '5h ago' aren't useful long term.  Parsed datetimes to string, plus keep hidden seconds-since-epoch attribute.
- URLs in info page where coming out relative to `chrome-extension://<big ID>/...`. Make URLs in info page absolute from document source.

Adding category seemed straight-forward.  I'm not sure that the other changes are done the most 'preferred' way; I considered using `cleanInformationNode()` instead, but it's not really 'cleaning' as such.  If you'd prefer a different approach, please advise me and I'll give it a try.

Keeping the hidden seconds-since-epoch attribute is purely selfish--I hope to parse WebToEpub output in FanFicFare and FFF users _really_ care about metadata like that; but parsing locale time is a pain and including ISO time is ugly.

Also, an unrelated minor fix for WLPublishingParser -- the 'manually select parser' list had two 'Default' values.  Gave WLPublishingParser a name.  Didn't think it was worth a separate PR.