### PR TITLE
Implement pagestage.kakao.com Parser

### DIFF
--- a/plugin/js/parsers/KakaoParser.js
+++ b/plugin/js/parsers/KakaoParser.js
@@ -1,0 +1,125 @@
+"use strict";
+
+parserFactory.registerUrlRule(
+    url => KakaoParser.isValidUrl(url),
+    () => new KakaoParser()
+);
+
+class KakaoParser extends Parser {
+    constructor() {
+        super();
+    }
+
+    static isValidUrl(url) {
+        // Return true when is on the table of contents page.
+        // Perhaps narrow this down so it can't execute on the chapters, but needs
+        // to execute on the chapter api
+        if (util.extractHostName(url).includes("api-pagestage.kakao.com")) {
+            return true;
+        }
+        if (util.extractHostName(url).includes("pagestage.kakao.com")) {
+            if(!url.includes("episode")) {
+                if(url.includes("novel")) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    async fetchChapter(url) {
+        let jsonUrl;
+        if (!url.includes("api-pagestage")) {
+            jsonUrl = url.replace("pagestage", "api-pagestage") + "/body";
+        } else {
+            jsonUrl = url + "/body";
+        }
+
+        let json = (await HttpClient.fetchJson(jsonUrl)).json;
+
+        let doc = Parser.makeEmptyDocForContent(url);
+
+        let metaChapId = doc.dom.createElement("meta");
+        metaChapId.id = "chapterId";
+        metaChapId.content = url.split("/")[6];
+        doc.content.appendChild(metaChapId);
+
+        let metaNovelId = doc.dom.createElement("meta");
+        metaNovelId.id = "novelId";
+        metaNovelId.content = url.split("/")[4];
+        doc.content.appendChild(metaNovelId);
+
+        let novelTitle = doc.dom.createElement("meta");
+        novelTitle.id = "novelTitle";
+        novelTitle.content = json.novelTitle;
+        doc.content.appendChild(novelTitle);
+
+        let body = json.body.split("\n").filter(s => !util.isNullOrEmpty(s));
+
+        let title = doc.dom.createElement("h1");
+        title.id = "title";
+        title.textContent = json.title + " - " + body[0];
+        doc.content.appendChild(title);
+
+        let div = doc.dom.createElement("div");
+        div.id = "content";
+        for(let i = 1; i < body.length; ++i){
+            let p = doc.dom.createElement("p");
+            p.textContent = body[i];
+            div.appendChild(p);
+        }
+        doc.content.appendChild(div);
+
+        return doc.dom;
+    }
+
+    findContent(dom) {
+        return dom.getElementById("content");
+    }
+
+    async getChapterUrls(dom) {
+        let jsonUrl = dom.baseURI.replace("pagestage", "api-pagestage");
+        let json = (await HttpClient.fetchJson(jsonUrl)).json;
+
+        jsonUrl = dom.baseURI.replace("pagestage", "api-pagestage")
+                        + "/episodes?size=" + json.publishedEpisodeCount
+                        + "&sort=publishedAt,id,asc";
+        json = (await HttpClient.fetchJson(jsonUrl)).json;
+
+        let chapterList = [];
+        for(let chapter of json.content) {
+            let url = dom.baseURI.replace("pagestage", "api-pagestage")
+                    + "/episodes/" + chapter.id;
+            let chapterInfo = {
+                sourceUrl: url,
+                title: chapter.title,
+                newArc: null
+            };
+            chapterList.push(chapterInfo);
+        }
+
+        return Promise.resolve(chapterList);
+    }
+
+    // extractAuthor
+    extractAuthor(dom) {
+        return dom.querySelector('[property="article:author"]').content;
+    }
+    // extractSubject
+    extractSubject(dom) {
+        return dom.querySelector('[name="tiara-pageMeta-category"]').content;
+    }
+    // extractDescription
+    extractDescription(dom) {
+        return dom.querySelector('[property="og:description"]').content;
+    }
+    // findChapterTitle
+    findChapterTitle(dom) {
+        return dom.getElementById("title");
+    }
+
+    // findCoverImageUrl
+    findCoverImageUrl(dom) {
+        return dom.querySelector('[property="og:image"]').content;
+    }
+}

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -486,6 +486,7 @@
     <script src="js/parsers/JadeRabbitParser.js"></script>
     <script src="js/parsers/JaptemParser.js"></script>
     <script src="js/parsers/JpmtlParser.js"></script>
+    <script src="js/parsers/KakaoParser.js"></script>
     <script src="js/parsers/KakuyomuParser.js"></script>
     <script src="js/parsers/KnoxtspaceParser.js"></script>
     <script src="js/parsers/KrytykalParser.js"></script>


### PR DESCRIPTION
This adds the requested parser and closes #639 

Finally had some time. 

Wondering about the alternative to a problem I had. Because all the data was passed to the page through GET calls, I wanted to modify the TOC dom so that when get author, genre, and such was called, it would be able to access the information directly from the api. I didn't see a way to modify that dom. Is there currently no method or is there an alternative I didn't think of? I'll look through the other parsers to see what they did.

This time, the page luckily came with the data pre-javascript execution so I was able to get the data from there.