### PR TITLE
Change 403 user options/ handling

### DIFF
--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -115,6 +115,14 @@
 		"message": "Retry",
 		"description": "Label on 'Retry' button when show error"
 	},
+	"__MSG_button_error_Open_URL__": {
+		"message": "Open URL for Captcha",
+		"description": "Label on 'Open URL for Captcha' button when show error HTTP 403"
+	},
+	"__MSG_button_error_Block_URL__": {
+		"message": "Block Website for future requests",
+		"description": "Label on 'Block Website for future requests' button when show error HTTP 403"
+	},
 	"__MSG_button_finished_default_parser__": {
 		"message": "Apply",
 		"description": "Label on button to finish configuring default parser"
@@ -635,7 +643,7 @@
 		"description": "Internal message for developer."
 	},
 	"warning403ErrorResponse": {
-		"message": "WARNING: Site '$host$' has sent an Access Denied (403) error.  You may need to logon to site, or browse site normally until you get a Cloudflare \"Are you a human\" page or satisfy some other CAPTCHA before WebToEpub can continue. Open Page?",
+		"message": "WARNING: Site '$host$' has sent an Access Denied (403) error.\nYou may need to logon to site, or browse site normally\nuntil you get a Cloudflare \"Are you a human\" page or satisfy some other CAPTCHA\nbefore WebToEpub can continue.\n",
 		"description": "Warning message for user when site sends a 403 response.",
 		"placeholders": {
 			"host": {

--- a/plugin/js/ErrorLog.js
+++ b/plugin/js/ErrorLog.js
@@ -89,6 +89,8 @@ class ErrorLog {
         let okButton = document.getElementById("errorButtonOk");
         let retryButton = document.getElementById("errorButtonRetry");
         let cancelButton = document.getElementById("errorButtonCancel");
+        let OpenURLButton = document.getElementById("errorButtonOpenURL");
+        let BlockURLButton = document.getElementById("errorButtonBlockURL");
         if (msg.retryAction !== undefined) {
             okButton.hidden = true;
             retryButton.hidden = false;
@@ -105,11 +107,30 @@ class ErrorLog {
             if (msg.cancelLabel !== undefined) {
                 cancelButton.textContent =  msg.cancelLabel;
             };
+            if (msg.openurl !== undefined) {
+                OpenURLButton.hidden = false;
+                OpenURLButton.onclick = function() {
+                    //window.open(new URL(msg.openurl), "_blank").focus();
+                    //use chrome.tabs.create to prevent auto popup block from browser
+                    chrome.tabs.create({ url: msg.openurl});
+                };
+                BlockURLButton.hidden = false;
+                BlockURLButton.onclick = function() {
+                    close();
+                    BlockedHostNames.add(new URL(msg.blockurl).hostname);
+                    msg.cancelAction();
+                };
+            } else {
+                OpenURLButton.hidden = true;
+                BlockURLButton.hidden = true;
+            }
         } else {
             okButton.hidden = false;
             okButton.onclick = close;
             retryButton.hidden = true;
             cancelButton.hidden = true;
+            OpenURLButton.hidden = true;
+            BlockURLButton.hidden = true;
         }
     }
 

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -23,6 +23,8 @@
                         <button class="expandedButton" id="errorButtonOk">__MSG_button_error_OK__</button>
                         <button class="expandedButton" id="errorButtonRetry">__MSG_button_error_Retry__</button>
                         <button class="expandedButton" id="errorButtonCancel">__MSG_button_error_Cancel__</button>
+                        <button class="expandedButton" id="errorButtonOpenURL">__MSG_button_error_Open_URL__</button>
+                        <button class="expandedButton" id="errorButtonBlockURL">__MSG_button_error_Block_URL__</button>
                     </td>
                 </tr>
                 <tr id="errorMessageRow">


### PR DESCRIPTION
reference: #1491, #1488, #1361
Added option to block URL.hostname from an 403 error URL. 
This can reduce the ammount of errors an user has to skip if the images on the website are now 403 like on patreon.

Changed 403 handling for the user.
Old:
![Neues draw io Diagramm-93867 drawio](https://github.com/user-attachments/assets/cd5cf352-5713-4900-8d52-7be9e6930d68)
New:
Only one error page.
![image](https://github.com/user-attachments/assets/319e210b-fcea-41a8-a6c6-e37c6020afd6)
