### PR TITLE
Better 403 handling

### DIFF
--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -627,13 +627,17 @@
 		"description": "Internal message for developer."
 	},
 	"warning403ErrorResponse": {
-		"message": "WARNING: Site '$host$' has sent an Access Denied (403) error.  You may need to logon to site, or browse site normally until you get a Cloudflare \"Are you a human\" page or satisfy some other CAPTCHA before WebToEpub can continue.",
+		"message": "WARNING: Site '$host$' has sent an Access Denied (403) error.  You may need to logon to site, or browse site normally until you get a Cloudflare \"Are you a human\" page or satisfy some other CAPTCHA before WebToEpub can continue. Open Page?",
 		"description": "Warning message for user when site sends a 403 response.",
 		"placeholders": {
 			"host": {
 				"content": "$1"
 			}
 		}
+	},
+	"wait403ErrorResponse": {
+		"message": "Wait until you cleared cloudflare or login.",
+		"description": "Wait message for user when site sends a 403 response."
 	},
 	"warning429ErrorResponse": {
 		"message": "WARNING: Site '$host$' has requested WebToEpub to slow down rate of chapter requests.  WebToEpub will wait until site allows requesting chapters again.  However, if this does not work, you may need to adjust manually.  Under 'Advanced Options' -> lower 'Max web pages to fetch simultaneously' and/or increase 'Manual Throttle|Delay per chapter'",

--- a/plugin/js/HttpClient.js
+++ b/plugin/js/HttpClient.js
@@ -73,7 +73,13 @@ class FetchErrorHandler {
         let retryDelay = [120, 60, 30, 15];
         switch(response.status) {
         case 403:
-            alert(chrome.i18n.getMessage("warning403ErrorResponse", new URL(response.url).hostname));
+            if (confirm(chrome.i18n.getMessage("warning403ErrorResponse", new URL(response.url).hostname))) {
+                // Open site
+                window.open(new URL(response.url), '_blank').focus();
+                alert(chrome.i18n.getMessage("wait403ErrorResponse", new URL(response.url).hostname));
+            } else {
+                // Do nothing!
+            }
             return {retryDelay: [1], promptUser: true};
         case 429:
             FetchErrorHandler.show429Error(response);

--- a/plugin/js/HttpClient.js
+++ b/plugin/js/HttpClient.js
@@ -75,7 +75,7 @@ class FetchErrorHandler {
         case 403:
             if (confirm(chrome.i18n.getMessage("warning403ErrorResponse", new URL(response.url).hostname))) {
                 // Open site
-                window.open(new URL(response.url), '_blank').focus();
+                window.open(new URL(response.url), "_blank").focus();
                 alert(chrome.i18n.getMessage("wait403ErrorResponse", new URL(response.url).hostname));
             } else {
                 // Do nothing!


### PR DESCRIPTION
If 403 error comes it could be annoying to open the url wich send the warning.
Example pictures are hosted on a different website than the normal contend and sends a 403 warning.
With this change it is one click to open the Webpage and wait until cloudflare etc. is finished -> close tab and confirm cloudflare is clear.