### PR TITLE
#1378   create default parser rate

### DIFF
--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -311,6 +311,10 @@
 		"message": "Additional Metadata URL",
 		"description": "Additional Metadata URL"
 	},
+	"__MSG_label_Override_Default_Minimum_Delay__": {
+		"message": "Override Minimum Throttle Value (where applicable)",
+		"description": "Override Minimum Throttle Value (where applicable)"
+	},
 	"__MSG_label_Overwrite_Epub_When_Filename_Duplicte__": {
 		"message": "Overwrite existing EPUB file with same name",
 		"description": "Label for checkbox to toggle between 'overwrite exisitng Epub files' and 'make names unique'"

--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -51,8 +51,9 @@ class ParserState {
     }
 }
 
-class Parser {
+class Parser {    
     constructor(imageCollector) {
+        this.minimumThrottle = null;
         this.state = new ParserState();
         this.imageCollector = imageCollector || new ImageCollector();
         this.userPreferences = null;
@@ -662,8 +663,24 @@ class Parser {
         return await this.getChaptersFromAllTocPages(chapters, extractPartialChapterList, urlsOfTocPages, chapterUrlsUI);
     }
 
+    getRateLimit()
+    {
+        if (this.userPreferences.manualDelayPerChapter.value == "simulate_reading")
+        {
+            return this.userPreferences.manualDelayPerChapter.value;
+        }
+        let manualDelayPerChapterValue = parseInt(this.userPreferences.manualDelayPerChapter.value);
+
+        if (!this.userPreferences.overrideMinimumDelay.value)
+        {
+            return Math.max(this.minimumThrottle, manualDelayPerChapterValue);
+        }
+        return manualDelayPerChapterValue;
+    }
+
     async rateLimitDelay() {
-        let manualDelayPerChapterValue = (this.userPreferences.manualDelayPerChapter.value == "simulate_reading" )? util.randomInteger(420000,900000): parseInt(this.userPreferences.manualDelayPerChapter.value);  
+        let manualDelayPerChapterValue = this.getRateLimit();
+        manualDelayPerChapterValue = (manualDelayPerChapterValue == "simulate_reading" )? util.randomInteger(420000,900000): manualDelayPerChapterValue;
         await util.sleep(manualDelayPerChapterValue);
     }
 

--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -98,6 +98,7 @@ class UserPreferences {
         this.addPreference("skipChaptersThatFailFetch", "skipChaptersThatFailFetchCheckbox", false);
         this.addPreference("maxChaptersPerEpub", "maxChaptersPerEpubTag", "10,000");
         this.addPreference("manualDelayPerChapter", "manualDelayPerChapterTag", "0");
+        this.addPreference("overrideMinimumDelay", "overrideMinimumDelayCheckbox", false);
         this.addPreference("skipImages", "skipImagesCheckbox", false);
         this.addPreference("overwriteExistingEpub", "overwriteEpubWhenDuplicateFilenameCheckbox", false);
         this.addPreference("themeColor", "themeColorTag", "");

--- a/plugin/js/parsers/69shuParser.js
+++ b/plugin/js/parsers/69shuParser.js
@@ -8,6 +8,7 @@ parserFactory.registerUrlRule(
 class ShuParser extends Parser{
     constructor() {
         super();
+        this.minimumThrottle = 1000;
     }
 
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/FanFictionParser.js
+++ b/plugin/js/parsers/FanFictionParser.js
@@ -11,6 +11,7 @@ parserFactory.register("www.fictionpress.com", function() { return new FanFictio
 class FanFictionParser extends Parser {
     constructor() {
         super();
+        this.minimumThrottle = 3000;
     }
 
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/RanobesParser.js
+++ b/plugin/js/parsers/RanobesParser.js
@@ -6,6 +6,7 @@ parserFactory.register("ranobes.top", () => new RanobesParser());
 class RanobesParser extends Parser{
     constructor() {
         super();
+        this.minimumThrottle = 1000;
     }
 
     async getChapterUrls(dom, chapterUrlsUI) {

--- a/plugin/js/parsers/ScribblehubParser.js
+++ b/plugin/js/parsers/ScribblehubParser.js
@@ -5,6 +5,7 @@ parserFactory.register("scribblehub.com", () => new ScribblehubParser());
 class ScribblehubParser extends Parser {
     constructor() {
         super();
+        this.minimumThrottle = 3000;
     }
 
     async getChapterUrls(dom, chapterUrlsUI) {

--- a/plugin/js/parsers/Template.js
+++ b/plugin/js/parsers/Template.js
@@ -28,6 +28,13 @@ parserFactory.registerRule(
 class TemplateParser extends Parser{
     constructor() {
         super();
+        //Optional Parameters:
+
+        /*
+        // Minimum delay (in ms) between page requests. Useful for 403 error prevention.
+        // If the sites this parser accesses throttles requests or uses cloudflare, it is recommended to set this.
+        this.minimumThrottle = 3000;
+        */
     }
 
     // returns promise with the URLs of the chapters to fetch

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -413,6 +413,10 @@
                     </tr>
                 </table>
                 <table id="advancedOptionsTable">
+                    <tr id="overrideParserDelayWithManualDelay">
+                        <td><input id="overrideMinimumDelayCheckbox" type="checkbox" name="overrideMinimumDelayCheckbox" value="false"></td>
+                        <td>__MSG_label_Override_Default_Minimum_Delay__</td>
+                    </tr>
                     <tr id="IncludeInReadingListRow">
                         <td><input id="includeInReadingListCheckbox" type="checkbox" name="includeInReadingListCheckbox" value="false"></td>
                         <td>__MSG_label_Include_in_Reading_List__</td>


### PR DESCRIPTION
Implemented logic for a default minimum rate threshold for requests.

Base Parser.js minimum threshold set at null/0ms. 

Implemented default values for Fanfiction, Scribblehub and 69shuParser

As this is a **non-standard** fix across a multitude of files, I will not close this pull request without external approval.

Affected Tickets:
#1377 #1378 #1405 

Ticket numbers are lost in squashes.