### PR TITLE
increase min browser version URL.canParse()

### DIFF
--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -28,8 +28,8 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "WebToEpub@Baka-tsuki.org",
-      "strict_min_version": "109.0"
+      "strict_min_version": "115.0"
     }
   },
-  "minimum_chrome_version": "119"
+  "minimum_chrome_version": "120"
 }


### PR DESCRIPTION
reference: #1576
https://developer.mozilla.org/en-US/docs/Web/API/URL/canParse_static
![image](https://github.com/user-attachments/assets/a2a60ae1-aa71-4acd-8a5c-6b7467b1d201)

@dteviot In manifest.json the "minimum_chrome_version" and "strict_min_version" got changed. This would be a "majore" release if the versioning is as described here #1515. 