### PR TITLE
potential fix #1775

### DIFF
--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -379,6 +379,10 @@
 		"message": "Remove Author Notes",
 		"description": "Label for checkbox to remove Author Notes from chapters"
 	},
+	"__MSG_label_Remove_Chapter_Number__": {
+		"message": "Remove Chapter Numbers",
+		"description": "Label for checkbox to remove Chapter Numbers from chapter titles"
+	},
 	"__MSG_label_Remove_Original__": {
 		"message": "Remove Original/Raw Text",
 		"description": "Label for checkbox to remove Original text from chapters"

--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -94,6 +94,7 @@ class UserPreferences {
         this.addPreference("chaptersPageInChapterList", "chaptersPageInChapterListCheckbox", false);
         this.addPreference("autoSelectBTSeriesPage", "autoParserSelectIncludesBTSeriesPageCheckbox", false);
         this.addPreference("removeAuthorNotes", "removeAuthorNotesCheckbox", false);
+        this.addPreference("removeChapterNumber", "removeChapterNumberCheckbox", false);
         this.addPreference("removeOriginal", "removeOriginalCheckbox", true);
         this.addPreference("maxPagesToFetchSimultaneously", "maxPagesToFetchSimultaneouslyTag", "1");
         this.addPreference("skipChaptersThatFailFetch", "skipChaptersThatFailFetchCheckbox", false);

--- a/plugin/js/parsers/QidianParser.js
+++ b/plugin/js/parsers/QidianParser.js
@@ -9,6 +9,7 @@ class QidianParser extends Parser{
     constructor() {
         super();
         this.minimumThrottle = 50; //Minimal delay to reduce frequency of 445 errors.
+        this.ChacheChapterTitle = new Map();
     }
 
     async getChapterUrls(dom) {
@@ -34,9 +35,11 @@ class QidianParser extends Parser{
         let element = link.querySelector("strong");
         if (element !== null) {
             title = element.textContent.trim();
-            element = link.querySelector("i");
-            if (element !== null) {
-                title = element.textContent + ": " + title;
+            if (!document.getElementById("removeChapterNumberCheckbox").checked) {
+                element = link.querySelector("i");
+                if (element !== null) {
+                    title = element.textContent + ": " + title;
+                }
             }
         }
         return {sourceUrl: link.href, title: title, 
@@ -49,6 +52,10 @@ class QidianParser extends Parser{
     };
 
     preprocessRawDom(webPage) {
+        if (this.ChacheChapterTitle.size == 0) {
+            let pagesToFetch = [...this.state.webPages.values()].filter(c => c.isIncludeable);
+            pagesToFetch.map(a => (this.ChacheChapterTitle.set(a.sourceUrl, a.title)));
+        }
         let content = this.findContent(webPage);
         if (content !== null) {
             content = this.cleanRawDom(content);
@@ -83,6 +90,16 @@ class QidianParser extends Parser{
         //Remove repeating & unused metadata from document. Approximately halves body length.
         content.querySelectorAll("i.para-comment_num, i.para-comment").forEach(i => i.remove());
         content.querySelectorAll("div.db").forEach(i => i.removeAttribute("data-ejs"));
+        let tmptitle = this.ChacheChapterTitle.get(content.baseURI);
+        if (tmptitle == undefined || tmptitle == "[placeholder]") {
+            let titleEl = content.querySelector("div.chapter_content h1");
+            let titleDupChapRegex = new RegExp("(\\w+[\\s\\-]+\\d+:)\\s*\\1(.*)", "i").exec(titleEl.textContent);
+            if (titleDupChapRegex && titleDupChapRegex.length > 2){
+                titleEl.textContent = titleDupChapRegex[1] + titleDupChapRegex[2];
+            }
+        } else {
+            content.querySelector("div.chapter_content h1").innerHTML = tmptitle;
+        }
         return content;
     }
 
@@ -149,6 +166,7 @@ class QidianParser extends Parser{
     populateUI(dom) {
         super.populateUI(dom);
         document.getElementById("removeAuthorNotesRow").hidden = false; 
+        document.getElementById("removeChapterNumberRow").hidden = false; 
     }
 
     // title of the story

--- a/plugin/js/parsers/QidianParser.js
+++ b/plugin/js/parsers/QidianParser.js
@@ -93,7 +93,7 @@ class QidianParser extends Parser{
         let tmptitle = this.ChacheChapterTitle.get(content.baseURI);
         if (tmptitle == undefined || tmptitle == "[placeholder]") {
             let titleEl = content.querySelector("div.chapter_content h1");
-            let titleDupChapRegex = new RegExp("(\\w+[\\s\\-]+\\d+:)\\s*\\1(.*)", "i").exec(titleEl.textContent);
+            let titleDupChapRegex = new RegExp("(\\w+[\\s\\-]+\\d+):\\s*\\1:?(.*)", "i").exec(titleEl.textContent);
             if (titleDupChapRegex && titleDupChapRegex.length > 2){
                 titleEl.textContent = titleDupChapRegex[1] + titleDupChapRegex[2];
             }

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -115,6 +115,10 @@
                     <td><input id="removeAuthorNotesCheckbox" type="checkbox" name="removeAuthorNotesCheckbox" value="false"></td>
                     <td>__MSG_label_Remove_Author_Notes__</td>
                 </tr>
+                <tr id="removeChapterNumberRow" hidden="true">
+                    <td><input id="removeChapterNumberCheckbox" type="checkbox" name="removeChapterNumberCheckbox" value="false"></td>
+                    <td>__MSG_label_Remove_Chapter_Number__</td>
+                </tr>
                 <tr id="removeOriginalRow" hidden="true">
                     <td><input id="removeOriginalCheckbox" type="checkbox" name="removeOriginalCheckbox" value="true"></td>
                     <td>__MSG_label_Remove_Original__</td>


### PR DESCRIPTION
@Kiradien in reference to #1778 and #1775

My idea is a little different from yours.
I added this Checkbox 
![image](https://github.com/user-attachments/assets/c75913c4-1589-470d-a0fa-95b0c193e6ce)
And my Idea is that the Chapter title in the content gets always replaced with the title from the ToC in case there is [placeholder] your fix from #1778 will be used.

I am going to be honest and say that i didn't really understand your regex i tried it here https://regex101.com/ and couldn't get it to work with problematic title (example: `Chapter 1: Chapter: 1`)

To be honest i am surprised that this isn't already the norm. Now that i think about it this would make `findChapterTitle()` for all parser irrelevant if always the ToC name would be used.