### PR TITLE
Update to H1 H2 CSS

### DIFF
--- a/plugin/js/EpubMetaInfo.js
+++ b/plugin/js/EpubMetaInfo.js
@@ -57,7 +57,6 @@ class EpubMetaInfo {
         // Centered headings and some margin to make sure it's not too close to the content.
         "h1, h2 {\r"+
         "   text-align: center;\r"+
-        "   page-break-before: always;\r"+
         "   margin-bottom: 10%;\r"+
         "   margin-top: 10%;\r"+
         "}\r"+


### PR DESCRIPTION
After recent updates to iOS and Android, page-break-before causes some weird behavior in some ebook reader.

Specifically, it render an entire blank page on some reader(iOS Book), or break text to speech on some other reader(eink android reader, unknown engine).

I have tested and confirm that it is indeed this tag that causes the issue using Calibre to rebuild the epub.

In most cases, this tag is redundant and alternatively we can try out other method if page break is really required(eg page-break-after on p tag)

