### PR TITLE
Add ability to manually set fetching delay per chapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     { "name": "snnsnn"},
     { "name": "Tom Goetz"},
     { "name": "Sergii Pravdzivyi"},
-    { "name": "JimmXinu"}
+    { "name": "JimmXinu"},
+    { "name": "Kondeeza"}
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -203,6 +203,10 @@
 		"message": "less tags",
 		"description": "Only extract genre"
 	},
+	"__MSG_label_Manual_Delay_Per_Chapter__": {
+		"message": "Manual Throttle|Delay per chapter",
+		"description": "Manual Throttle|Delay per chapter"
+	},
 	"__MSG_label_Manually_Select_Parser__": {
 		"message": "Manually Select Parser:",
 		"description": "Label for menu to change parser (in advanced options section)"

--- a/plugin/images/ChapterStateSleeping.svg
+++ b/plugin/images/ChapterStateSleeping.svg
@@ -1,0 +1,14 @@
+<svg version="1.1"
+     baseProfile="full"
+     width="32" height="32"
+     xmlns="http://www.w3.org/2000/svg">
+  <line stroke-width="2" y2="4.3" x2="15.1" y1="4.3" x1="6.2" stroke="#965607" />
+  <line stroke-width="2" y2="11.1" x2="15.0" y1="11.1" x1="6.0" stroke="#965607" />
+  <line y2="11.5" x2="6.7" y1="4.4" x1="14.4" stroke-dasharray="null" stroke-width="2" stroke="#965607" />
+  <line stroke-width="2" y2="9.0" x2="27.7" y1="9.0" x1="18.7" stroke="#965607" />
+  <line stroke-width="2" y2="15.8" x2="27.6" y1="15.8" x1="18.6" stroke="#965607" />
+  <line y2="16.2" x2="19.2" y1="9.1" x1="26.9" stroke-dasharray="null" stroke-width="2" stroke="#965607" />
+  <line stroke-width="2" y2="20.4" x2="16.3" y1="20.4" x1="7.3" stroke="#965607" />
+  <line stroke-width="2" y2="27.3" x2="16.2" y1="27.3" x1="7.2" stroke="#965607" />
+  <line y2="27.6" x2="7.9" y1="20.6" x1="15.6" stroke-dasharray="null" stroke-width="2" stroke="#965607" />
+</svg>

--- a/plugin/js/ChapterUrlsUI.js
+++ b/plugin/js/ChapterUrlsUI.js
@@ -436,11 +436,13 @@ class ChapterUrlsUI {
 ChapterUrlsUI.DOWNLOAD_STATE_NONE = 0;
 ChapterUrlsUI.DOWNLOAD_STATE_DOWNLOADING = 1;
 ChapterUrlsUI.DOWNLOAD_STATE_LOADED = 2;
+ChapterUrlsUI.DOWNLOAD_STATE_SLEEPING = 3;
 
 ChapterUrlsUI.ImageForState = [
     "images/ChapterStateNone.svg",
     "images/ChapterStateDownloading.svg",
-    "images/ChapterStateLoaded.svg"
+    "images/ChapterStateLoaded.svg",
+    "images/ChapterStateSleeping.svg"
 ];
 
 ChapterUrlsUI.lastSelectedRow = null;

--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -427,6 +427,10 @@ class Parser {
         ProgressBar.setValue(1);
     }
 
+    sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
     fetchWebPages() {
         let that = this;
 
@@ -466,8 +470,15 @@ class Parser {
         return blocks;
     }
 
-    fetchWebPageContent(webPage) {
+    randomInteger(min, max) {
+        return Math.floor(Math.random() * (max - min + 1)) + min;
+    }
+
+    async fetchWebPageContent(webPage) {
         let that = this;
+        let manualDelayPerChapterValue = (that.userPreferences.manualDelayPerChapter.value == "simulate_reading" )? that.randomInteger(420000,900000): parseInt(that.userPreferences.manualDelayPerChapter.value);  
+        ChapterUrlsUI.showDownloadState(webPage.row, ChapterUrlsUI.DOWNLOAD_STATE_SLEEPING);
+        await that.sleep(manualDelayPerChapterValue);
         ChapterUrlsUI.showDownloadState(webPage.row, ChapterUrlsUI.DOWNLOAD_STATE_DOWNLOADING);
         let pageParser = webPage.parser;
         return pageParser.fetchChapter(webPage.sourceUrl).then(function (webPageDom) {

--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -96,6 +96,7 @@ class UserPreferences {
         this.addPreference("maxPagesToFetchSimultaneously", "maxPagesToFetchSimultaneouslyTag", "1");
         this.addPreference("skipChaptersThatFailFetch", "skipChaptersThatFailFetchCheckbox", false);
         this.addPreference("maxChaptersPerEpub", "maxChaptersPerEpubTag", "10,000");
+        this.addPreference("manualDelayPerChapter", "manualDelayPerChapterTag", "0");
         this.addPreference("skipImages", "skipImagesCheckbox", false);
         this.addPreference("overwriteExistingEpub", "overwriteEpubWhenDuplicateFilenameCheckbox", false);
         this.addPreference("themeColor", "themeColorTag", "");

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -281,6 +281,25 @@
                         </td>
                         <td>__MSG_label_Max_chapters_per_epub__</td>
                     </tr>
+                    <tr id="manualDelayPerChapter">
+                        <td>
+                            <select id="manualDelayPerChapterTag">
+                                <option value="0" selected>Default (No Chapter Throttle/Delay)</option>
+                                <option value="3000">3 Secs/Chapter</option>
+                                <option value="5000">5 Secs/Chapter </option>
+                                <option value="10000">10 Secs/Chapter</option>
+                                <option value="20000">20 Secs/Chapter </option>
+                                <option value="30000">30 Secs/Chapter</option>
+                                <option value="60000">1 Min/Chapter</option>
+                                <option value="300000">5 Mins/Chapter</option>
+                                <option value="600000">10 Mins/Chapter</option>
+                                <option value="1800000">30 Mins/Chapter</option>
+                                <option value="3600000">60 Mins/Chapter</option>
+                                <option value="simulate_reading">Simulate Reading (7-15 Mins/Chapter)</option>
+                            </select>
+                        </td>
+                        <td>__MSG_label_Manual_Delay_Per_Chapter__</td>
+                    </tr>
                     <tr id="IncludeInReadingListRow">
                         <td><input id="includeInReadingListCheckbox" type="checkbox" name="includeInReadingListCheckbox" value="false"></td>
                         <td>__MSG_label_Include_in_Reading_List__</td>

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@ Credits
 * Tom Goetz
 * Alen Toma (css styling)
 * JimmXinu
+* Kondeeza
 
 ## How to use with Baka-Tsuki:
 * Browse to a Baka-Tsuki web page that has the full text of a story.


### PR DESCRIPTION
### Pull Request Check List

- Do all existing unit tests pass?  `yes. 566 assertions of 566 passed, 0 failed. (Firefox)`
- Have all warnings and errors reported by eslint been fixed? `yes. that was a tough one because the whole npm thing is new to me.  Managed to follow all instruction until this step "Command line for eslint is "eslint packed.js > error.txt" then got eslint command not recognised error. Ended up just installing eslint plugin for vscode which then throw indentation error on my line and I later corrected`
- If you've added new behavior, Can a user turn it off? Is it off by default? `It's off by default, Accessible in Advanced Options , no reason to throttle if it works normally after all`
- Have you updated the "contributors" section of packages.json with your name? (and ideally email, so I can contact you easily.) `yes`
- Have you updated the "Credits" section of readme.md with your name? `yes`
- Are you committing to the ExperimentalTab branch? `Eh, I'm new to working with others in Github and its branch feature. Should I be working on ExperimentalTab branch instead of the main one? Don't really know whether experimental branch is for "almost certainly working commits waiting for more extensive test" or "experimental experimental commits that's halfway working". Let me know if I should pull merge request to experimental branch instead. Sorry for wordy question`
- Have you rebased your commit?  `no`

### What does it do?

Options to Throttle/delay fetching webpage by x seconds/chapter. Accessible via Advanced option (Off by default).

I saw some people in the issue tab had similar issue of wanting to throttle and had to throttle via 'object inspector' as hotfix. I want to make it easier for basic users to throttle speed because even I don't know how to throttle via 'object inspector'.

### Why? isn't error 429, 509  auto exponential throttle enough?

There were some site that just outright block you for a whole day after fetching 50 chapters within an hour (even with no simultaneous fetching), causing the whole packing to fail.  This is useful for users with 24/7 PC who are willing to throttle chapter fetching  as long as epub gets compile eventually.

It's also compatible with simultaneous fetching, so you can get 1 Chapter /3 Secs , 2 Chapter /5 Secs,  8 Chapter /1 Minutes, etc. (Or even adjust speed during the fetching process)

### Screenshots

![sleeping_icon](https://user-images.githubusercontent.com/3808273/109439020-d30a4400-7a80-11eb-89a1-eb04a4569d41.JPG)


![newconfig](https://user-images.githubusercontent.com/3808273/109439226-9428be00-7a81-11eb-9c62-a65522927f92.JPG)