### PR TITLE
Updated WanderingInnParser.js

### DIFF
--- a/plugin/js/parsers/WanderinginnParser.js
+++ b/plugin/js/parsers/WanderinginnParser.js
@@ -18,5 +18,9 @@ class WanderinginnParser extends WordpressBaseParser{
     
     extractAuthor() {
         return "pirateaba";
-    }    
+    }
+    
+    removeNextAndPreviousChapterHyperlinks(webPage, content) {
+        util.removeElements(content.querySelectorAll("a[href*='https://wanderinginn.com/']"));
+    }
 }


### PR DESCRIPTION
Wandering inn parser will now call the "removeNextAndPreviousChapterHyperLinks" method to remove the unneeded next and previous hyperlinks. (This also removes the large white spaces in between chapters)

Before:
![Before](https://github.com/user-attachments/assets/e0960cd3-507b-447e-addb-672af0955909)

After:
![After](https://github.com/user-attachments/assets/46f23e4f-fbef-4889-a2e2-a5c0bdcad1a3)

