### PR TITLE
add npm release scripts

### DIFF
--- a/eslint/pack.js
+++ b/eslint/pack.js
@@ -217,17 +217,17 @@ var makeManifestForChrome = function(data) {
     return manifest;    
 }
 
-var packExtension = function(manifest, fileExtension, browser) {
+var packExtension = function(manifest, fileExtension) {
     let zip = new JSZip();
     zip.file("manifest.json", JSON.stringify(manifest));
-    return packNonManifestExtensionFiles(zip, "WebToEpub." + browser + "." + manifest.version + fileExtension);
+    return packNonManifestExtensionFiles(zip, "WebToEpub" + manifest.version + fileExtension);
 }
 
 // pack the extensions for Chrome and firefox
 readFilePromise("../plugin/manifest.json")
     .then(function (data) {
-        packExtension(makeManifestForFirefox(data), ".xpi", "firefox");
-        packExtension(makeManifestForChrome(data), ".zip", "chrome");
+        packExtension(makeManifestForFirefox(data), ".xpi");
+        packExtension(makeManifestForChrome(data), ".zip");
     }).catch(function (err) {
         console.log(err);
     });

--- a/eslint/pack.js
+++ b/eslint/pack.js
@@ -217,17 +217,17 @@ var makeManifestForChrome = function(data) {
     return manifest;    
 }
 
-var packExtension = function(manifest, fileExtension) {
+var packExtension = function(manifest, fileExtension, browser) {
     let zip = new JSZip();
     zip.file("manifest.json", JSON.stringify(manifest));
-    return packNonManifestExtensionFiles(zip, "WebToEpub" + manifest.version + fileExtension);
+    return packNonManifestExtensionFiles(zip, "WebToEpub." + browser + "." + manifest.version + fileExtension);
 }
 
 // pack the extensions for Chrome and firefox
 readFilePromise("../plugin/manifest.json")
     .then(function (data) {
-        packExtension(makeManifestForFirefox(data), ".xpi");
-        packExtension(makeManifestForChrome(data), ".zip");
+        packExtension(makeManifestForFirefox(data), ".xpi", "firefox");
+        packExtension(makeManifestForChrome(data), ".zip", "chrome");
     }).catch(function (err) {
         console.log(err);
     });

--- a/eslint/release.js
+++ b/eslint/release.js
@@ -8,6 +8,7 @@ let version = JSON.parse(fs.readFileSync("plugin/manifest.json", 'utf-8')).versi
 let isDraft = process.argv.includes('draft');
 let isPrerelease = process.argv.includes('pre');
 let commitHash = execSync('git rev-parse --short HEAD').toString().trim();
+let commitLongHash = execSync('git rev-parse HEAD').toString().trim();
 let nameVersion = isPrerelease ? `${version}.pre-${commitHash}` : version;
 
 execSync('npm run lint');
@@ -27,7 +28,7 @@ let command = `
 	--title ${version}${isPrerelease ? '.pre-' + commitHash : ''}
 	${chromeCopyName}
 	${firefoxCopyName}
-	--target ${isPrerelease ? 'ExperimentalTabMode' : 'master'}
+	--target ${isPrerelease ? commitLongHash : 'master'}
 	--notes ""
 	${isPrerelease ? '--prerelease' : ''}
 	${isDraft ? '--draft' : ''}

--- a/eslint/release.js
+++ b/eslint/release.js
@@ -1,0 +1,38 @@
+"use strict";
+
+var fs = require("fs");
+var npm = require("npm-commands");
+var { execSync } = require('child_process');
+
+let version = JSON.parse(fs.readFileSync("plugin/manifest.json", 'utf-8')).version;
+let isDraft = process.argv.includes('draft');
+let isPrerelease = process.argv.includes('pre');
+let commitHash = execSync('git rev-parse --short HEAD').toString().trim();
+let nameVersion = isPrerelease ? `${version}.pre-${commitHash}` : version;
+
+execSync('npm run lint');
+
+let chromeName = `./eslint/WebToEpub.chrome.${version}.zip`;
+let firefoxName = `./eslint/WebToEpub.firefox.${version}.xpi`;
+let chromeCopyName = `./eslint/WebToEpub.chrome.${nameVersion}.zip`
+let firefoxCopyName = `./eslint/WebToEpub.firefox.${nameVersion}.zip`;
+
+fs.copyFileSync(chromeName, chromeCopyName);
+// make firefox version a zip for user to unzip, because unsigned xpis can't be installed
+fs.copyFileSync(firefoxName, firefoxCopyName);
+
+let command = `
+	gh release create
+	${version}${isPrerelease ? '.pre-' + commitHash : ''}
+	--title ${version}${isPrerelease ? '.pre-' + commitHash : ''}
+	${chromeCopyName}
+	${firefoxCopyName}
+	--target ${isPrerelease ? 'ExperimentalTabMode' : 'master'}
+	--notes ""
+	${isPrerelease ? '--prerelease' : ''}
+	${isDraft ? '--draft' : ''}
+`.replace(/\n\t?/g, ' ').trim();
+
+
+console.log(command)
+execSync(command, {stdio: 'inherit'});

--- a/eslint/release.js
+++ b/eslint/release.js
@@ -10,6 +10,11 @@ let isPrerelease = process.argv.includes('pre');
 let commitHash = execSync('git rev-parse --short HEAD').toString().trim();
 let commitLongHash = execSync('git rev-parse HEAD').toString().trim();
 let nameVersion = isPrerelease ? `${version}.pre-${commitHash}` : version;
+let branch = execSync('git rev-parse --abbrev-ref HEAD');
+
+if (branch != 'master' && !isPrerelease) {
+	throw new Error('Can not make a full release: not on master branch');
+}
 
 execSync('npm run lint');
 

--- a/eslint/release.js
+++ b/eslint/release.js
@@ -11,9 +11,15 @@ let commitHash = execSync('git rev-parse --short HEAD').toString().trim();
 let commitLongHash = execSync('git rev-parse HEAD').toString().trim();
 let nameVersion = isPrerelease ? `${version}.pre-${commitHash}` : version;
 let branch = execSync('git rev-parse --abbrev-ref HEAD');
+let masterCommitHash = execSync('git rev-parse origin/master').toString().trim();
 
-if (branch != 'master' && !isPrerelease) {
-	throw new Error('Can not make a full release: not on master branch');
+if (!isPrerelease) {
+	if (branch != 'master') {
+		throw new Error('Can not make a full release: not on master branch');
+	}
+	if (commitLongHash != masterCommitHash) {
+		throw new Error('Can not make a full release: master is not pushed to remote');
+	}
 }
 
 execSync('npm run lint');

--- a/eslint/release.js
+++ b/eslint/release.js
@@ -2,27 +2,27 @@
 
 var fs = require("fs");
 var npm = require("npm-commands");
-var { execSync } = require('child_process');
+var { execSync } = require("child_process");
 
-let version = JSON.parse(fs.readFileSync("plugin/manifest.json", 'utf-8')).version;
-let isDraft = process.argv.includes('draft');
-let isPrerelease = process.argv.includes('pre');
-let commitHash = execSync('git rev-parse --short HEAD').toString().trim();
-let commitLongHash = execSync('git rev-parse HEAD').toString().trim();
+let version = JSON.parse(fs.readFileSync("plugin/manifest.json", "utf-8")).version;
+let isDraft = process.argv.includes("draft");
+let isPrerelease = process.argv.includes("pre");
+let commitHash = execSync("git rev-parse --short HEAD").toString().trim();
+let commitLongHash = execSync("git rev-parse HEAD").toString().trim();
 let nameVersion = isPrerelease ? `${version}.pre-${commitHash}` : version;
-let branch = execSync('git rev-parse --abbrev-ref HEAD');
-let masterCommitHash = execSync('git rev-parse origin/master').toString().trim();
+let branch = execSync("git rev-parse --abbrev-ref HEAD");
+let masterCommitHash = execSync("git rev-parse origin/master").toString().trim();
 
 if (!isPrerelease) {
-	if (branch != 'master') {
-		throw new Error('Can not make a full release: not on master branch');
-	}
-	if (commitLongHash != masterCommitHash) {
-		throw new Error('Can not make a full release: master is not pushed to remote');
-	}
+    if (branch != "master") {
+        throw new Error("Can not make a full release: not on master branch");
+    }
+    if (commitLongHash != masterCommitHash) {
+        throw new Error("Can not make a full release: master is not pushed to remote");
+    }
 }
 
-execSync('npm run lint');
+execSync("npm run lint");
 
 let chromeName = `./eslint/WebToEpub.chrome.${version}.zip`;
 let firefoxName = `./eslint/WebToEpub.firefox.${version}.xpi`;
@@ -35,16 +35,16 @@ fs.copyFileSync(firefoxName, firefoxCopyName);
 
 let command = `
 	gh release create
-	${version}${isPrerelease ? '.pre-' + commitHash : ''}
-	--title ${version}${isPrerelease ? '.pre-' + commitHash : ''}
+	${version}${isPrerelease ? ".pre-" + commitHash : ""}
+	--title ${version}${isPrerelease ? ".pre-" + commitHash : ""}
 	${chromeCopyName}
 	${firefoxCopyName}
-	--target ${isPrerelease ? commitLongHash : 'master'}
+	--target ${isPrerelease ? commitLongHash : "master"}
 	--notes ""
-	${isPrerelease ? '--prerelease' : ''}
-	${isDraft ? '--draft' : ''}
-`.replace(/\n\t?/g, ' ').trim();
+	${isPrerelease ? "--prerelease" : ""}
+	${isDraft ? "--draft" : ""}
+`.replace(/\n\t?/g, " ").trim();
 
 
 console.log(command)
-execSync(command, {stdio: 'inherit'});
+execSync(command, {stdio: "inherit"});

--- a/eslint/release.js
+++ b/eslint/release.js
@@ -24,8 +24,8 @@ if (!isPrerelease) {
 
 execSync("npm run lint");
 
-let chromeName = `./eslint/WebToEpub.chrome.${version}.zip`;
-let firefoxName = `./eslint/WebToEpub.firefox.${version}.xpi`;
+let chromeName = `./eslint/WebToEpub${version}.zip`;
+let firefoxName = `./eslint/WebToEpub${version}.xpi`;
 let chromeCopyName = `./eslint/WebToEpub.chrome.${nameVersion}.zip`
 let firefoxCopyName = `./eslint/WebToEpub.firefox.${nameVersion}.zip`;
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "postinstall": "copyfiles -V -u 1 node_modules/jszip/dist/jszip.min.js plugin",
     "test": "http-server -o unitTest/Tests.html",
     "lint": "cd eslint && node pack.js && eslint packed.js",
-    "build": "cd eslint && node pack.js"
+    "build": "cd eslint && node pack.js",
+    "release": "node eslint/release.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### add npm release scripts
use as `npm run release` with optional additional args `pre` and `draft`
requires [Github CLI (`gh`)](https://github.com/cli/cli)

- `npm run release` - makes a release on `master` with correct tag `0.0.0.xxx` and with chrome and firefox zips  
   provides link to the rease in the end of output
- `npm run release draft` - same, but makes a *draft* of release (should be comfirmed in web to actually create tag and release)
- `npm run release pre` - makes a *pre*release (not displayed as latest in main github page) on `ExperimentalTabMode` branch with tag `0.0.0.xxx.pre-[commit hash]` with zips  
   provides link to the rease in the end of output
- `npm run release pre draft` - same, but makes a *draft* of release