### PR TITLE
#1777 Set MinimumThrottle for DaoDivine parser

### DIFF
--- a/plugin/js/parsers/DaoDivineTlParser.js
+++ b/plugin/js/parsers/DaoDivineTlParser.js
@@ -5,6 +5,7 @@ parserFactory.register("dao-divine-tl.com", () => new DaoDivineTlParser());
 class DaoDivineTlParser extends Parser{
     constructor() {
         super();
+        this.minimumThrottle = 500;
     }
 
     async getChapterUrls(dom, chapterUrlsUI) {


### PR DESCRIPTION
Set Dao-Divine parser minimumThrottle to 500ms.
- Tested against 874 chapters.
- 300ms worked on shorter length stories, 500ms seems stable.