### PR TITLE
Increase minimumThrottle for ScribbleHub

### DIFF
--- a/plugin/js/parsers/ScribblehubParser.js
+++ b/plugin/js/parsers/ScribblehubParser.js
@@ -5,7 +5,7 @@ parserFactory.register("scribblehub.com", () => new ScribblehubParser());
 class ScribblehubParser extends Parser {
     constructor() {
         super();
-        this.minimumThrottle = 3000;
+        this.minimumThrottle = 5000;
     }
 
     async getChapterUrls(dom, chapterUrlsUI) {


### PR DESCRIPTION
Failed/second Requests on ScribbleHub are common enough to trigger a cloudflare error.