### PR TITLE
Reduce http header cookie clutter

### DIFF
--- a/plugin/js/HttpClient.js
+++ b/plugin/js/HttpClient.js
@@ -222,6 +222,7 @@ class HttpClient {
             let cookies = "";
             if (!util.isFirefox()) {
                 cookies = await chrome.cookies.getAll({domain: urlparts[urlparts.length-2]+"."+urlparts[urlparts.length-1],partitionKey: {}});
+                cookies = cookies.filter(item => item.session || item.sameSite == "no_restriction");
             }else{
                 cookies = await browser.cookies.getAll({domain: urlparts[urlparts.length-2]+"."+urlparts[urlparts.length-1],partitionKey: {}});
             }

--- a/plugin/js/HttpClient.js
+++ b/plugin/js/HttpClient.js
@@ -222,10 +222,10 @@ class HttpClient {
             let cookies = "";
             if (!util.isFirefox()) {
                 cookies = await chrome.cookies.getAll({domain: urlparts[urlparts.length-2]+"."+urlparts[urlparts.length-1],partitionKey: {}});
-                cookies = cookies.filter(item => item.session || item.sameSite == "no_restriction");
             }else{
                 cookies = await browser.cookies.getAll({domain: urlparts[urlparts.length-2]+"."+urlparts[urlparts.length-1],partitionKey: {}});
             }
+            cookies = cookies.filter(item => item.partitionKey != undefined);
             //create new cookies for the site without the partitionKey
             //cookies without the partitionKey get sent with fetch
             cookies.forEach(element => chrome.cookies.set({

--- a/plugin/js/parsers/SpacebattlesParser.js
+++ b/plugin/js/parsers/SpacebattlesParser.js
@@ -12,6 +12,7 @@ class SpacebattlesParser extends Parser{
     constructor() {
         super();
         this.cache = new FetchCache();
+        this.minimumThrottle = 50; //182 at 20
     }
 
     clampSimultanousFetchSize() {


### PR DESCRIPTION
Previous logic attempted to duplicate cookies which were being set by default within chrome's request object. Cookies at issue had specialized settings of "Session" or no_restriction on SameSite.

@gamebeaker - I'd like your opinion on the HttpClient change before pushing it through; under the current build, if you open the chrome dev console while running on a site like fanfiction.net, you can see the number of errors popping up. The errors don't actually break anything, but they do make debugging other things a tad annoying. 
I'm fairly confident it covers all situations for your former fix, but I'd like to know if there's any glaring issues or if you think the filter should be handled from a different angle.

To no one in particular: SpacebattlesParser change is more of an irregularity than anything, I'm fine pushing it but the reasons for the throttle are a bit unusual: By default, cloudflare isn't actually an issue on the Xenforo forums, but when requesting 150+ chapters too quickly (Inconsistent number due to caching) they DO request throttling and eventually temp ban. I have not been able to replicate the error since setting to 50ms, however it is trial&error. It's mainly included here because I forgot to check it in when I changed it.

Now I'll get back to looking at 1454 without these errors. *whistles innocently*