### PR TITLE
Remove Royalroad watermark

### DIFF
--- a/plugin/js/parsers/RoyalRoadParser.js
+++ b/plugin/js/parsers/RoyalRoadParser.js
@@ -32,6 +32,27 @@ class RoyalRoadParser extends Parser{
         return content || dom.querySelector(".page-content-wrapper");
     }
 
+    preprocessRawDom(webPageDom) { 
+        this.removeWatermarks(webPageDom);
+    }
+
+    //watermarks are regular <p> elements set to "display: none" by internal css
+    removeWatermarks(webPageDom) {
+        //href === null means it's internal css
+        let internalStyles = [...webPageDom.styleSheets].filter(st => st.href === null);
+        let allCssRules = [];
+        for(let style of internalStyles) {
+            for(let rule of style.rules) {
+                allCssRules.push(rule);
+            }
+        }
+        let filtered = allCssRules.filter(s => s.style.display == "none");
+        
+        for(let i = 0; i < filtered.length; i++) {
+            webPageDom.querySelector(filtered[i].selectorText)?.remove();
+        }
+    }
+
     populateUI(dom) {
         super.populateUI(dom);
         document.getElementById("removeAuthorNotesRow").hidden = false; 


### PR DESCRIPTION
Royal road recently added watermarks - in every chapter, they insert a single `<p>` element.
This element is then set `display: none` by internal css.
You can check this easily by running following code in any chapter:
`[...document.querySelectorAll('p')].filter(p => getComputedStyle(p).display == 'none');`

As WebToEpub doesn't grab css, the text is shown in final epub.

This PR grabs the internal css, looks for elements that are set `display: none` and removes them.