### PR TITLE
Library export import function

### DIFF
--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -23,6 +23,14 @@
 		"message": "Clear Library",
 		"description": "Label on button to clear Local Storage"
 	},
+	"__MSG_button_Lib_Template_Export_Library__": {
+		"message": "Export Library",
+		"description": "Label on button to export Library in json format"
+	},
+	"__MSG_button_Lib_Template_Import_Library__": {
+		"message": "Import Library",
+		"description": "Label on button to import Library in json format"
+	},
 	"__MSG_button_Lib_Template_Upload_Epub__": {
 		"message": "Upload Epub",
 		"description": "Label on button to Upload Epub in Library"

--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -702,10 +702,6 @@ class Library {
             retobj.ReadingList.epubs = retobj.ReadingList.epubs.filter(a => storyurls.includes(a.toc));
             let serialized = JSON.stringify(retobj);
             let blob = new Blob([serialized], {type : "application/json"});
-            let test = {};
-            test.files = [];
-            test.files[0] = blob;
-            Library.LibHandelImport(test);
             return Download.save(blob, "Libraryexport.json").catch (err => ErrorLog.showErrorMessage(err));
         });
     }

--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -271,6 +271,10 @@ class Library {
                 LibTemplateMergeUploadButton = document.getElementById("LibTemplateMergeUploadButton").innerHTML;
                 LibTemplateEditMetadataButton = document.getElementById("LibTemplateEditMetadataButton").innerHTML;
                 LibRenderString += "<button id='libdeleteall'>"+document.getElementById("LibTemplateClearLibrary").innerHTML+"</button>";
+                LibRenderString += "<button id='libexportall'>"+document.getElementById("LibTemplateExportLibrary").innerHTML+"</button>";
+                LibRenderString += "<label data-libbuttonid='LibImportLibraryButton' data-libepubid='' id='LibImportLibraryLabel' for='LibImportLibraryFile' style='cursor: pointer;'>";
+                LibRenderString += "<button id='LibImportLibraryButton' style='pointer-events: none;'>"+document.getElementById("LibTemplateImportEpubButton").innerHTML+"</button></label>";
+                LibRenderString += "<input type='file' data-libepubid='LibImportLibrary' id='LibImportLibraryFile' hidden>";
                 LibRenderString += "<br>";
                 LibRenderString += "<p>"+document.getElementById("LibTemplateUploadEpubFileLabel").innerHTML+"</p>";
                 LibRenderString += "<label data-libbuttonid='LibUploadEpubButton' data-libepubid='' id='LibUploadEpubLabel' for='LibEpubNewUploadFile' style='cursor: pointer;'>";
@@ -330,6 +334,10 @@ class Library {
             Library.AppendHtmlInDiv(LibRenderString, LibRenderResult, "LibDivRenderWraper");
             if (ShowAdvancedOptions) {
                 document.getElementById("libdeleteall").addEventListener("click", function(){Library.Libdeleteall()});
+                document.getElementById("libexportall").addEventListener("click", function(){Library.Libexportall()});
+                document.getElementById("LibImportLibraryLabel").addEventListener("mouseover", function(){Library.LibMouseoverButtonUpload(this)});
+                document.getElementById("LibImportLibraryLabel").addEventListener("mouseout", function(){Library.LibMouseoutButtonUpload(this)});
+                document.getElementById("LibImportLibraryFile").addEventListener("change", function(){Library.LibHandelImport(this)});
                 document.getElementById("LibUploadEpubLabel").addEventListener("mouseover", function(){Library.LibMouseoverButtonUpload(this)});
                 document.getElementById("LibUploadEpubLabel").addEventListener("mouseout", function(){Library.LibMouseoutButtonUpload(this)});
                 document.getElementById("LibEpubNewUploadFile").addEventListener("change", function(){Library.LibHandelUpdate(this, -1, "", "", -1)});
@@ -560,6 +568,7 @@ class Library {
         LibFileReader.LibStorageValueId = Id;
         LibFileReader.readAsDataURL(Blobdata);
     }
+
     static async LibFileReaderload(){
         if (-1 == LibFileReader.LibStorageValueId) {
             let CurrentLibKeys = await Library.LibGetAllLibStorageKeys("LibEpub");
@@ -652,6 +661,74 @@ class Library {
             let blobdata = Library.LibConvertDataUrlToBlob(items["LibEpub" + objbtn.dataset.libepubid]);
             return Download.save(blobdata , items["LibFilename" + objbtn.dataset.libepubid] + ".epub", overwriteExisting, backgroundDownload);
         });
+    }
+
+    static Libexportall(){
+        chrome.storage.local.get(null, async function(items) {
+            let CurrentLibKeys = await Library.LibGetAllLibStorageKeys("LibEpub");
+            var retobj = {};
+            retobj.Library = [];
+            for (let i = 0; i < CurrentLibKeys.length; i++) {
+                CurrentLibKeys[i] = CurrentLibKeys[i].replace("LibEpub","");
+            }
+            for (let i = 0; i < CurrentLibKeys.length; i++) {
+                retobj.Library[i] = {};
+                retobj.Library[i].LibCover = items["LibCover" + CurrentLibKeys[i]];
+                retobj.Library[i].LibEpub = items["LibEpub" + CurrentLibKeys[i]];
+                retobj.Library[i].LibFilename = items["LibFilename" + CurrentLibKeys[i]];
+                retobj.Library[i].LibStoryURL = items["LibStoryURL" + CurrentLibKeys[i]];
+            }
+            let storyurls = retobj.Library.map(a => a.LibStoryURL);
+            let readingList = new ReadingList();
+            readingList.readFromLocalStorage();
+            retobj.ReadingList = JSON.parse(readingList.toJson());
+            retobj.ReadingList.epubs = retobj.ReadingList.epubs.filter(a => storyurls.includes(a.toc));
+            let serialized = JSON.stringify(retobj);
+            let blob = new Blob([serialized], {type : "application/json"});
+            let test = {};
+            test.files = [];
+            test.files[0] = blob;
+            Library.LibHandelImport(test);
+            return Download.save(blob, "Libraryexport.json").catch (err => ErrorLog.showErrorMessage(err));
+        });
+    }
+
+    static async LibHandelImport(objbtn){
+        Library.LibShowLoadingText();
+        await Library.LibFileReaderAddListenersImport(LibFileReader);
+        let Blobdata = objbtn.files[0];
+        LibFileReader.readAsText(Blobdata);
+    }
+
+    static LibFileReaderAddListenersImport(LibFileReader){
+        LibFileReader.addEventListener("load", function(){Library.LibFileReaderloadImport()});
+        LibFileReader.addEventListener("error", function(event){Library.LibFileReadererror(event)});
+        LibFileReader.addEventListener("abort", function(event){Library.LibFileReaderabort(event)});
+    }
+
+    static async LibFileReaderloadImport(){
+        let json = JSON.parse(LibFileReader.result);
+        let CurrentLibKeys = await Library.LibGetAllLibStorageKeys("LibEpub");
+        let HighestLibEpub = 0;
+        CurrentLibKeys.forEach(element => {
+            element = element.replace("LibEpub","");
+            if (parseInt(element)>=HighestLibEpub) {
+                HighestLibEpub = parseInt(element)+1; 
+            }
+        });
+        for (let i = 0; i < json.Library.length; i++) {
+            chrome.storage.local.set({
+                ["LibEpub" + HighestLibEpub]: json.Library[i].LibEpub,
+                ["LibStoryURL" + HighestLibEpub]: json.Library[i].LibStoryURL,
+                ["LibCover" + HighestLibEpub]: json.Library[i].LibCover,
+                ["LibFilename" + HighestLibEpub]: json.Library[i].LibFilename
+            });
+            HighestLibEpub++;
+        }
+        let userPreferences = new UserPreferences;
+        userPreferences = UserPreferences.readFromLocalStorage();
+        userPreferences.loadReadingListFromJson(json);
+        Library.LibRenderSavedEpubs();
     }
 
     static LibSaveTextURLChange(obj){

--- a/plugin/js/main.js
+++ b/plugin/js/main.js
@@ -40,7 +40,6 @@ var main = (function () {
         if (setParser(url, dom)) {
             try {
                 userPreferences.addObserver(parser);
-                userPreferences.addObserver(library);
                 let metaInfo = parser.getEpubMetaInfo(dom, userPreferences.useFullTitle.value);
                 populateMetaInfo(metaInfo);
                 setUiToDefaultState();

--- a/plugin/js/parsers/GenesiStudioParser.js
+++ b/plugin/js/parsers/GenesiStudioParser.js
@@ -8,7 +8,7 @@ parserFactory.register("genesistudio.com", () => new GenesiStudioParser());
 class GenesiStudioParser extends Parser{
     constructor() {
         super();
-        this.minimumThrottle = 3000;
+        this.minimumThrottle = 1000;
     }
     
     clampSimultanousFetchSize() {

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -157,6 +157,8 @@
                             <tr>
                                 <td id="LibTemplateLibraryUses">Library uses: </td>
                                 <td colspan="2"><button id="LibTemplateClearLibrary">__MSG_button_Lib_Template_Clear_Library__</button></td>
+                                <td colspan="2"><button id="LibTemplateExportLibrary">__MSG_button_Lib_Template_Export_Library__</button></td>
+                                <td colspan="2"><button id="LibTemplateImportEpubButton">__MSG_button_Lib_Template_Import_Library__</button></td>
                             </tr>
                             <tr>
                                 <td id="LibTemplateUploadEpubFileLabel">__MSG_label_Lib_Template_Upload_Epub_File_Label__</td>


### PR DESCRIPTION
@Kiradien related to #1365 #1365
I changed how the Readinglist gets updated if the book is deleted. 
Why?
If you open WebToEpub from a not valid page example in 
chrome: `chrome://extensions/`
firefox: `about:addons`
It wasn't possible to delete a epub.
Additionally i added the deletion of the reading list of the saved books if the Library gets cleared with "Clear Library".
Is that ok or did you have other reason to use .addObserver(library)?

Now the original commit:
Allow the user to export/ import the current Library with reading status as json file.
minor fix: the save as dialog got triggered if "Add to Library" is used on a new url -> now only triggers if the Option "Download Epubs after new Chapter got added automatically" is checked.