### PR TITLE
Add Site mvlempyr

### DIFF
--- a/plugin/js/parsers/MvlempyrParser.js
+++ b/plugin/js/parsers/MvlempyrParser.js
@@ -1,0 +1,54 @@
+"use strict";
+
+parserFactory.register("mvlempyr.com", () => new MvlempyrParser());
+
+class MvlempyrParser extends Parser {
+    constructor() {
+        super();
+    }
+
+    async getChapterUrls(dom) {
+        let imgLink = dom.querySelector("div.novel-image-wrapper img").src;
+        let slug = imgLink.split("/").pop().split(".")[0];
+        let chapterCount = parseInt(dom.querySelector("div#chapter-count").textContent);
+
+        let chapterList = [];
+
+        for (let i = 1; i <= chapterCount; i++) {
+            let link = `https://www.mvlempyr.com/chapter/${slug}-${i}`;
+            chapterList.push({
+                sourceUrl: link,
+                title: `Chapter ${i}`
+            });
+        }
+        return chapterList;
+    }
+
+    findContent(dom) {
+        return (
+            dom.querySelector("div#chapter") || dom.querySelector("#chapter-content")
+        );
+    }
+
+    extractTitleImpl(dom) {
+        return dom.querySelector("h1.novel-title");
+    }
+
+    extractAuthor(dom) {
+        let authorLabel = dom.querySelector("div.novelinfo .text-block-9");
+        return authorLabel?.textContent ?? super.extractAuthor(dom);
+    }
+
+    findChapterTitle(dom) {
+        return dom.querySelector("#span-28-164").textContent;
+    }
+
+    findCoverImageUrl(dom) {
+        return util.getFirstImgSrc(dom, "div.novel-image-wrapper");
+    }
+
+    getInformationEpubItemChildNodes(dom) {
+        return [...dom.querySelectorAll("div.synopsis")];
+    }
+
+}

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -666,6 +666,7 @@
     <script src="js/parsers/MtnovelParser.js"></script>
     <script src="js/parsers/MoonQuillParser.js"></script>
     <script src="js/parsers/MuggleNetParser.js"></script>
+    <script src="js/parsers/MvlempyrParser.js"></script>
     <script src="js/parsers/MyxlsParser.js"></script>
     <script src="js/parsers/NanodesuParser.js"></script>
     <script src="js/parsers/NanomashinonlineParser.js"></script>


### PR DESCRIPTION
Solves Issue #1568 

One of the weirdest sites.

Notes:

1. Each Novel has a slug which is used to get the Novel Id, Chapter Count but don't know from where slug is being created. Had to take the slug from image source. This api call sometimes fail. So, had to use again chapter count div to get it
2. API call to get Chapter URL always give 404 for some reason. No time to check.

API Call to get ID : 	https://chp.mvlempyr.net/wp-json/wp/v2/tags?slug=6062 => {"id": 2021, "count": 190} and more
API Call to get Chapters : https://chp.mvlempyr.net/wp-json/wp/v2/posts?tags=2021&per_page=500&page=1 => Gives JSON error

@dteviot can you check

Code is working fine but is there any better implementations?