### PR TITLE
Add support for PG-15 chapters from Kakao.com

### DIFF
--- a/eslint/.eslintrc.js
+++ b/eslint/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
     "env": {
         "browser": true,
         "es6": true,
-		"webextensions": true,
+        "webextensions": true,
     },
     "parserOptions": {
         "ecmaVersion": 2020


### PR DESCRIPTION
I was unfortunately forced to learn promises and could no longer chain awaits 😢.

I messed up my git completely and was stuck to commit this fork a few commits behind. For some reason, rebasing, refetching, remerging, hard undoing commits, etc, would not correct the git history to match with ExperimentalTabMode. Thankfully, since it is behind, I was able to pull request just the two commits.

Required to be logged in with a verified account to download PG-15 books.

Closes #648

-----

KNOWN BUGS:
Start on the main page when using WebToEpub. Having ?page=[num] in the url can and will break the rest of the code.
Adding "&& !url.includes("page")" will cause it to break as well. Requires specific if and else cases within wrapFetch to clean URLs. Ugly. Much better to start on main page.

Written on a MacBook. I ran "npm run lint -- --fix" and it fixed all the line ending errors, but if it occurs, this is why.