### PR TITLE
Add CHIPS cookie state to firefox (cloudflare)

### DIFF
--- a/plugin/js/HttpClient.js
+++ b/plugin/js/HttpClient.js
@@ -207,33 +207,35 @@ class HttpClient {
     }
 
     static async setPartitionCookies(url) {
-        if (!util.isFirefox()) {
-            // get partitionKey in the form of https://<site name>.<tld>
-            let parsedUrl = new URL(url);
+        // get partitionKey in the form of https://<site name>.<tld>
+        let parsedUrl = new URL(url);
+        //keep old code for reference in case it changes again
+        //let topLevelSite = parsedUrl.protocol + "//" + parsedUrl.hostname;
+
+        try {
+            //  get all cookie from the site which use the partitionKey (e.g. cloudflare)
             //keep old code for reference in case it changes again
-            //let topLevelSite = parsedUrl.protocol + "//" + parsedUrl.hostname;
-
-            try {
-                //  get all cookie from the site which use the partitionKey (e.g. cloudflare)
-                //keep old code for reference in case it changes again
-                //let cookies = await chrome.cookies.getAll({partitionKey: {topLevelSite: topLevelSite}});
-                
-                //set domain to the highest level from the website as all subdomains are included #1447 #1445
-                let urlparts = parsedUrl.hostname.split(".");
-                let cookies = await chrome.cookies.getAll({domain: urlparts[urlparts.length-2]+"."+urlparts[urlparts.length-1],partitionKey: {}});
-
-                //create new cookies for the site without the partitionKey
-                //cookies without the partitionKey get sent with fetch
-                cookies.forEach(element => chrome.cookies.set({
-                    domain: element.domain,
-                    url: "https://"+element.domain.substring(1),
-                    name: element.name, 
-                    value: element.value
-                }));
-            } catch {
-                // Probably running browser that doesn't support partitionKey, e.g. Kiwi
-            } 
-        }
+            //let cookies = await chrome.cookies.getAll({partitionKey: {topLevelSite: topLevelSite}});
+            
+            //set domain to the highest level from the website as all subdomains are included #1447 #1445
+            let urlparts = parsedUrl.hostname.split(".");
+            let cookies = "";
+            if (!util.isFirefox()) {
+                cookies = await chrome.cookies.getAll({domain: urlparts[urlparts.length-2]+"."+urlparts[urlparts.length-1],partitionKey: {}});
+            }else{
+                cookies = await browser.cookies.getAll({domain: urlparts[urlparts.length-2]+"."+urlparts[urlparts.length-1],partitionKey: {}});
+            }
+            //create new cookies for the site without the partitionKey
+            //cookies without the partitionKey get sent with fetch
+            cookies.forEach(element => chrome.cookies.set({
+                domain: element.domain,
+                url: "https://"+element.domain.substring(1),
+                name: element.name, 
+                value: element.value
+            }));
+        } catch {
+            // Probably running browser that doesn't support partitionKey, e.g. Kiwi
+        } 
     }
 }
 


### PR DESCRIPTION
reference: #1447
firefox added [CHIPS](https://developer.mozilla.org/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies) support in Nightly build.
![image](https://github.com/user-attachments/assets/b0977ead-8e89-4956-ab18-b8e676e30351)
The fix is backwards [compatible](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/getAll) with firefox > 94.0
![image](https://github.com/user-attachments/assets/97cdf753-a954-4b34-8ff6-3d1c7182a66e)
No need to change min firefox version in manifest.json
Tested with:
https://mtlarchive.com/novel/traveling-through-thousands-of-realms-starting-from-obtaining-the-ten-marvel-rings
Firefox version 130.0 (64-bit)
Firefox version 132.0a1 (2024-09-06) (64-bit)
Google Chrome Version 128.0.6613.115