### PR TITLE
Fix error caused by novels on Madara without description

### DIFF
--- a/plugin/js/parsers/MadaraParser.js
+++ b/plugin/js/parsers/MadaraParser.js
@@ -56,7 +56,12 @@ class MadaraParser extends WordpressBaseParser{
     }
 
     extractDescription(dom) {
-        return dom.querySelector("div .summary__content").textContent.trim();
+        let selectedElement = dom.querySelector("div .summary__content");
+        if (selectedElement)
+        {
+            return selectedElement.textContent.trim();
+        }
+        return "";
     }
     
 


### PR DESCRIPTION
Novels using this parser where the site has failed to enter any description caused a failure which prevented further generation. Simply defaulted summary to return empty when no description is detected.

Considering how simple this pull request is, feel free to just copy/paste or whatever is simpler rather than merge.