### PR TITLE
Move Tab Logic to Background Script

### DIFF
--- a/plugin/background.js
+++ b/plugin/background.js
@@ -1,0 +1,44 @@
+function getActiveTab() {
+    return new Promise(function (resolve, reject) {
+        chrome.tabs.query({currentWindow: true, active: true}, function (tabs) {
+            if ((tabs != null) && (0 < tabs.length)) {
+                resolve(tabs[0].id);
+            } else {
+                reject();
+            }
+        });
+    });
+}
+
+function openTabWindow() {
+    // open new tab window, passing ID of open tab with content to convert to epub as query parameter.
+    getActiveTab().then(function (tabId) {
+        let url = chrome.runtime.getURL("popup.html") + "?id=";
+        url += tabId;
+        chrome.tabs.create({url: url});
+        window.close();
+    });
+}
+
+chrome.browserAction.onClicked.addListener(
+    function () {
+        openTabWindow();
+    }
+);
+
+chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+    fetch(request.input, request.init).then(function (response) {
+        return response.text().then(function (text) {
+            sendResponse([{
+                body: text,
+                status: response.status,
+                statusText: response.statusText,
+            }, null]);
+        });
+    }, function (error) {
+        sendResponse([null, error]);
+    });
+    return true;
+});
+
+

--- a/plugin/js/main.js
+++ b/plugin/js/main.js
@@ -261,28 +261,6 @@ var main = (function () {
         userPreferences.readFromUi();
     }
 
-    function openTabWindow() {
-        // open new tab window, passing ID of open tab with content to convert to epub as query parameter.
-        getActiveTab().then(function (tabId) {
-            let url = chrome.runtime.getURL("popup.html") + "?id=";
-            url += tabId;
-            chrome.tabs.create({ url: url });
-            window.close();
-        });
-    }
-
-    function getActiveTab() {
-        return new Promise(function (resolve, reject) {
-            chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
-                if ((tabs != null) && (0 < tabs.length)) {
-                    resolve(tabs[0].id);
-                } else {
-                    reject();
-                };
-            });
-        });
-    }
-
     function onLoadAndAnalyseButtonClick() {
         // load page via XmlHTTPRequest
         let url = getValueFromUiField("startingUrlInput");
@@ -576,17 +554,15 @@ var main = (function () {
     // actions to do when window opened
     window.onload = function () {
         userPreferences = UserPreferences.readFromLocalStorage();
-        if (isRunningInTabMode()) {
-            localizeHtmlPage();
-            getAdvancedOptionsSection().hidden = !userPreferences.advancedOptionsVisibleByDefault.value;
-            addEventHandlers();
-            populateControls();
-            if (util.isFirefox()) {
-                Firefox.startWebRequestListeners();
-            }
-        } else {
-            openTabWindow();
+        localizeHtmlPage();
+        getAdvancedOptionsSection().hidden = !userPreferences.advancedOptionsVisibleByDefault.value;
+        addEventHandlers();
+        populateControls();
+        /*
+        if (util.isFirefox()) {
+            Firefox.startWebRequestListeners();
         }
+        */
     }
 
     return {

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -8,17 +8,20 @@
   },
   "permissions": [
     "downloads",
-    "webRequest",
-    "webRequestBlocking",
-    "<all_urls>"
+    "<all_urls>",
+    "*://*/*",
+    "tabs"
   ],
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": false
+  },
   "browser_action": {
     "browser_style": false,
     "default_title": "",
-    "default_icon": "book128.png",
-    "default_popup": "popup.html"
+    "default_icon": "book128.png"
   },
-  "incognito": "split",
+  "incognito": "spanning",
   "applications": {
     "gecko": {
       "id": "WebToEpub@Baka-tsuki.org",


### PR DESCRIPTION
This is more of a proof of concept than an actual pull request. 

There are some leftover functions that I accidentally left in from trying to maneuver around CORS on IOS Safari. I also accidentally left in "incognito": "spanning" for testing on Firefox. 

Is there a reason this extension doesn't use something like webpack with its crossbrowser support? More of a rhetorical question, I haven't learned enough to understand the difference that it would make. I only know that trying to import different node modules didn't work out so smoothly because of it.

If you are fine with moving the tab logic to the background script, this fixes a bug on Safari MacOS and IOS that causes it to either flicker on startup and not work, or open a new tab while opening the popup on top of the extension tab.