### PR TITLE
Fix: fixLazyLoadImageSource when image source in data-src attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     { "name": "Dimava"},
     { "name": "Leone Jacob Sunil (ImLJS)"},
     { "name": "Yoanhg421"},
-    { "name": "xRahul"}
+    { "name": "xRahul"},
+    { "name": "Oleksii Taranenko"}
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/js/ImageCollector.js
+++ b/plugin/js/ImageCollector.js
@@ -270,9 +270,12 @@ class ImageCollector {
             }
         }
 
-        let lazySrc = img.getAttribute("data-lazy-src");
-        if (lazySrc != null) {
-            img.src = lazySrc;
+        for(let attrib of ["data-lazy-src", "data-src"]) {
+            let lazySrc = img.getAttribute(attrib);
+            if (lazySrc != null) {
+                img.src = lazySrc;
+                break;
+            }
         }
         return img.src;
     }

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@ Credits
 * Yoanhg421
 * Leone Jacob Sunil (ImLJS)
 * xRahul
+* Oleksii Taranenko
 
 ## How to use with Baka-Tsuki:
 * Browse to a Baka-Tsuki web page that has the full text of a story.


### PR DESCRIPTION
Some websites have image path in data-src attribute.
Example:
`<img class="lazyload" data-background="" data-src="https://ranobelib.me/uploads/ranobe/goburin-sureiya/chapters/1843364/7-tom-nacalnye-illyustracii-1_NsIU.jpg" />`