### PR TITLE
Library change SearchNewChapter to Update

### DIFF
--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -47,6 +47,10 @@
 		"message": "Search new Chapters",
 		"description": "Label on button to Search new Chapters"
 	},
+	"__MSG_button_Lib_Template_Update_new_Chapters__": {
+		"message": "Update",
+		"description": "Label on button to Update new Chapters"
+	},
 	"__MSG_button_Lib_Template_Download_EPUB__": {
 		"message": "Download EPUB",
 		"description": "Label on button to Download EPUB"

--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -303,6 +303,7 @@ class Library {
         let LibRenderString = "";
         let LibTemplateDeleteEpub = document.getElementById("LibTemplateDeleteEpub").innerHTML;
         let LibTemplateSearchNewChapter = document.getElementById("LibTemplateSearchNewChapter").innerHTML;
+        let LibTemplateUpdateNewChapter = document.getElementById("LibTemplateUpdateNewChapter").innerHTML;
         let LibTemplateDownload = document.getElementById("LibTemplateDownload").innerHTML;
         let LibTemplateNewChapter = document.getElementById("LibTemplateNewChapter").innerHTML;
         let LibTemplateURL = document.getElementById("LibTemplateURL").innerHTML;
@@ -343,7 +344,7 @@ class Library {
             LibRenderString += "<td style='height: 115.5px; width: 106.5px;' rowspan='4'>   <img class='LibCover' id='LibCover"+CurrentLibKeys[i]+"'></td>";
             LibRenderString += "<td colspan='2'>";
             LibRenderString += "<button data-libepubid="+CurrentLibKeys[i]+" id='LibDeleteEpub"+CurrentLibKeys[i]+"'>"+LibTemplateDeleteEpub+"</button>";
-            LibRenderString += "<button data-libepubid="+CurrentLibKeys[i]+" id='LibSearchNewChapter"+CurrentLibKeys[i]+"'>"+LibTemplateSearchNewChapter+"</button>";
+            LibRenderString += "<button data-libepubid="+CurrentLibKeys[i]+" id='LibUpdateNewChapter"+CurrentLibKeys[i]+"'>"+LibTemplateUpdateNewChapter+"</button>";
             LibRenderString += "<button data-libepubid="+CurrentLibKeys[i]+" id='LibDownload"+CurrentLibKeys[i]+"'>"+LibTemplateDownload+"</button>";
             LibRenderString += "<span style='padding: 1em; font-size: 1.2em; color: Chartreuse;' id='LibNewChapterCount"+CurrentLibKeys[i]+"'></span>";
             if (ShowAdvancedOptions) {
@@ -354,8 +355,8 @@ class Library {
                 LibRenderString += "<label id='LibMergeUploadLabel"+CurrentLibKeys[i]+"' data-libbuttonid='LibMergeUploadButton' data-libepubid="+CurrentLibKeys[i]+" for='LibMergeUpload"+CurrentLibKeys[i]+"' style='cursor: pointer;'>";
                 LibRenderString += "<button id='LibMergeUploadButton"+CurrentLibKeys[i]+"' style='pointer-events: none;'>"+LibTemplateMergeUploadButton+"</button></label>";
                 LibRenderString += "<input type='file' data-libepubid="+CurrentLibKeys[i]+" id='LibMergeUpload"+CurrentLibKeys[i]+"' hidden>";
+                LibRenderString += "<button data-libepubid="+CurrentLibKeys[i]+" id='LibSearchNewChapter"+CurrentLibKeys[i]+"'>"+LibTemplateSearchNewChapter+"</button>";
                 LibRenderString += "<button data-libepubid="+CurrentLibKeys[i]+" id='LibEditMetadata"+CurrentLibKeys[i]+"'>"+LibTemplateEditMetadataButton+"</button>";
-            
             }
             LibRenderString += "</td>";
             LibRenderString += "</tr>";
@@ -399,7 +400,7 @@ class Library {
         }
         for (let i = 0; i < CurrentLibKeys.length; i++) {
             document.getElementById("LibDeleteEpub"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibDeleteEpub(this)});
-            document.getElementById("LibSearchNewChapter"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibSearchNewChapter(this)});
+            document.getElementById("LibUpdateNewChapter"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibUpdateNewChapter(this)});
             document.getElementById("LibDownload"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibDownload(this)});
             document.getElementById("LibStoryURL"+CurrentLibKeys[i]).addEventListener("change", function(){Library.LibSaveTextURLChange(this)});
             document.getElementById("LibStoryURL"+CurrentLibKeys[i]).addEventListener("focusin", function(){Library.LibShowTextURLWarning(this)});
@@ -409,6 +410,7 @@ class Library {
                 document.getElementById("LibMergeUpload"+CurrentLibKeys[i]).addEventListener("change", function(){Library.LibMergeUpload(this)});
                 document.getElementById("LibMergeUploadLabel"+CurrentLibKeys[i]).addEventListener("mouseover", function(){Library.LibMouseoverButtonUpload(this)});
                 document.getElementById("LibMergeUploadLabel"+CurrentLibKeys[i]).addEventListener("mouseout", function(){Library.LibMouseoutButtonUpload(this)});
+                document.getElementById("LibSearchNewChapter"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibSearchNewChapter(this)});
                 document.getElementById("LibEditMetadata"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibEditMetadata(this)});
             }
         }
@@ -704,6 +706,20 @@ class Library {
         Library.userPreferences.readingList.tryDeleteEpubAndSave(document.getElementById("LibStoryURL" + objbtn.dataset.libepubid).value);
         chrome.storage.local.remove(LibRemove);
         Library.LibRenderSavedEpubs();
+    }
+
+    static async LibUpdateNewChapter(objbtn){
+        let LibGetURL = ["LibStoryURL" + objbtn.dataset.libepubid];
+        Library.LibClearFields();
+        let obj = {};
+        obj.dataset = {};
+        obj.dataset.libclick = "yes";
+        document.getElementById("startingUrlInput").value = await Library.LibGetFromStorage(LibGetURL);
+        await main.onLoadAndAnalyseButtonClick.call(obj);
+        if (document.getElementById("includeInReadingListCheckbox").checked != true) {
+            document.getElementById("includeInReadingListCheckbox").click();
+        }
+        await main.fetchContentAndPackEpub.call(obj);
     }
 
     static LibSearchNewChapter(objbtn){

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -167,6 +167,7 @@
                                 <td colspan="2">
                                     <button id="LibTemplateDeleteEpub">__MSG_button_Lib_Template_Delete_EPUB__</button>
                                     <button id="LibTemplateSearchNewChapter">__MSG_button_Lib_Template_Search_new_Chapters__</button>
+                                    <button id="LibTemplateUpdateNewChapter">__MSG_button_Lib_Template_Update_new_Chapters__</button>
                                     <button id="LibTemplateDownload">__MSG_button_Lib_Template_Download_EPUB__</button>
                                     <label style="cursor: pointer;">
                                         <button id="LibTemplateMergeUploadButton" style="pointer-events: none;">__MSG_button_Lib_Template_Add_Chapter_from_different_EPUB__</button>


### PR DESCRIPTION
The only reason for "Search new Chapters" to exist was that the Chapter search wasn't async with Update all this got implemented. If someone uses "Search new Chapters" he will click "Add to Library" after that. This is now one click.