### PR TITLE
#1422 - Fixed ChaleuriaParser

### DIFF
--- a/plugin/js/parsers/ChaleuriaParser.js
+++ b/plugin/js/parsers/ChaleuriaParser.js
@@ -8,9 +8,14 @@ class ChaleuriaParser extends WordpressBaseParser{
     }
 
     async getChapterUrls(dom) {
-        let rows = [...dom.querySelectorAll("table.toctable tr.tocrow")]
-            .map(this.rowToChapter);
-        return rows;
+        let rows = dom.querySelectorAll("table.toctable tr.tocrow");
+        if (rows.length>0) {
+            return [...rows].map(row => this.rowToChapter(row));
+        }
+        else {
+            let menu = dom.querySelector(".entry-content");
+            return util.hyperlinksToChapterList(menu);
+        }
     }
     
     rowToChapter(row) {


### PR DESCRIPTION
FIxes #1422.

Normal URL - [https://chaleuria.com/complete-guide-personal-assistant/.](https://chaleuria.com/novels/complete-guide-use-care-personal-assistant/)
Issue - https://chaleuria.com/complete-guide-personal-assistant/

It turns out they provide different toc layout based on URL