### PR TITLE
Fixed Library.js LibMergeEpub()

### DIFF
--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -272,8 +272,8 @@
 		"description": "No tags and description in metadata"
 	},
 	"__MSG_label_auto_search_metadata__": {
-		"message": "auto search metadata on novelupdates or wlnupdates (long loading time)",
-		"description": "auto search metadata on novelupdates or wlnupdates"
+		"message": "auto search Metadata on novelupdates or wlnupdates (long loading time)",
+		"description": "auto search Metadata on novelupdates or wlnupdates"
 	},
 	"__MSG_label_less_tags__": {
 		"message": "less tags",

--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -47,6 +47,7 @@ class Library {
 
     static async LibMergeEpub(PreviousEpub, AddEpub, LibidURL){
         return new Promise((resolve, reject) => {
+            Library.LibShowLoadingText();
             let Prevjszip = new JSZip();
             let Addjszip = new JSZip();
             Prevjszip.loadAsync(PreviousEpub).then(async function(PreviousEpubzip) {
@@ -161,16 +162,21 @@ class Library {
                             string2 = "<li><a href=\""+ newChaptername.slice(6) + "\">"+AddEpubTocText.match(regex1)[0].replace(regex2, "").replace(regex3, "")+"</a></li>";
                             PreviousEpubTocEpub3Text = PreviousEpubTocEpub3Text.replace(string1, string2+string1);
                         }
+                        PreviousEpubzip = await PreviousEpubzip.loadAsync(await ToMergeEpubzip.generateAsync({ type: "blob", compression: "DEFLATE", mimeType: "application/epub+zip",}));
+                        ToMergeEpubzip = new JSZip();
                         TextnumberPreviousEpub++;
                         TextnumberAddEpub++;
                     }
-                    ToMergeEpubzip.file("OEBPS/content.opf", PreviousEpubContentText, { compression: "DEFLATE" });
-                    ToMergeEpubzip.file("OEBPS/toc.ncx", PreviousEpubTocText, { compression: "DEFLATE" });
-                    if (PreviousEpubTocEpub3Text != null) {
-                        ToMergeEpubzip.file("OEBPS/toc.xhtml", PreviousEpubTocEpub3Text, { compression: "DEFLATE" });
-                    }
                     let ToMergeEpubzipgenerated = await ToMergeEpubzip.generateAsync({ type: "blob", compression: "DEFLATE", mimeType: "application/epub+zip",});
                     PreviousEpubzip.loadAsync(ToMergeEpubzipgenerated).then(async function (zip) {
+                        zip.remove("OEBPS/content.opf");
+                        zip.file("OEBPS/content.opf", PreviousEpubContentText, { compression: "DEFLATE" });
+                        zip.remove("OEBPS/toc.ncx");
+                        zip.file("OEBPS/toc.ncx", PreviousEpubTocText, { compression: "DEFLATE" });
+                        if (PreviousEpubTocEpub3Text != null) {
+                            zip.remove("OEBPS/toc.xhtml");
+                            zip.file("OEBPS/toc.xhtml", PreviousEpubTocEpub3Text, { compression: "DEFLATE" });
+                        }
                         let content = await zip.generateAsync({ type: "blob", compression: "DEFLATE", mimeType: "application/epub+zip",});
                         Library.LibHandelUpdate(-1, content, await Library.LibGetFromStorage("LibStoryURL" + LibidURL), await Library.LibGetFromStorage("LibFilename" + LibidURL), LibidURL);
                         resolve(content);


### PR DESCRIPTION
Bug:
1. Go to https://www.royalroad.com/fiction/11209/the-legend-of-randidly-ghosthound
2. Click WebToEpub
3. Download Chapter 1-813 and Chapter 814-2098 in seperate epubs
4. Click Library -> Check Show Advanced Library Options
5. Click Upload Epub
6. Select the Epub with Chapter 1-813
7. Right click -> Inspect -> Sources -> Library.js
8. Set Breakpoint on line 174 (let content = await zip.generateAsync({ type: "blob", com)
9. Click Add Chapter from different EPUB
10. select the epub with Chapter 814-2098
11. js stops on Breakpoint
12. Press F10
13. js doesn't execute/stops without error

I don't know what was wrong in the old code.