### PR TITLE
fix_changelog_from_tag

### DIFF
--- a/.github/workflows/AutoRelease.yml
+++ b/.github/workflows/AutoRelease.yml
@@ -126,7 +126,7 @@ jobs:
         set /p var_commit_sha=<commit_sha.txt
 
         if "0.0.0.0" == "%var_old_change_log_version%" (
-          set var_old_change_log_version=0.0.0.160
+          set var_old_change_log_version=0.0.0.167
         )
      
         if "milestone"=="%version%" (


### PR DESCRIPTION
The link to view Changelog points at the moment to 0.0.0.160 instead of 0.0.0.167
If the next release increases another version number than the dev version number e.g. 0.0.1.0 no manual fix is needed.
Why?
The logic just sets the dev number to 0 and compares this tag with the current developer-build.
If the old tag is 0.0.0.0 than it gets replaced with 0.0.0.167 as exception.
reference: #1410