### PR TITLE
Fix site freewebnovel.com for novels with less than 40 chapters

### DIFF
--- a/plugin/js/parsers/FreeWebNovelParser.js
+++ b/plugin/js/parsers/FreeWebNovelParser.js
@@ -18,21 +18,22 @@ class FreeWebNovelParser extends Parser {
 
     static getUrlsOfTocPages(dom) {
         // lastUrl should be example https://freewebnovel.com/<some-novel-name>/<index>.html
-        let lastUrl = dom.querySelectorAll(".page a.lastTocIndex-container-btn")[3];
-        if (lastUrl == null) {
-            lastUrl = dom.querySelectorAll("a.index-container-btn")[3];
-        }
-        lastUrl = lastUrl.href;
-
+        let lastUrl = dom.querySelectorAll(".page a.index-container-btn")[3].href;
         let lastTocIndex = lastUrl.lastIndexOf("/");
         let lastIndexPageName = lastUrl.substring(lastTocIndex + 1);
         let lastIndex = parseInt(lastIndexPageName.substr(0, lastIndexPageName.length - ".html".length));
-        let baseUrl = lastUrl.substring(0, lastTocIndex + 1);
-        let urls = [];
-        for (var i = 2; i <= lastIndex; ++i) {
-            urls.push(baseUrl + i + ".html");
+        if (isNaN(lastIndex)) {
+            // If less then 40 chapter the link is to the frontpage instead of a "index" page, this will be NaN
+            return [];
+        } else {
+            let baseUrl = lastUrl.substring(0, lastTocIndex + 1);
+            let urls = [];
+            for (var i = 2; i <= lastIndex; ++i) {
+                urls.push(baseUrl + i + ".html");
+            }
+            return urls;
         }
-        return urls;
+
     }
 
     static extractPartialChapterList(dom) {


### PR DESCRIPTION
Fix two things
1) `let lastUrl = dom.querySelectorAll(".page a.lastTocIndex-container-btn")[3];` -> `dom.querySelectorAll(".page a.index-container-btn")[3]` was an error in the previous commit where i did a IDE refactoring of a variable named `index` to `lastTocIndex` which changed the css selector as well. 
2) As I was checking i did some more testing and found that if there are less than 40 chapter it will generate an error. So I did a fix for that as well.