### PR TITLE
Fix Firefox Upload EPUBs to Library

### DIFF
--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -584,7 +584,7 @@ class Library {
                 LibFileReader.LibStorageValueURL = await Library.LibGetSourceURL(LibFileReader.result);
             }
         }
-        let StorageNewChapterCount = await (await chrome.storage.local.get("LibNewChapterCount" + LibFileReader.LibStorageValueId))?.["LibNewChapterCount" + LibFileReader.LibStorageValueId];
+        let StorageNewChapterCount = await Library.LibGetFromStorage("LibNewChapterCount" + LibFileReader.LibStorageValueId);
         let NewChapterCount = LibFileReader.NewChapterCount + (StorageNewChapterCount || 0);
         //Catch Firefox upload wrong Content-Type
         let result = LibFileReader.result;

--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -584,10 +584,16 @@ class Library {
                 LibFileReader.LibStorageValueURL = await Library.LibGetSourceURL(LibFileReader.result);
             }
         }
-        let StorageNewChapterCount = (await chrome.storage.local.get("LibNewChapterCount" + LibFileReader.LibStorageValueId))["LibNewChapterCount" + LibFileReader.LibStorageValueId];
+        let StorageNewChapterCount = await (await chrome.storage.local.get("LibNewChapterCount" + LibFileReader.LibStorageValueId))?.["LibNewChapterCount" + LibFileReader.LibStorageValueId];
         let NewChapterCount = LibFileReader.NewChapterCount + (StorageNewChapterCount || 0);
+        //Catch Firefox upload wrong Content-Type
+        let result = LibFileReader.result;
+        if (result.startsWith("data:application/octet-stream;base64,")) {
+            let regex = new RegExp("^data:application/octet-stream;base64,");
+            result = result.replace(regex, "data:application/epub+zip;base64,");
+        }
         chrome.storage.local.set({
-            ["LibEpub" + LibFileReader.LibStorageValueId]: LibFileReader.result,
+            ["LibEpub" + LibFileReader.LibStorageValueId]: result,
             ["LibStoryURL" + LibFileReader.LibStorageValueId]: LibFileReader.LibStorageValueURL,
             ["LibFilename" + LibFileReader.LibStorageValueId]: LibFileReader.LibStorageValueFilename,
             ["LibNewChapterCount" + LibFileReader.LibStorageValueId]: NewChapterCount


### PR DESCRIPTION
reference: #1724
Firefox designated the wrong content type on file upload and handled not found in local storage different than chrome.
