### PR TITLE
Fix downloads when using Firefox for Android

### DIFF
--- a/plugin/js/Download.js
+++ b/plugin/js/Download.js
@@ -64,14 +64,44 @@ class Download {
     }
 
     static saveOnFirefox(options, cleanup) {
-        if (Download.isAndroid()) {
-            options.saveAs = false;
-        }
-        return browser.downloads.download(options).then(
-            // on Firefox, resolves when "Save As" dialog CLOSES, so no
-            // need to delay past this point.
-            downloadId => Download.onDownloadStarted(downloadId, cleanup)
-        ).catch(cleanup);
+        return browser.runtime.getPlatformInfo().then(platformInfo => {
+            // If the extension's web page is opened with the
+            // "Reqeust Desktop Site" toggle enabled then only the second check
+            // will correctly detect android.
+            //
+            // This is important to support since fetch requests can be
+            // redirected to mobile versions of web sites when the toggle is
+            // disabled.
+            if (Download.isAndroid() || platformInfo.os.toLowerCase().includes("android")) {
+                try {
+                    options.saveAs = false;
+
+                    // `browser.downloads.download` isn't implemented in
+                    // "Firefox for Android" yet, so we starts downloads
+                    // the same way any normal web page would do it:
+                    const link = document.createElement("a");
+                    link.style.display = "hidden";
+
+                    link.href = options.url;
+                    link.download = options.filename;
+
+                    document.body.appendChild(link);
+                    try {
+                        link.click();
+                    } finally {
+                        document.body.removeChild(link);
+                    }
+                } finally {
+                    cleanup();
+                }
+            } else {
+                return browser.downloads.download(options).then(
+                    // on Firefox, resolves when "Save As" dialog CLOSES, so no
+                    // need to delay past this point.
+                    downloadId => Download.onDownloadStarted(downloadId, cleanup)
+                );
+            }
+        }).catch(cleanup);
     }
 
     static isAndroid() {

--- a/plugin/js/Download.js
+++ b/plugin/js/Download.js
@@ -73,27 +73,24 @@ class Download {
             // redirected to mobile versions of web sites when the toggle is
             // disabled.
             if (Download.isAndroid() || platformInfo.os.toLowerCase().includes("android")) {
+                options.saveAs = false;
+
+                // `browser.downloads.download` isn't implemented in
+                // "Firefox for Android" yet, so we starts downloads
+                // the same way any normal web page would do it:
+                const link = document.createElement("a");
+                link.style.display = "hidden";
+
+                link.href = options.url;
+                link.download = options.filename;
+
+                document.body.appendChild(link);
                 try {
-                    options.saveAs = false;
-
-                    // `browser.downloads.download` isn't implemented in
-                    // "Firefox for Android" yet, so we starts downloads
-                    // the same way any normal web page would do it:
-                    const link = document.createElement("a");
-                    link.style.display = "hidden";
-
-                    link.href = options.url;
-                    link.download = options.filename;
-
-                    document.body.appendChild(link);
-                    try {
-                        link.click();
-                    } finally {
-                        document.body.removeChild(link);
-                    }
+                    link.click();
                 } finally {
-                    cleanup();
+                    document.body.removeChild(link);
                 }
+                cleanup();
             } else {
                 return browser.downloads.download(options).then(
                     // on Firefox, resolves when "Save As" dialog CLOSES, so no


### PR DESCRIPTION
This change allows using the extension on Firefox Fenix (the newer "Firefox for Android" browser). 

It seems like the `browser.downloads.download` API isn't implemented yet in Fenix so when it is called nothing happens. No error is thrown but the promise never resolves either. As a workaround I used a temp `a` tag to initiate the download as suggested at [Download File Using JavaScript/jQuery - Stack Overflow](https://stackoverflow.com/questions/3749231/download-file-using-javascript-jquery/9834261#9834261).

I also improved the Android detection using the [`browser.runtime.getPlatformInfo`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getPlatformInfo) API. This isn't required but it is very useful since it works even when the extension page is opened with the "Reqeust Desktop Site" toggle enabled. When I tested my changes with a story from https://www.fanfiction.net/ I noticed that the addon would try to download chapters from https://www.m.fanfiction.net/ (notice the m) even though I specified URLs without the "m". It [seems that the server is looking at the `User-Agent` header](https://stackoverflow.com/questions/11702453/how-does-chromes-request-desktop-site-option-work) and returning a redirect response (to the `fetch` method). If the extension web page is also opened with the "Reqeust Desktop Site" toggle enabled then the `User-Agent` for the fetch requests is overridden and they are no longer redirected. I suppose one could maybe [manually override the `User-Agent`](https://stackoverflow.com/questions/42815087/sending-a-custom-user-agent-string-along-with-my-headers-fetch) in this extension's code but I think it is simpler to leave that work to the browser. It would be nice with some better error messages for these cases (tell the user to try the "Reqeust Desktop Site" toggle for the extension's web page and warn about URLs that are redirected to a mobile site).

Fixes #480.