### PR TITLE
Fix Patreon Collections

### DIFF
--- a/plugin/js/parsers/PatreonParser.js
+++ b/plugin/js/parsers/PatreonParser.js
@@ -8,10 +8,20 @@ class PatreonParser extends Parser{
     }
 
     async getChapterUrls(dom) {
+        if (this.state.chapterListUrl?.indexOf("collection") != -1) {
+            return this.getCollectionLinks(dom);
+        }
         let cards = [...dom.querySelectorAll("div[data-tag='post-card']")]
         return cards
             .filter(c => this.hasAccessableContent(c))
             .map(s => this.cardToChapter(s)).reverse();
+    }
+
+    getCollectionLinks(dom) {
+        return [...dom.querySelectorAll("a[href*='posts/']")]
+            .filter((a) => a.querySelector("h3") != null)
+            .map(util.hyperLinkToChapter)
+            .reverse();
     }
 
     cardToChapter(card) {

--- a/plugin/js/parsers/PatreonParser.js
+++ b/plugin/js/parsers/PatreonParser.js
@@ -8,7 +8,7 @@ class PatreonParser extends Parser{
     }
 
     async getChapterUrls(dom) {
-        if (this.state.chapterListUrl?.indexOf("collection") != -1) {
+        if (this.isCollectionList()) {
             return this.getCollectionLinks(dom);
         }
         let cards = [...dom.querySelectorAll("div[data-tag='post-card']")]
@@ -77,11 +77,39 @@ class PatreonParser extends Parser{
     }
 
     extractAuthor(dom) {
+        if (this.isCollectionList()) {
+            return this.extractCollectionAuthor(dom);
+        }
         let authorLabel = dom.querySelector("h1");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
     }
 
+    extractCollectionAuthor(dom) {
+        let title = dom.querySelector("h1");
+        let parent = title.parentNode;
+        while (parent.querySelector("a") == null) {
+            parent = parent.parentNode;
+        }
+        return parent.querySelector("a")?.textContent ?? "Not Found";
+    }
+
     findCoverImageUrl(dom) {
+        if (this.isCollectionList()) {
+            return this.extractCollectionCover(dom);
+        }
         return util.getFirstImgSrc(dom, "picture");
+    }
+
+
+    extractCollectionCover(dom) {
+        let divsWithPicutres = dom.querySelectorAll("div[src]")
+        if (divsWithPicutres.length == 0) {
+            return null;
+        }
+        return divsWithPicutres[divsWithPicutres.length - 1].getAttribute("src");
+    }
+
+    isCollectionList() {
+        return this.state.chapterListUrl?.indexOf("collection") != -1;
     }
 }


### PR DESCRIPTION
Patreon collections changed again (I guess...).
This collects all loaded post links from a collection using a nested h3 as discriminator (this is the title of the card), there's no data-tag attributes anymore on the collection page