### PR TITLE
Improve edit chapter urls

### DIFF
--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -255,6 +255,10 @@
 		"message": "CSS selector for element(s) to remove:",
 		"description": "Label in front input for CCS selector for elements to remove"
 	},
+	"__MSG_label_Edit_URLs_Hint__": {
+		"message": "You can edit the URLs in html format or as a simle URL list (one URL per line).",
+		"description": "Label in Edit Chapter URLs to help the user."
+	},
 	"__MSG_label_Element_With_Chapter_Content__": {
 		"message": "Element with Chapter Content:",
 		"description": "Label in front input for type of element holding each chapter's content"

--- a/plugin/js/ChapterUrlsUI.js
+++ b/plugin/js/ChapterUrlsUI.js
@@ -280,6 +280,7 @@ class ChapterUrlsUI {
         document.getElementById("coverUrlSection").hidden = !toTable;
         document.getElementById("chapterSelectControlsDiv").hidden = !toTable;
         ChapterUrlsUI.modifyApplyChangesButtons(button => button.hidden = toTable);
+        document.getElementById("editURLsHint").hidden = toTable;
     }
 
     /** 

--- a/plugin/js/ChapterUrlsUI.js
+++ b/plugin/js/ChapterUrlsUI.js
@@ -290,8 +290,8 @@ class ChapterUrlsUI {
             let inputvalue = ChapterUrlsUI.getEditChaptersUrlsInput().value;
             let chapters;
             let lines = inputvalue.split("\n");
+            lines = lines.filter(function(line) { return line.trim() != ""; });
             if (URL.canParse(lines[0])) {
-                lines = lines.filter(function(line) { return line.trim() != ""; });
                 chapters = this.URLsToChapters(lines);
             } else {
                 chapters = this.htmlToChapters(inputvalue);

--- a/plugin/js/ChapterUrlsUI.js
+++ b/plugin/js/ChapterUrlsUI.js
@@ -290,7 +290,7 @@ class ChapterUrlsUI {
             let inputvalue = ChapterUrlsUI.getEditChaptersUrlsInput().value;
             let chapters;
             let lines = inputvalue.split("\n");
-            lines = lines.filter(function(line) { return line.trim() != ""; });
+            lines = lines.filter(a => a.trim() != "").map(a => a.trim());
             if (URL.canParse(lines[0])) {
                 chapters = this.URLsToChapters(lines);
             } else {

--- a/plugin/js/ChapterUrlsUI.js
+++ b/plugin/js/ChapterUrlsUI.js
@@ -289,9 +289,9 @@ class ChapterUrlsUI {
         try {
             let inputvalue = ChapterUrlsUI.getEditChaptersUrlsInput().value;
             let chapters;
-            let lines = inputvalue.split('\n');
+            let lines = inputvalue.split("\n");
             if (URL.canParse(lines[0])) {
-                lines = lines.filter(function(line) { return line.trim() != ''; });
+                lines = lines.filter(function(line) { return line.trim() != ""; });
                 chapters = this.URLsToChapters(lines);
             } else {
                 chapters = this.htmlToChapters(inputvalue);
@@ -332,7 +332,7 @@ class ChapterUrlsUI {
     URLsToChapters(URLs) {
         let returnchapters = URLs.map(e => ({
             sourceUrl: e,
-            title: `[placeholder]`
+            title: "[placeholder]"
         }));
         return returnchapters;
     }

--- a/plugin/js/ChapterUrlsUI.js
+++ b/plugin/js/ChapterUrlsUI.js
@@ -287,7 +287,15 @@ class ChapterUrlsUI {
     */
     setTableMode() {
         try {
-            let chapters = this.htmlToChapters(ChapterUrlsUI.getEditChaptersUrlsInput().value);
+            let inputvalue = ChapterUrlsUI.getEditChaptersUrlsInput().value;
+            let chapters;
+            let lines = inputvalue.split('\n');
+            if (URL.canParse(lines[0])) {
+                lines = lines.filter(function(line) { return line.trim() != ''; });
+                chapters = this.URLsToChapters(lines);
+            } else {
+                chapters = this.htmlToChapters(inputvalue);
+            }
             this.parser.setPagesToFetch(chapters);
             this.populateChapterUrlsTable(chapters);
             this.usingTable = true;
@@ -316,6 +324,17 @@ class ChapterUrlsUI {
         let html = "<html><head><title></title><body>" + innerHtml + "</body></html>";
         let doc = new DOMParser().parseFromString(html, "text/html");
         return [...doc.body.querySelectorAll("a")].map(a => util.hyperLinkToChapter(a));
+    }
+
+    /** 
+    * @private
+    */
+    URLsToChapters(URLs) {
+        let returnchapters = URLs.map(e => ({
+            sourceUrl: e,
+            title: `[placeholder]`
+        }));
+        return returnchapters;
     }
 
     /** @private */

--- a/plugin/js/DefaultParserUI.js
+++ b/plugin/js/DefaultParserUI.js
@@ -133,6 +133,7 @@ class DefaultParserUI {
         if (isVisible) {
             ChapterUrlsUI.getEditChaptersUrlsInput().hidden = true;
             ChapterUrlsUI.modifyApplyChangesButtons(button => button.hidden = true);
+            document.getElementById("editURLsHint").hidden = true;
         }
         document.getElementById("defaultParserSection").hidden = !isVisible;
     }

--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -108,23 +108,23 @@ class Parser {
 
     addTitleToContent(webPage, content) {
         let title = this.findChapterTitle(webPage.rawDom, webPage);
-        if (webPage.title == "[placeholder]") {
-            if (title != null) {
-                webPage.title = title.trim();
-            } else {
-                webPage.title = webPage.rawDom.title;
-            }
-        }
         if (title != null) {
             if (title instanceof HTMLElement) {
                 title = title.textContent;
+            }
+            if (webPage.title == "[placeholder]") {
+                webPage.title = title.trim();
             }
             if (!this.titleAlreadyPresent(title, content)) {
                 let titleElement = webPage.rawDom.createElement("h1");
                 titleElement.appendChild(webPage.rawDom.createTextNode(title.trim()));
                 content.insertBefore(titleElement, content.firstChild);
             }
-        };
+        } else {
+            if (webPage.title == "[placeholder]") {
+                webPage.title = webPage.rawDom.title;
+            }
+        }
     }
 
     titleAlreadyPresent(title, content) {

--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -108,12 +108,16 @@ class Parser {
 
     addTitleToContent(webPage, content) {
         let title = this.findChapterTitle(webPage.rawDom, webPage);
+        if (webPage.title == "[placeholder]") {
+            if (title != null) {
+                webPage.title = title.trim();
+            } else {
+                webPage.title = webPage.rawDom.title;
+            }
+        }
         if (title != null) {
             if (title instanceof HTMLElement) {
                 title = title.textContent;
-            }
-            if (webPage.title == "[placeholder]") {
-                webPage.title = title.trim();
             }
             if (!this.titleAlreadyPresent(title, content)) {
                 let titleElement = webPage.rawDom.createElement("h1");

--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -112,6 +112,9 @@ class Parser {
             if (title instanceof HTMLElement) {
                 title = title.textContent;
             }
+            if (webPage.title == "[placeholder]") {
+                webPage.title = title.trim();
+            }
             if (!this.titleAlreadyPresent(title, content)) {
                 let titleElement = webPage.rawDom.createElement("h1");
                 titleElement.appendChild(webPage.rawDom.createTextNode(title.trim()));

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -490,6 +490,7 @@
                 </div>
             </div>
             <button id="applyChangesButton" hidden>__MSG_button_Apply_Changes__</button>
+            <p id="editURLsHint" class="i18n" hidden>__MSG_label_Edit_URLs_Hint__</p>
             <div id="findingChapterUrlsMessageRow" class="i18n warning">__MSG_Searching_For_URLs_Please_Wait__</div>
             <table id="chapterUrlsTable" class="chapterlist">
                 <tr>


### PR DESCRIPTION
reference:  #1452
"Edit Chapter URLs" accepts now pure URLs (one URL per line)
![image](https://github.com/user-attachments/assets/32de1383-742e-49d1-9917-447012ee95fa)
The title name is `[placeholder]` if the parser has implemented `findChapterTitle()` this name is used if `findChapterTitle()` isn't implemented `dom.title` gets used.
Problem:
You have to know that you can simple paste an URLs list. (no hint etc,)
@Darthagnon any ideas how to inform the users?