### PR TITLE
fix github actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,11 +27,3 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install
     - run: npm run lint
-    
-    - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v3
-      with:
-        # A file, directory or wildcard pattern that describes what to upload
-        path: |
-          eslint/*.xpi
-          eslint/*.zip


### PR DESCRIPTION
fixes #1663 
@dteviot i just removed the actions/upload-artifact as it isn't needed as the releases get created with [AutoRelease.yml](https://github.com/dteviot/WebToEpub/blob/ExperimentalTabMode/.github/workflows/AutoRelease.yml) 