### PR TITLE
Fix #1112 - Fixed QQ image redirect issue

### DIFF
--- a/plugin/js/parsers/QuestionableQuestingParser.js
+++ b/plugin/js/parsers/QuestionableQuestingParser.js
@@ -78,6 +78,11 @@ class QuestionableQuestingParser extends Parser{
             if (i.src !== dataUrl ) {
                 i.src = dataUrl;
             }
+
+            if (i.src.indexOf("/threads/") < 40) //Simple check to see if early proxy link is misdirected through thread uri.
+            {
+                i.src = i.src.replace(/https:\/\/questionablequesting\.com\/threads\/[\w\-\d\.]+?\/proxy\.php\?/i, "https://questionablequesting.com/proxy.php?");
+            }
         }
     }
 


### PR DESCRIPTION
Replaced full thread path with basic path to QQ proxy, using regex to replace entire qq path up to proxy.php with the correct path. Somewhat brute-force, but the easiest working solution.