### PR TITLE
update Libexport for zip.js logic

### DIFF
--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -677,7 +677,7 @@ class Library {
             dlzip.file("LibraryVersion.txt", "1");
             //simplyfies import espacially for zip.js as the api is different from jszip currenty not needed for import
             //it is for the change to zip.js from jszip
-            dlzip.file("LibraryCountEntries.txt", CurrentLibKeys.length);
+            dlzip.file("LibraryCountEntries.txt", CurrentLibKeys.length + "");
 
             for (let i = 0; i < CurrentLibKeys.length; i++) {
                 dlzip.file("Library/"+i+"/LibCover", items["LibCover" + CurrentLibKeys[i]]);

--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -675,6 +675,9 @@ class Library {
             let dlzip = new JSZip();
             //in case for future changes to differntiate between different export versions
             dlzip.file("LibraryVersion.txt", "1");
+            //simplyfies import espacially for zip.js as the api is different from jszip currenty not needed for import
+            //it is for the change to zip.js from jszip
+            dlzip.file("LibraryCountEntries.txt", CurrentLibKeys.length);
 
             for (let i = 0; i < CurrentLibKeys.length; i++) {
                 dlzip.file("Library/"+i+"/LibCover", items["LibCover" + CurrentLibKeys[i]]);


### PR DESCRIPTION
As the api for zip.js is different than jszip it is easier this way and as it is the 1 zip export version i won't have the make a different logic for version 1 and 2.