### PR TITLE
Fix #1314 - Update ScribblehubParser.js to remove unnecessary fields

### DIFF
--- a/plugin/js/parsers/ScribblehubParser.js
+++ b/plugin/js/parsers/ScribblehubParser.js
@@ -36,7 +36,7 @@ class ScribblehubParser extends Parser{
     }
 
     findContent(dom) {
-        return dom.querySelector("div#chp_contents");
+        return dom.querySelector("div#chp_raw");
     };
 
     populateUI(dom) {


### PR DESCRIPTION
Switched FindContent selector to div#chp_raw instead of div#chp_content - it's an inner div that only includes the content of the chapter and author notes.