### PR TITLE
#1732 - update QidianParser for more versatile usage

### DIFF
--- a/plugin/js/parsers/QidianParser.js
+++ b/plugin/js/parsers/QidianParser.js
@@ -13,8 +13,8 @@ class QidianParser extends Parser{
 
     async getChapterUrls(dom) {
         if (!dom.baseURI.match(new RegExp("/catalog$"))) {
-            let regex = new RegExp("/?$");
-            dom = (await HttpClient.wrapFetch(dom.baseURI.replace(regex, "/catalog"))).responseXML;
+            let regex = new RegExp("(/book/.*?\\d+\\b).*");
+            dom = (await HttpClient.wrapFetch(dom.baseURI.replace(regex, "$1/catalog"))).responseXML;
         }
         let links = Array.from(dom.querySelectorAll("ul.content-list a"));
         if (links.length === 0) {


### PR DESCRIPTION
Extra URI parameters inserted via google, anchor links, cloudflare and other miscellaneous sources caused extension failure in catalog retrieval. Better handling of url via regex to cover this scenario as well as allowing incomplete generation from chapter page.