### PR TITLE
Mark scribblehub announcement-card as an author-note

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     { "name": "perishableloc"}, 
     { "name": "praschke"},
     { "name": "ImmortalDreamer"},
-    { "name": "ktrin"}
+    { "name": "ktrin"},
+    { "name": "nozwock" }
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/js/parsers/ScribblehubParser.js
+++ b/plugin/js/parsers/ScribblehubParser.js
@@ -1,6 +1,6 @@
 "use strict";
 
-parserFactory.register("scribblehub.com", function () { return new ScribblehubParser() });
+parserFactory.register("scribblehub.com", () => new ScribblehubParser());
 
 class ScribblehubParser extends Parser {
     constructor() {
@@ -62,8 +62,7 @@ class ScribblehubParser extends Parser {
     }
 
     preprocessRawDom(webPageDom) {
-        this.tagAuthorNotesBySelector(webPageDom, ".wi_authornotes");
-        this.tagAuthorNotesBySelector(webPageDom, ".wi_news");
+        this.tagAuthorNotesBySelector(webPageDom, ".wi_authornotes", ".wi_news");
     }
 
     getInformationEpubItemChildNodes(dom) {

--- a/plugin/js/parsers/ScribblehubParser.js
+++ b/plugin/js/parsers/ScribblehubParser.js
@@ -1,8 +1,8 @@
 "use strict";
 
-parserFactory.register("scribblehub.com", function() { return new ScribblehubParser() });
+parserFactory.register("scribblehub.com", function () { return new ScribblehubParser() });
 
-class ScribblehubParser extends Parser{
+class ScribblehubParser extends Parser {
     constructor() {
         super();
     }
@@ -41,7 +41,7 @@ class ScribblehubParser extends Parser{
 
     populateUI(dom) {
         super.populateUI(dom);
-        document.getElementById("removeAuthorNotesRow").hidden = false; 
+        document.getElementById("removeAuthorNotesRow").hidden = false;
     }
 
     extractTitleImpl(dom) {
@@ -52,7 +52,7 @@ class ScribblehubParser extends Parser{
         let author = dom.querySelector("span.auth_name_fic");
         return (author === null) ? super.extractAuthor(dom) : author.textContent;
     };
-    
+
     findChapterTitle(dom) {
         return dom.querySelector("div.chapter-title").textContent;
     }
@@ -63,6 +63,7 @@ class ScribblehubParser extends Parser{
 
     preprocessRawDom(webPageDom) {
         this.tagAuthorNotesBySelector(webPageDom, ".wi_authornotes");
+        this.tagAuthorNotesBySelector(webPageDom, ".wi_news");
     }
 
     getInformationEpubItemChildNodes(dom) {

--- a/plugin/js/parsers/ScribblehubParser.js
+++ b/plugin/js/parsers/ScribblehubParser.js
@@ -11,7 +11,7 @@ class ScribblehubParser extends Parser {
         let baseUrl = dom.baseURI;
         let nextTocIndex = 1;
         let numChapters = parseInt(dom.querySelector("span.cnt_toc").textContent);
-        let nextTocPageUrl = function (dom, chapters, lastFetch) {
+        let nextTocPageUrl = function (_dom, chapters, lastFetch) {
             // site has bug, sometimes, won't return chapters, so 
             // don't loop forever when this happens
             return ((chapters.length < numChapters) && (0 < lastFetch.length))
@@ -29,10 +29,6 @@ class ScribblehubParser extends Parser {
     static getChapterUrlsFromTocPage(dom) {
         return [...dom.querySelectorAll("a.toc_a")]
             .map(a => util.hyperLinkToChapter(a))
-    }
-
-    static nextTocPageUrl(baseUrl, nextTocIndex) {
-        return `${baseUrl}?toc=${nextTocIndex}`;
     }
 
     findContent(dom) {

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,7 @@ Credits
 * praschke
 * ImmortalDreamer
 * ktrin
+* nozwock
 
 ## How to use with Baka-Tsuki:
 * Browse to a Baka-Tsuki web page that has the full text of a story.


### PR DESCRIPTION
In addition to the bottom author's note card, ScribbleHub also offers an announcement card (or news) option at the top.

This PR adds it to the `Remove Author Note` option.

Here's an instance of a chapter having it: https://www.scribblehub.com/read/426788-ecdysis/chapter/519798/

![](https://github.com/dteviot/WebToEpub/assets/57829219/35bff041-d953-4a28-b183-df94fe64761b)
