### PR TITLE
speedup Library.LibRenderSavedEpubs()

### DIFF
--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -261,7 +261,6 @@ class Library {
     }
 
     static LibRenderSavedEpubs(){
-        var startTime = performance.now()
         chrome.storage.local.get(null, async function(items) {
             let ShowAdvancedOptions = document.getElementById("LibShowAdvancedOptionsCheckbox").checked;
             let CurrentLibKeys = await Library.LibGetAllLibStorageKeys("LibEpub", Object.keys(items));
@@ -376,8 +375,6 @@ class Library {
             for (let i = 0; i < CurrentLibKeys.length; i++) {
                 document.getElementById("LibCover"+CurrentLibKeys[i]).src = await items["LibCover" + CurrentLibKeys[i]];
             }
-        var endTime = performance.now()
-        console.log(`Call to doSomething took ${endTime - startTime} milliseconds`)
         });
     }
 

--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -14,7 +14,7 @@ class Library {
             document.getElementById("includeInReadingListCheckbox").click();
         }
         chrome.storage.local.get(null, async function(items) {
-            let CurrentLibStoryURLKeys = await Library.LibGetAllLibStorageKeys("LibStoryURL");
+            let CurrentLibStoryURLKeys = await Library.LibGetAllLibStorageKeys("LibStoryURL", Object.keys(items));
             let LibidURL = -1;
             for (let i = 0; i < CurrentLibStoryURLKeys.length; i++) {
                 if (items[CurrentLibStoryURLKeys[i]] == document.getElementById("startingUrlInput").value) {
@@ -242,7 +242,7 @@ class Library {
 
     static Libdeleteall(){
         chrome.storage.local.get(null, async function(items) {
-            let CurrentLibKeys = await Library.LibGetAllLibStorageKeys("LibEpub");
+            let CurrentLibKeys = await Library.LibGetAllLibStorageKeys("LibEpub", Object.keys(items));
             let storyurls = [];
             for (let i = 0; i < CurrentLibKeys.length; i++) {
                 CurrentLibKeys[i] = CurrentLibKeys[i].replace("LibEpub","");
@@ -261,9 +261,10 @@ class Library {
     }
 
     static LibRenderSavedEpubs(){
+        var startTime = performance.now()
         chrome.storage.local.get(null, async function(items) {
             let ShowAdvancedOptions = document.getElementById("LibShowAdvancedOptionsCheckbox").checked;
-            let CurrentLibKeys = await Library.LibGetAllLibStorageKeys("LibEpub");
+            let CurrentLibKeys = await Library.LibGetAllLibStorageKeys("LibEpub", Object.keys(items));
             let LibRenderResult = document.getElementById("LibRenderResult");
             let LibRenderString = "";
             let LibTemplateDeleteEpub = document.getElementById("LibTemplateDeleteEpub").innerHTML;
@@ -375,6 +376,8 @@ class Library {
             for (let i = 0; i < CurrentLibKeys.length; i++) {
                 document.getElementById("LibCover"+CurrentLibKeys[i]).src = await items["LibCover" + CurrentLibKeys[i]];
             }
+        var endTime = performance.now()
+        console.log(`Call to doSomething took ${endTime - startTime} milliseconds`)
         });
     }
 
@@ -682,7 +685,7 @@ class Library {
 
     static Libexportall(){
         chrome.storage.local.get(null, async function(items) {
-            let CurrentLibKeys = await Library.LibGetAllLibStorageKeys("LibEpub");
+            let CurrentLibKeys = await Library.LibGetAllLibStorageKeys("LibEpub", Object.keys(items));
             var retobj = {};
             retobj.Library = [];
             for (let i = 0; i < CurrentLibKeys.length; i++) {
@@ -762,18 +765,28 @@ class Library {
         document.getElementById("LibURLWarning"+obj.dataset.libepubid).innerHTML = "<tr><td></td></tr>";
     }
 
-    static async LibGetAllLibStorageKeys(Substring){
+    static async LibGetAllLibStorageKeys(Substring, AllStorageKeysList){
         return new Promise((resolve) => {
-            chrome.storage.local.get(null, function(items){
-                let AllStorageKeys = Object.keys(items);
+            if (AllStorageKeysList == undefined) {
+                chrome.storage.local.get(null, function(items){
+                    let AllStorageKeys = Object.keys(items);
+                    let AllLibStorageKeys = [];
+                    for (let i = 0, end = AllStorageKeys.length; i < end; i++) {
+                        if(AllStorageKeys[i].includes(Substring)){
+                            AllLibStorageKeys.push(AllStorageKeys[i]);
+                        }   
+                    }
+                    resolve(AllLibStorageKeys);
+                });
+            } else {
                 let AllLibStorageKeys = [];
-                for (let i = 0, end = AllStorageKeys.length; i < end; i++) {
-                    if(AllStorageKeys[i].includes(Substring)){
-                        AllLibStorageKeys.push(AllStorageKeys[i]);
+                for (let i = 0, end = AllStorageKeysList.length; i < end; i++) {
+                    if(AllStorageKeysList[i].includes(Substring)){
+                        AllLibStorageKeys.push(AllStorageKeysList[i]);
                     }   
                 }
                 resolve(AllLibStorageKeys);
-            });
+            }
         });
     }
 


### PR DESCRIPTION
Double render speed of Library.
The more Bytes are saved in chrome.storage.local or the Library the slower the rendering is.
With the reduction from 2 calls of chrome.storage.local.get() to 1 it is double the speed.
