### PR TITLE
walkTocPages() add slow down

### DIFF
--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -703,6 +703,7 @@ class Parser {
         chapterUrlsUI.showTocProgress(chapters);
         let url = nextTocPageUrl(dom, chapters, chapters);
         while (url != null) {
+            await this.rateLimitDelay();
             dom = (await HttpClient.wrapFetch(url)).responseXML;
             let partialList = chaptersFromDom(dom);
             chapterUrlsUI.showTocProgress(partialList);


### PR DESCRIPTION
Example: https://www.scribblehub.com/series/16599/bl-oh-my-fate/
Has 90 requests for Searching for URLs at the moment they are fetcht without slow down.
