### PR TITLE
Fix: fixLazyLoadImageSource when image source in data-src attribute

### DIFF
--- a/plugin/js/ImageCollector.js
+++ b/plugin/js/ImageCollector.js
@@ -270,9 +270,12 @@ class ImageCollector {
             }
         }
 
-        let lazySrc = img.getAttribute("data-lazy-src");
-        if (lazySrc != null) {
-            img.src = lazySrc;
+        for(let attrib of ["data-lazy-src", "data-src"]) {
+            let lazySrc = img.getAttribute(attrib);
+            if (lazySrc != null) {
+                img.src = lazySrc;
+                break;
+            }
         }
         return img.src;
     }


### PR DESCRIPTION
Some websites have image path in data-src attribute.
Example:
`<img class="lazyload" data-background="" data-src="https://ranobelib.me/uploads/ranobe/goburin-sureiya/chapters/1843364/7-tom-nacalnye-illyustracii-1_NsIU.jpg" />`