### PR TITLE
Add parser for mtgstory.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ eslint/*.zip
 eslint/packed.js
 eslint/index.csv
 node_modules
-plugin/**/*.*
+!plugin/**/*.*
 !plugin/jszip/dist/jszip.min.js

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ eslint/packed.js
 eslint/index.csv
 node_modules
 !plugin/**/*.*
-!plugin/jszip/dist/jszip.min.js
+plugin/jszip/dist/jszip.min.js
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     { "name": "ImmortalDreamer"},
     { "name": "ktrin"},
     { "name": "Tyderion"},
-    { "name": "nozwock" }
+    { "name": "nozwock"},
+    { "name": "Darthagnon"}
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/js/parsers/MagicWizardsParser.js
+++ b/plugin/js/parsers/MagicWizardsParser.js
@@ -1,3 +1,6 @@
+/*
+  parser for mtgstory.com (redirect)
+*/
 "use strict";
 
 // Register the parser for magic.wizards.com (archive.org is implicit) TODO: mtglore.com
@@ -65,23 +68,11 @@ class MagicWizardsParser extends Parser {
             return dom.querySelector("#article-body article, #primary-area section, section article, section");
         }
     }
-    
-findCoverImageUrl(dom) {
-    // Try to find an image inside the '.swiper-slide' or inside an 'article'
-    let imgElement = dom.querySelector(".swiper-slide img, article img");
-
-    // If an image is found, return its 'src' attribute
-    if (imgElement) {
-        return imgElement.getAttribute("src");
-    // Check if the URL starts with '//' (protocol-relative URL)
-        if (imgSrc && imgSrc.startsWith("//")) {
-            // Add 'https:' to the start of the URL
-            imgSrc = "https:" + imgSrc;
-        }
+   
+    // Grab cover image
+    findCoverImageUrl(dom) {
+        return util.getFirstImgSrc(dom, ".swiper-slide img, article img");
     }
-    // Fallback if no image was found
-    return null;
-}
 
 
 }

--- a/plugin/js/parsers/MagicWizardsParser.js
+++ b/plugin/js/parsers/MagicWizardsParser.js
@@ -1,11 +1,22 @@
 /*
-  parser for mtgstory.com (redirect)
+  MagicWizardsParser.js v0.72
+  
+  Parser for Magic the Gathering fiction, found on:
+  - mtgstory.com (redirect)
+  - https://magic.wizards.com/en/story (2023-2024)
+  - https://magic.wizards.com/en/articles/columns/magic-story (2014-2018)
+  - Archive.org versions of the above
+  - TODO: mtglore.com (redirects & mirrors)
+  - TODO: https://magic.wizards.com/en/story (Q4 2018-2022)
+  - TODO: Planeswalkers & Planes Databank
+  - TODO: Featured story slider Q1 2018
+  - UNTESTED: http://www.wizards.com/Magic/Magazine/Article.aspx (2014 and earlier)
+  - WONTFIX: hanweirchronicle.com (Tumblr blog, mostly image posts)
 */
 "use strict";
 
-// Register the parser for magic.wizards.com (archive.org is implicit) TODO: mtglore.com
+// Register the parser for magic.wizards.com (archive.org is implicit)
 parserFactory.register("magic.wizards.com", () => new MagicWizardsParser());
-//parserFactory.register("mtglore.com", () => new MagicWizardsParser());
 
 class MagicWizardsParser extends Parser {
     constructor() {
@@ -36,14 +47,23 @@ class MagicWizardsParser extends Parser {
 
     // Format chapter links into a standardized structure
     linkToChapter(link) {
-        let titleElement;
+        const titleSelectors = [
+            "h3",                     // First option: <h3> tag
+            ".article-item .title",   // Second option: <p class="title">
+            ".details .title"         // Third option: <p class="title" inside .details>
+        ];
     
-        // Try to find the <h3> tag inside the parent of the link (assuming link is inside <article>)
-        titleElement = link.closest("article")?.querySelector("h3");
-        
-        // Fallback to the <p class="title"> if no <h3> is found
-        if (!titleElement) {
-            titleElement = link.closest(".article-item")?.querySelector(".title");
+        let titleElement = null;
+    
+        // Iterate through the selectors and find the first matching element
+        for (const selector of titleSelectors) {
+            titleElement = link.closest("article")?.querySelector(selector) || 
+                        link.closest(".article-item")?.querySelector(selector) || 
+                        link.closest(".details")?.querySelector(selector);
+            
+            if (titleElement) {
+                break; // Exit the loop if a title element is found
+            }
         }
     
         // Fallback to the link text itself if no titleElement found (this handles simpler cases)

--- a/plugin/js/parsers/MagicWizardsParser.js
+++ b/plugin/js/parsers/MagicWizardsParser.js
@@ -15,18 +15,10 @@ class MagicWizardsParser extends Parser {
     // Extract the list of chapter URLs
     async getChapterUrls(dom) {
         let chapterLinks = [];
-        if (window.location.hostname.includes("web.archive.org")) {
-            // For archived versions, select the correct container within #content
-            chapterLinks = [...dom.querySelectorAll("#content article a, #content .article-content a")];
-        } else {
-            // For live pages
-            chapterLinks = [...dom.querySelectorAll("article a, .article-content a, window.location.hostname")];
-        }
-        
-        // Filter out author links using their URL pattern
-        chapterLinks = chapterLinks.filter(link => !this.isAuthorLink(link));
-        
-        return chapterLinks.map(this.linkToChapter);
+            chapterLinks = [...dom.querySelectorAll("article a, .article-content a, window.location.hostname, #content article a, #content .article-content a, .articles-listing .article-item a, .articles-bloc .article .details a")];
+            // Filter out author links using their URL pattern
+            chapterLinks = chapterLinks.filter(link => !this.isAuthorLink(link));
+            return chapterLinks.map(this.linkToChapter);
     }
 
     // Helper function to detect if a link is an author link
@@ -47,7 +39,12 @@ class MagicWizardsParser extends Parser {
         let titleElement;
     
         // Try to find the <h3> tag inside the parent of the link (assuming link is inside <article>)
-        titleElement = link.closest("article").querySelector("h3");
+        titleElement = link.closest("article")?.querySelector("h3");
+        
+        // Fallback to the <p class="title"> if no <h3> is found
+        if (!titleElement) {
+            titleElement = link.closest(".article-item")?.querySelector(".title");
+        }
     
         // Fallback to the link text itself if no titleElement found (this handles simpler cases)
         let title = titleElement ? titleElement.textContent.trim() : link.textContent.trim();
@@ -60,13 +57,7 @@ class MagicWizardsParser extends Parser {
 
     // Extract the content of the chapter
     findContent(dom) {
-        if (window.location.hostname.includes("web.archive.org")) {
-            // For archived pages, the content is often inside #content
-            return dom.querySelector("#content article");
-        } else {
-            // For live pages
-            return dom.querySelector("#article-body article, #primary-area section, section article, section");
-        }
+        return dom.querySelector("#content article, .article_detail #main-content article, #article-body article, #primary-area section, section article, section, .article_detail #main-content");
     }
    
     // Grab cover image

--- a/plugin/js/parsers/MagicWizardsParser.js
+++ b/plugin/js/parsers/MagicWizardsParser.js
@@ -1,0 +1,87 @@
+"use strict";
+
+// Register the parser for magic.wizards.com (archive.org is implicit) TODO: mtglore.com
+parserFactory.register("magic.wizards.com", () => new MagicWizardsParser());
+//parserFactory.register("mtglore.com", () => new MagicWizardsParser());
+
+class MagicWizardsParser extends Parser {
+    constructor() {
+        super();
+    }
+
+    // Extract the list of chapter URLs
+    async getChapterUrls(dom) {
+        let chapterLinks = [];
+        if (window.location.hostname.includes("web.archive.org")) {
+            // For archived versions, select the correct container within #content
+            chapterLinks = [...dom.querySelectorAll("#content article a, #content .article-content a")];
+        } else {
+            // For live pages
+            chapterLinks = [...dom.querySelectorAll("article a, .article-content a, window.location.hostname")];
+        }
+        
+        // Filter out author links using their URL pattern
+        chapterLinks = chapterLinks.filter(link => !this.isAuthorLink(link));
+        
+        return chapterLinks.map(this.linkToChapter);
+    }
+
+    // Helper function to detect if a link is an author link
+    isAuthorLink(link) {
+        const href = link.href;
+        const authorPattern = /\/archive\?author=/;
+        
+        // Check if the link matches the author URL pattern or CSS selector
+        if (authorPattern.test(href)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    // Format chapter links into a standardized structure
+    linkToChapter(link) {
+        let titleElement;
+    
+        // Try to find the <h3> tag inside the parent of the link (assuming link is inside <article>)
+        titleElement = link.closest("article").querySelector("h3");
+    
+        // Fallback to the link text itself if no titleElement found (this handles simpler cases)
+        let title = titleElement ? titleElement.textContent.trim() : link.textContent.trim();
+    
+        return {
+            sourceUrl: link.href,
+            title: title
+        };
+    }
+
+    // Extract the content of the chapter
+    findContent(dom) {
+        if (window.location.hostname.includes("web.archive.org")) {
+            // For archived pages, the content is often inside #content
+            return dom.querySelector("#content article");
+        } else {
+            // For live pages
+            return dom.querySelector("#article-body article, #primary-area section, section article, section");
+        }
+    }
+    
+findCoverImageUrl(dom) {
+    // Try to find an image inside the '.swiper-slide' or inside an 'article'
+    let imgElement = dom.querySelector(".swiper-slide img, article img");
+
+    // If an image is found, return its 'src' attribute
+    if (imgElement) {
+        return imgElement.getAttribute("src");
+    // Check if the URL starts with '//' (protocol-relative URL)
+        if (imgSrc && imgSrc.startsWith("//")) {
+            // Add 'https:' to the start of the URL
+            imgSrc = "https:" + imgSrc;
+        }
+    }
+    // Fallback if no image was found
+    return null;
+}
+
+
+}

--- a/plugin/js/parsers/MagicWizardsParser.js
+++ b/plugin/js/parsers/MagicWizardsParser.js
@@ -26,10 +26,10 @@ class MagicWizardsParser extends Parser {
     // Extract the list of chapter URLs
     async getChapterUrls(dom) {
         let chapterLinks = [];
-            chapterLinks = [...dom.querySelectorAll("article a, .article-content a, window.location.hostname, #content article a, #content .article-content a, .articles-listing .article-item a, .articles-bloc .article .details a")];
-            // Filter out author links using their URL pattern
-            chapterLinks = chapterLinks.filter(link => !this.isAuthorLink(link));
-            return chapterLinks.map(this.linkToChapter);
+        chapterLinks = [...dom.querySelectorAll("article a, .article-content a, window.location.hostname, #content article a, #content .article-content a, .articles-listing .article-item a, .articles-bloc .article .details a")];
+        // Filter out author links using their URL pattern
+        chapterLinks = chapterLinks.filter(link => !this.isAuthorLink(link));
+        return chapterLinks.map(this.linkToChapter);
     }
 
     // Helper function to detect if a link is an author link

--- a/plugin/js/parsers/MagicWizardsParser.js
+++ b/plugin/js/parsers/MagicWizardsParser.js
@@ -38,11 +38,7 @@ class MagicWizardsParser extends Parser {
         const authorPattern = /\/archive\?author=/;
         
         // Check if the link matches the author URL pattern or CSS selector
-        if (authorPattern.test(href)) {
-            return true;
-        } else {
-            return false;
-        }
+        return authorPattern.test(href);
     }
 
     // Format chapter links into a standardized structure

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -636,6 +636,7 @@
     <script src="js/parsers/LnmtlParser.js"></script>
     <script src="js/parsers/MachineTranslationParser.js"></script>
     <script src="js/parsers/MadnovelParser.js"></script>
+    <script src="js/parsers/MagicWizardsParser.js"></script>
     <script src="js/parsers/MangadexParser.js"></script>
     <script src="js/parsers/MandarinducktalesParser.js"></script>
     <script src="js/parsers/MangakakalotParser.js"></script>

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ Credits
 * ktrin
 * nozwock
 * Tyderion
+* Darthagnon
 
 ## How to use with Baka-Tsuki:
 * Browse to a Baka-Tsuki web page that has the full text of a story.


### PR DESCRIPTION
WIP. Add parser for mtgstory.com (redirects to https://magic.wizards.com/en/story). Seems to work on most versions of the website (e.g. current live version, archive.org version from 2-3 years ago, untested on 10 years ago archive.org version). Still missing fallback support for mtglore.com. 

Based on MagicWizardsParser.js v0.6 from https://github.com/Darthagnon/web2epub-tidy-script