### PR TITLE
Library fix errors

### DIFF
--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -13,44 +13,42 @@ class Library {
         Library.userPreferences = userPreferences;
     }
     
-    LibAddToLibrary(AddEpub, fileName, startingUrlInput, overwriteExisting, backgroundDownload){
+    async LibAddToLibrary(AddEpub, fileName, startingUrlInput, overwriteExisting, backgroundDownload){
         if (document.getElementById("includeInReadingListCheckbox").checked != true) {
             document.getElementById("includeInReadingListCheckbox").click();
         }
-        chrome.storage.local.get(null, async function(items) {
-            let CurrentLibStoryURLKeys = await Library.LibGetAllLibStorageKeys("LibStoryURL", Object.keys(items));
-            let LibidURL = -1;
-            for (let i = 0; i < CurrentLibStoryURLKeys.length; i++) {
-                if (items[CurrentLibStoryURLKeys[i]] == startingUrlInput) {
-                    LibidURL = CurrentLibStoryURLKeys[i].replace("LibStoryURL","");
-                    continue;
-                }
+        let CurrentLibStoryURLKeys = await Library.LibGetAllLibStorageKeys("LibStoryURL");
+        let CurrentLibStoryURLs = await Library.LibGetFromStorageArray(CurrentLibStoryURLKeys);
+        let LibidURL = -1;
+        for (let i = 0; i < CurrentLibStoryURLKeys.length; i++) {
+            if (CurrentLibStoryURLs[CurrentLibStoryURLKeys[i]] == startingUrlInput) {
+                LibidURL = CurrentLibStoryURLKeys[i].replace("LibStoryURL","");
+                continue;
             }
-            if (LibidURL == -1) {
-                Library.LibHandelUpdate(-1, AddEpub, document.getElementById("startingUrlInput").value, fileName.replace(".epub", ""), LibidURL);
-                if (document.getElementById("LibDownloadEpubAfterUpdateCheckbox").checked) {
-                    return Download.save(AddEpub, fileName, overwriteExisting, backgroundDownload);
-                }else{
-                    return new Promise((resolve) => {resolve();});
-                }
+        }
+        if (LibidURL == -1) {
+            Library.LibHandelUpdate(-1, AddEpub, document.getElementById("startingUrlInput").value, fileName.replace(".epub", ""), LibidURL);
+            if (document.getElementById("LibDownloadEpubAfterUpdateCheckbox").checked) {
+                return Download.save(AddEpub, fileName, overwriteExisting, backgroundDownload);
+            }else{
+                return new Promise((resolve) => {resolve();});
             }
-            
-            fileName = EpubPacker.addExtensionIfMissing(items["LibFilename" + LibidURL]);
+        }
+
+        let PreviousEpubBase64 = await Library.LibGetFromStorage("LibEpub" + LibidURL);
+        let MergedEpub = await Library.LibMergeEpub(PreviousEpubBase64, AddEpub, LibidURL);
+        if (document.getElementById("LibDownloadEpubAfterUpdateCheckbox").checked) {
+            fileName = EpubPacker.addExtensionIfMissing(await Library.LibGetFromStorage("LibFilename" + LibidURL));
             if (Download.isFileNameIllegalOnWindows(fileName)) {
                 ErrorLog.showErrorMessage(chrome.i18n.getMessage("errorIllegalFileName",
                     [fileName, Download.illegalWindowsFileNameChars]
                 ));
                 return;
             }
-
-            let PreviousEpubBase64 = items["LibEpub" + LibidURL];
-            let MergedEpub = await Library.LibMergeEpub(PreviousEpubBase64, AddEpub, LibidURL);
-            if (document.getElementById("LibDownloadEpubAfterUpdateCheckbox").checked) {
-                return Download.save(MergedEpub, fileName, overwriteExisting, backgroundDownload);
-            }else{
-                return new Promise((resolve) => {resolve();});
-            }
-        });
+            return Download.save(MergedEpub, fileName, overwriteExisting, backgroundDownload);
+        }else{
+            return new Promise((resolve) => {resolve();});
+        }
     }
 
     static LibHighestFileNumber(Content, Regex, String){
@@ -238,6 +236,7 @@ class Library {
     }
 
     static Libdeleteall(){
+        Library.LibShowLoadingText();
         chrome.storage.local.get(null, async function(items) {
             let CurrentLibKeys = await Library.LibGetAllLibStorageKeys("LibEpub", Object.keys(items));
             let storyurls = [];
@@ -863,6 +862,7 @@ class Library {
     }
     
     static Libexportall(){
+        Library.LibShowLoadingText();
         chrome.storage.local.get(null, async function(items) {
             let CurrentLibKeys = await Library.LibGetAllLibStorageKeys("LibEpub", Object.keys(items));
             let storyurls = [];
@@ -892,7 +892,8 @@ class Library {
                 zipWriter.add("Library/"+i+"/LibStoryURL", new zip.TextReader(items["LibStoryURL" + CurrentLibKeys[i]]));
             }
             zipWriter.add("ReadingList.json", new zip.TextReader(JSON.stringify(fileReadingList)));
-            return Download.save(await zipWriter.close(), "Libraryexport.zip").catch (err => ErrorLog.showErrorMessage(err));            
+            Download.save(await zipWriter.close(), "Libraryexport.zip").catch (err => ErrorLog.showErrorMessage(err));
+            Library.LibRenderSavedEpubs();
         });
     }
 
@@ -1018,6 +1019,14 @@ class Library {
                 }
                 resolve(AllLibStorageKeys);
             }
+        });
+    }
+
+    static async LibGetFromStorageArray(Keys){
+        return new Promise((resolve) => {
+            chrome.storage.local.get(Keys, function(items){
+                resolve(items);
+            });
         });
     }
 

--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -673,7 +673,7 @@ class Library {
 
     static async LibHandelUpdate(objbtn, Blobdata, StoryURL, Filename, Id, NewChapterCount){
         Library.LibShowLoadingText();
-        await Library.LibFileReaderAddListeners(LibFileReader);
+        Library.LibFileReaderAddListeners();
         if (objbtn != -1) {
             Blobdata = objbtn.files[0];
             Filename = Blobdata.name.replace(".epub", "");
@@ -764,11 +764,11 @@ class Library {
         return retblob;
     };
 
-    static LibFileReaderAddListeners(LibFileReader){
-        LibFileReader.removeEventListener("load", function(){Library.LibFileReaderloadImport()});
+    static LibFileReaderAddListeners(){
+        LibFileReader.removeEventListener("load", Library.LibFileReaderloadImport);
         LibFileReader.removeEventListener("error", function(event){Library.LibFileReadererror(event)});
         LibFileReader.removeEventListener("abort", function(event){Library.LibFileReaderabort(event)});
-        LibFileReader.addEventListener("load", function(){Library.LibFileReaderload()});
+        LibFileReader.addEventListener("load", Library.LibFileReaderload);
         LibFileReader.addEventListener("error", function(event){Library.LibFileReadererror(event)});
         LibFileReader.addEventListener("abort", function(event){Library.LibFileReaderabort(event)});
     }
@@ -899,7 +899,7 @@ class Library {
 
     static async LibHandelImport(objbtn){
         Library.LibShowLoadingText();
-        await Library.LibFileReaderAddListenersImport(LibFileReader);
+        Library.LibFileReaderAddListenersImport();
         let Blobdata = objbtn.files[0];
         LibFileReader.name = objbtn.files[0].name;
         let regex = new RegExp("zip$");
@@ -910,11 +910,11 @@ class Library {
         }
     }
 
-    static LibFileReaderAddListenersImport(LibFileReader){
-        LibFileReader.removeEventListener("load", function(){Library.LibFileReaderload()});
+    static LibFileReaderAddListenersImport(){
+        LibFileReader.removeEventListener("load", Library.LibFileReaderload);
         LibFileReader.removeEventListener("error", function(event){Library.LibFileReadererror(event)});
         LibFileReader.removeEventListener("abort", function(event){Library.LibFileReaderabort(event)});
-        LibFileReader.addEventListener("load", function(){Library.LibFileReaderloadImport()});
+        LibFileReader.addEventListener("load", Library.LibFileReaderloadImport);
         LibFileReader.addEventListener("error", function(event){Library.LibFileReadererror(event)});
         LibFileReader.addEventListener("abort", function(event){Library.LibFileReaderabort(event)});
     }


### PR DESCRIPTION
This fixes an error with update all
If the 1st epub is still merging when the 2nd epub tries to merge there are multiple errors:
![image](https://github.com/user-attachments/assets/01f9bdb9-8dc7-4f82-a0bc-a4279cd64f92)
This pull request should fix this problem.
Additionally there is a problem with the EventListeners in the Library (If an exported library gets imported the eventlisteners don't get removed)
![image](https://github.com/user-attachments/assets/0dba6944-e63f-4524-b200-0f89b9416060)
This pull request should fix this problem.
