### PR TITLE
Update WtrlabParser.js to always use google for translation

### DIFF
--- a/plugin/js/parsers/WtrlabParser.js
+++ b/plugin/js/parsers/WtrlabParser.js
@@ -10,7 +10,7 @@ class WtrlabParser extends Parser{
     async getChapterUrls(dom) {
         let items = [...dom.querySelectorAll("div.accordion a.chapter-item")];
         return items.map(a => ({
-            sourceUrl:  a.href + '?service=google',
+            sourceUrl:  a.href + "?service=google",
             title: this.formatTitle(a)
         }));
     }

--- a/plugin/js/parsers/WtrlabParser.js
+++ b/plugin/js/parsers/WtrlabParser.js
@@ -10,7 +10,7 @@ class WtrlabParser extends Parser{
     async getChapterUrls(dom) {
         let items = [...dom.querySelectorAll("div.accordion a.chapter-item")];
         return items.map(a => ({
-            sourceUrl:  a.href,
+            sourceUrl:  a.href + '?service=google',
             title: this.formatTitle(a)
         }));
     }


### PR DESCRIPTION
#1430 wtr-lab now has AI translation which is causing the download failure.

Issues not resolved by this PR:
- wtr-lab also support other free translation services like Bing and Sogou, a user might want the option to chose between these services. Allow this in advanced config?
- Since wtr-lab seems to do the translation on demand, if the chapter is not already translated  WebToEpub  would still fail. 