### PR TITLE
Open tab as child of current tab

### DIFF
--- a/plugin/js/main.js
+++ b/plugin/js/main.js
@@ -281,7 +281,7 @@ var main = (function () {
         getActiveTab().then(function (tabId) {
             let url = chrome.runtime.getURL("popup.html") + "?id=";
             url += tabId;
-            chrome.tabs.create({ url: url });
+            chrome.tabs.create({ url: url, openerTabId: tabId });
             window.close();
         });
     }


### PR DESCRIPTION
Fixes #702.

This simply makes the web2epub tab open as a child of the current one, which means it's directly after the current tab, rather than at the end of the tab list.