### PR TITLE
Adding new parser for marxists.org support

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "contributors" : [
     { "name": "Alen Toma"},
+    { "name": "Anartigone"},
     { "name": "Asif Mahmood"},
     { "name": "Aurimas Niekis"},
     { "name": "Markus Vieth"},

--- a/plugin/js/parsers/MarxistsCNParser.js
+++ b/plugin/js/parsers/MarxistsCNParser.js
@@ -1,0 +1,53 @@
+"use strict";
+
+parserFactory.register("marxists.org", () => new MarxistsCNParser());
+
+class MarxistsCNParser extends Parser {
+    constructor() {
+        super();
+    }
+
+    async getChapterUrls(dom) {
+        let menu = dom.querySelector("table[border='0']");
+        let chapterUrls = [];
+        let links = menu.querySelectorAll("a");
+        for (let link of links) {
+            if (link.href && link.href.endsWith(".htm")) {
+                chapterUrls.push({ 
+                    sourceUrl: link.href, 
+                    title: link.textContent 
+                });
+            }
+        }
+        return chapterUrls;
+    }
+
+    findContent(dom) {
+        return dom.querySelector("body");
+    }
+    
+    extractTitleImpl(dom) {
+        return dom.querySelector("title0");
+    }
+
+    extractLanguage() {
+        return "cn";
+    }
+    
+    extractAuthor(dom) {
+        let element = dom.querySelector("author");
+        return (element === null) ? "" : element.textContent;
+    }
+
+    findChapterTitle(dom) {
+        return dom.querySelector("title");
+    }
+
+    async fetchChapter(url) {
+        // site does not tell us gbk is used to encode text
+        let options = { 
+            makeTextDecoder: () => new TextDecoder("gbk") 
+        };
+        return (await HttpClient.wrapFetch(url, options)).responseXML;
+    }
+}

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -667,6 +667,7 @@
     <script src="js/parsers/ManhwadenParser.js"></script>
     <script src="js/parsers/ManhwatopParser.js"></script>
     <script src="js/parsers/Marx2maoParser.js"></script>
+    <script src="js/parsers/MarxistsCNParser.js"></script>
     <script src="js/parsers/MayanovelParser.js"></script>
     <script src="js/parsers/McStoriesParser.js"></script>
     <script src="js/parsers/MeionovelParser.js"></script>

--- a/readme.md
+++ b/readme.md
@@ -779,6 +779,7 @@ Don't forget to give the project a star! Thanks again!
     <li>phazei</li>
     <li>rizkiv1</li>
     <li>pavan3999</li>
+    <li>Anartigone</li>
   </ul>
 </details>
 


### PR DESCRIPTION
- Adding new script `MarxistsCNParser.js` into `plugin/js/parsers/`.
- Adding one line in `popup.html` correspondingly. 
- Adding myself into `package.json`and `Credits`.

Currently, only works on pages have an index page. For example:
```
https://www.marxists.org/chinese/emma-goldman/1910/index.htm
https://www.marxists.org/chinese/bukharin/1917/index.htm
https://www.marxists.org/chinese/rosa-luxemburg/1898/index.htm
```

The output epub file is complete and clean.