### PR TITLE
Create convertTableToDiv to fix royalroad tables on tolino

### DIFF
--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -89,6 +89,7 @@ class Parser {
         util.decodeCloudflareProtectedEmails(content);
         this.removeNextAndPreviousChapterHyperlinks(webPage, content);
         this.removeUnwantedElementsFromContentElement(content);
+        this.convertTabletoDiv(content);
         this.addTitleToContent(webPage, content);
         util.fixBlockTagsNestedInInlineTags(content);
         this.imageCollector.replaceImageTags(content);
@@ -141,6 +142,12 @@ class Parser {
         util.removeMicrosoftWordCrapElements(element);
         util.removeShareLinkElements(element);
         util.removeLeadingWhiteSpace(element);
+    };
+
+    convertTabletoDiv(element) {
+        if (this.userPreferences.styleSheet.value.includes(".WebToEpub-table")) {
+            util.convertTableToDiv(element);
+        }
     };
 
     customRawDomToContentStep(chapter, content) { // eslint-disable-line no-unused-vars

--- a/plugin/js/Util.js
+++ b/plugin/js/Util.js
@@ -234,6 +234,33 @@ var util = (function () {
         node.remove();
     }
 
+    var convertTableToDiv = function(element) {
+        for(let table of [...element.querySelectorAll("table")]) {
+            replaceTableToDivHelper(table, "td", "WebToEpub-cell");
+            replaceTableToDivHelper(table, "tr", "WebToEpub-row");
+            replaceTableToDivHelper(table, "tbody", "");
+            replaceTableToDivHelper(table.parentNode, "table", "WebToEpub-table");
+        }
+    }
+
+    var replaceTableToDivHelper =  function(element, elementtoreplace, divclass) {
+        if (element == null || element == undefined) {
+            return;
+        }
+        for(let node of [...element.querySelectorAll(elementtoreplace)]) {
+            let elementchildren = [...node.childNodes];
+            let div = document.createElement("div");
+            div.append(...elementchildren);
+            if (elementtoreplace == "table") {
+                node.parentNode.style.overflow = "visible";
+            }
+            if (divclass != "") {
+                div.classList.add(divclass);
+            }
+            node.replaceWith(div);
+        }
+    }
+
     /**
     * @todo expand to remove ALL event handlers
     */
@@ -1035,7 +1062,8 @@ var util = (function () {
         createChapterTab: createChapterTab,
         syncLoadSampleDoc : syncLoadSampleDoc,
         xmlToString: xmlToString,
-        zeroPad: zeroPad
+        zeroPad: zeroPad,
+        convertTableToDiv: convertTableToDiv
     };
 })();
 


### PR DESCRIPTION
reference: #1455
To use the change add this to the Stylesheet:
```
.WebToEpub-table {
    border-collapse: collapse;
    width: 100%;
}
.WebToEpub-row {
    display: flex;
    border: 1px solid black;
}
.WebToEpub-cell {
    flex: 1;
    padding: 5px;
    border: 1px solid black;
}
```
@dteviot as this is really obscure i would appreciate other ideas to enable this option.
Maybe a new Checkbox "tolino compatibility"?.
Why not always convert tables to div?
It looks like only tolino has the problem and not other reader. As the table looks better than the div version other user shouldn't be impacted from the tolino fix.

Tested with:
https://www.royalroad.com/fiction/22546/inexorable-chaos-complete/chapter/324087/chapter-four-abnormal-summoning
There is a table in a table and the table is to long for tolino.