### PR TITLE
Add declarativeNetRequest header handling

### DIFF
--- a/plugin/js/parsers/EstarParser.js
+++ b/plugin/js/parsers/EstarParser.js
@@ -1,0 +1,92 @@
+"use strict";
+
+parserFactory.register("estar.jp", () => new EstarParser());
+
+class EstarParser extends Parser{
+    constructor() {
+        super();
+    }
+
+    async getChapterUrls(dom) {
+        let rule = 
+        [{
+            "id": 1,
+            "priority": 1,
+            "action": {
+                "type": "modifyHeaders",
+                "requestHeaders": [{ "header": "origin", "operation": "remove" }]
+            },
+            "condition": { "urlFilter" : "estar.jp"}
+        }]
+        await HttpClient.setDeclarativeNetRequestRules(rule);
+
+        let leaves = dom.baseURI.split("/");
+        let id = leaves[leaves.length - 1];
+        let fetchUrl = "https://estar.jp/api/graphql";
+        let formData = {"query":"pages/novels/workId/episodes","data":{"workId":id,"first":30,"page":1}};
+        let header = {"Content-Type": "application/json;charset=UTF-8", "x-from": "https://estar.jp/"}
+        let options = {
+            method: "POST",
+            credentials: "include",
+            body: JSON.stringify(formData),
+            headers: header
+        };
+        let bookinfo = (await HttpClient.fetchJson(fetchUrl, options)).json;
+        formData = {"query":"pages/novels/workId/episodes","data":{"workId":id,"first":bookinfo.data.novel.episodeCount,"page":1}};
+        bookinfo = (await HttpClient.fetchJson(fetchUrl, options)).json;
+        let chapters = bookinfo.data.novel.episodes.nodes.map(a => ({
+            sourceUrl: "https://estar.jp/novels/"+bookinfo.data.novel.workId+"/viewer?page="+a.pageNo, 
+            title: a.title
+        }));
+        return chapters;
+    }
+
+    findContent(dom) {
+        return Parser.findConstrutedContent(dom);
+    }
+
+    extractTitleImpl(dom) {
+        return dom.querySelector("div.info .title").textContent;
+    }
+
+    extractAuthor(dom) {
+        return dom.querySelector("div.info .nickname").textContent;
+    }
+
+    extractSubject(dom) {
+        let tags = [...dom.querySelectorAll(".tags a")];
+        return tags.map(a => a.textContent).join(", ");
+    }
+
+    extractDescription(dom) {
+        return dom.querySelector(".description").textContent.trim();
+    }
+
+    findCoverImageUrl(dom) {
+        let pic = dom.querySelector(".novelData picture meta");
+        return pic.content;
+    }
+
+    async fetchChapter(url) {
+        let dom = (await HttpClient.wrapFetch(url)).responseXML;
+        return this.buildChapter(dom, url);
+    }
+
+    buildChapter(dom, url) {
+        let newDoc = Parser.makeEmptyDocForContent(url);
+        let title = newDoc.dom.createElement("h1");
+        title.textContent = dom.querySelector("h1.subject").textContent;
+        newDoc.content.appendChild(title);
+        let text = dom.querySelector(".mainBody .content").textContent;
+        text = text.replace("\n\n", "\n");
+        text = text.split("\n");
+        let br = document.createElement("br");
+        for (let element of text) {
+            let pnode = newDoc.dom.createElement("p");
+            pnode.textContent = element;
+            newDoc.content.appendChild(pnode);
+            newDoc.content.appendChild(br);
+        }
+        return newDoc.dom;
+    }
+}

--- a/plugin/js/parsers/EstarParser.js
+++ b/plugin/js/parsers/EstarParser.js
@@ -33,6 +33,12 @@ class EstarParser extends Parser{
         };
         let bookinfo = (await HttpClient.fetchJson(fetchUrl, options)).json;
         formData = {"query":"pages/novels/workId/episodes","data":{"workId":id,"first":bookinfo.data.novel.episodeCount,"page":1}};
+        options = {
+            method: "POST",
+            credentials: "include",
+            body: JSON.stringify(formData),
+            headers: header
+        };
         bookinfo = (await HttpClient.fetchJson(fetchUrl, options)).json;
         let chapters = bookinfo.data.novel.episodes.nodes.map(a => ({
             sourceUrl: "https://estar.jp/novels/"+bookinfo.data.novel.workId+"/viewer?page="+a.pageNo, 

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -11,6 +11,7 @@
     "downloads",
     "webRequest",
     "webRequestBlocking",
+    "declarativeNetRequest",
     "scripting",
     "storage",
     "unlimitedStorage"

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -632,6 +632,7 @@
         <script src="js/parsers/EightMusesParser.js"></script>
         <script src="js/parsers/EngnovelParser.js"></script>
         <script src="js/parsers/ErofusParser.js"></script>
+        <script src="js/parsers/EstarParser.js"></script>
         <script src="js/parsers/ExiledrebelsscanlationsParser.js"></script>
         <script src="js/parsers/FanFicParadiseParser.js"></script>
         <script src="js/parsers/FanFictionParser.js"></script>


### PR DESCRIPTION
reference: #1770
@dteviot please confirm merge it could be that this triggers a manual review as a new permission is needed for the change
`declarativeNetRequest`

What is the problem?
Some sites check the headers they receive and only send content if the headers are correct.
estar.jp for example checks if the "origin" header is correct if it exists.
With this change i created a rule that removes the "origin" header from all requests.

This could also be used for other sites such as wtr-lab.com #1847 as they changed to a "POST" api which checks these headers.
I created it in HttpClient.js to try and abstract the security concerns.
declarativeNetRequest rules are pretty powerful and can compromise the security on other sites if they aren't bound to WebToEpub only. 