### PR TITLE
update speed logic

### DIFF
--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -324,8 +324,8 @@
 		"description": "Show more Metadata options to user"
 	},
 	"__MSG_label_Manual_Delay_Per_Chapter__": {
-		"message": "Manual Throttle|Delay per chapter",
-		"description": "Manual Throttle|Delay per chapter"
+		"message": "Delay per chapter in ms",
+		"description": "Delay per chapter in ms"
 	},
 	"__MSG_label_Manually_Select_Parser__": {
 		"message": "Manually Select Parser:",

--- a/plugin/css/default.css
+++ b/plugin/css/default.css
@@ -103,7 +103,7 @@ button:disabled {
 }
 
 
-input[type=text], input[type=url], textarea, select {
+input[type=text], input[type=url], textarea, select, #manualDelayPerChapterTag {
     padding: 4px;
     border: 1px #CCC solid;
     border-radius: 3px;
@@ -111,7 +111,7 @@ input[type=text], input[type=url], textarea, select {
     min-width: 356px;
 }
 
-#advancedOptionsSection textarea, #advancedOptionsSection select {
+#advancedOptionsSection textarea, #advancedOptionsSection select, #manualDelayPerChapterTag {
     min-width: inherit !important;
 }
 

--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -53,7 +53,8 @@ class ParserState {
 
 class Parser {    
     constructor(imageCollector) {
-        this.minimumThrottle = null;
+        this.minimumThrottle = 500;
+        this.maxSimultanousFetchSize = 1;
         this.state = new ParserState();
         this.imageCollector = imageCollector || new ImageCollector();
         this.userPreferences = null;
@@ -501,9 +502,7 @@ class Parser {
     }
 
     groupPagesToFetch(webPages, index) {
-        let blockSize = parseInt(this.userPreferences.maxPagesToFetchSimultaneously.value);
-        blockSize = this.clampSimultanousFetchSize(blockSize);
-        return webPages.slice(index, index + blockSize);
+        return webPages.slice(index, index + this.maxSimultanousFetchSize);
     }
 
     async fetchWebPageContent(webPage) {
@@ -631,16 +630,6 @@ class Parser {
         return null;
     }
 
-    /**
-     * limit number of pages to fetch at once 
-     * ignoing user preference.
-     * Some sites can't handle high load.  e.g. Comrademao
-     * @param {any} fetchSize
-     */
-    clampSimultanousFetchSize(fetchSize) {
-        return fetchSize;
-    }
-
     tagAuthorNotes(elements) {
         for(let e of elements) {
             e.classList.add("webToEpub-author-note");
@@ -682,12 +671,7 @@ class Parser {
 
     getRateLimit()
     {
-        if (this.userPreferences.manualDelayPerChapter.value == "simulate_reading")
-        {
-            return this.userPreferences.manualDelayPerChapter.value;
-        }
-        let manualDelayPerChapterValue = parseInt(this.userPreferences.manualDelayPerChapter.value);
-
+        let manualDelayPerChapterValue = parseInt(this.userPreferences.manualDelayPerChapter.value)?parseInt(this.userPreferences.manualDelayPerChapter.value):this.minimumThrottle;
         if (!this.userPreferences.overrideMinimumDelay.value)
         {
             return Math.max(this.minimumThrottle, manualDelayPerChapterValue);
@@ -697,7 +681,6 @@ class Parser {
 
     async rateLimitDelay() {
         let manualDelayPerChapterValue = this.getRateLimit();
-        manualDelayPerChapterValue = (manualDelayPerChapterValue == "simulate_reading" )? util.randomInteger(420000,900000): manualDelayPerChapterValue;
         await util.sleep(manualDelayPerChapterValue);
     }
 

--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -671,7 +671,7 @@ class Parser {
 
     getRateLimit()
     {
-        let manualDelayPerChapterValue = parseInt(this.userPreferences.manualDelayPerChapter.value)?parseInt(this.userPreferences.manualDelayPerChapter.value):this.minimumThrottle;
+        let manualDelayPerChapterValue = (!isNaN(parseInt(this.userPreferences.manualDelayPerChapter.value)))?parseInt(this.userPreferences.manualDelayPerChapter.value):this.minimumThrottle;
         if (!this.userPreferences.overrideMinimumDelay.value)
         {
             return Math.max(this.minimumThrottle, manualDelayPerChapterValue);

--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -98,10 +98,9 @@ class UserPreferences {
         this.addPreference("removeOriginal", "removeOriginalCheckbox", true);
         this.addPreference("selectTranslationGoogle", "selectTranslationGoogleCheckbox", true);
         this.addPreference("removeTranslated", "removeTranslatedCheckbox", false);
-        this.addPreference("maxPagesToFetchSimultaneously", "maxPagesToFetchSimultaneouslyTag", "1");
         this.addPreference("skipChaptersThatFailFetch", "skipChaptersThatFailFetchCheckbox", false);
         this.addPreference("maxChaptersPerEpub", "maxChaptersPerEpubTag", "10,000");
-        this.addPreference("manualDelayPerChapter", "manualDelayPerChapterTag", "0");
+        this.addPreference("manualDelayPerChapter", "manualDelayPerChapterTag", "500");
         this.addPreference("overrideMinimumDelay", "overrideMinimumDelayCheckbox", false);
         this.addPreference("skipImages", "skipImagesCheckbox", false);
         this.addPreference("overwriteExistingEpub", "overwriteEpubWhenDuplicateFilenameCheckbox", false);

--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -100,7 +100,7 @@ class UserPreferences {
         this.addPreference("removeTranslated", "removeTranslatedCheckbox", false);
         this.addPreference("skipChaptersThatFailFetch", "skipChaptersThatFailFetchCheckbox", false);
         this.addPreference("maxChaptersPerEpub", "maxChaptersPerEpubTag", "10,000");
-        this.addPreference("manualDelayPerChapter", "manualDelayPerChapterTag", "500");
+        this.addPreference("manualDelayPerChapter", "manualDelayPerChapterTag", "0");
         this.addPreference("overrideMinimumDelay", "overrideMinimumDelayCheckbox", false);
         this.addPreference("skipImages", "skipImagesCheckbox", false);
         this.addPreference("overwriteExistingEpub", "overwriteEpubWhenDuplicateFilenameCheckbox", false);

--- a/plugin/js/parsers/AlphapolisParser.js
+++ b/plugin/js/parsers/AlphapolisParser.js
@@ -4,9 +4,7 @@ class AlphapolisParser extends Parser{
     constructor() {
         super();
         this.minimumThrottle = 15000;
-    }
-    clampSimultanousFetchSize() {
-        return 1;
+        this.maxSimultanousFetchSize = 1;
     }
     async getChapterUrls(dom) {
         let menu = dom.querySelector("div.episodes");

--- a/plugin/js/parsers/AlphapolisParser.js
+++ b/plugin/js/parsers/AlphapolisParser.js
@@ -4,7 +4,6 @@ class AlphapolisParser extends Parser{
     constructor() {
         super();
         this.minimumThrottle = 15000;
-        this.maxSimultanousFetchSize = 1;
     }
     async getChapterUrls(dom) {
         let menu = dom.querySelector("div.episodes");

--- a/plugin/js/parsers/BabelChainParser.js
+++ b/plugin/js/parsers/BabelChainParser.js
@@ -8,6 +8,7 @@ parserFactory.register("babelnovel.com", () => new BabelChainParser());
 class BabelChainParser extends Parser{
     constructor() {
         super();
+        this.maxSimultanousFetchSize = 1;
     }
     
     async getChapterUrls(dom) {
@@ -59,11 +60,6 @@ class BabelChainParser extends Parser{
     getInformationEpubItemChildNodes(dom) {
         let synopsis = this.findDiv(dom, "book-info_synopsis-wrapper");
         return synopsis === null ? [] : [synopsis];
-    }
-
-    // rate limit site
-    clampSimultanousFetchSize() {
-        return 1;
     }
 
     async fetchChapter(url) {

--- a/plugin/js/parsers/BabelChainParser.js
+++ b/plugin/js/parsers/BabelChainParser.js
@@ -8,7 +8,6 @@ parserFactory.register("babelnovel.com", () => new BabelChainParser());
 class BabelChainParser extends Parser{
     constructor() {
         super();
-        this.maxSimultanousFetchSize = 1;
     }
     
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/ComrademaoParser.js
+++ b/plugin/js/parsers/ComrademaoParser.js
@@ -6,7 +6,6 @@ parserFactory.register("comrademao.com", function() { return new ComrademaoParse
 class ComrademaoParser extends Parser{
     constructor() {
         super();
-        this.maxSimultanousFetchSize = 1;
     }
 
     disabled() {

--- a/plugin/js/parsers/ComrademaoParser.js
+++ b/plugin/js/parsers/ComrademaoParser.js
@@ -6,15 +6,11 @@ parserFactory.register("comrademao.com", function() { return new ComrademaoParse
 class ComrademaoParser extends Parser{
     constructor() {
         super();
+        this.maxSimultanousFetchSize = 1;
     }
 
     disabled() {
         return chrome.i18n.getMessage("warningParserDisabledComradeMao");
-    }
-
-    // This site can't handle more than 1 page at a time
-    clampSimultanousFetchSize() {
-        return 1;
     }
 
     populateUI(dom) {

--- a/plugin/js/parsers/FanFicParadiseParser.js
+++ b/plugin/js/parsers/FanFicParadiseParser.js
@@ -7,7 +7,6 @@ class FanFicParadiseParser extends Parser{
         super();
         this.cache = new FetchCache();
         this.minimumThrottle = 50; //182 at 20
-        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/FanFicParadiseParser.js
+++ b/plugin/js/parsers/FanFicParadiseParser.js
@@ -7,10 +7,7 @@ class FanFicParadiseParser extends Parser{
         super();
         this.cache = new FetchCache();
         this.minimumThrottle = 50; //182 at 20
-    }
-
-    clampSimultanousFetchSize() {
-        return 1;
+        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/GenesiStudioParser.js
+++ b/plugin/js/parsers/GenesiStudioParser.js
@@ -9,7 +9,6 @@ class GenesiStudioParser extends Parser{
     constructor() {
         super();
         this.minimumThrottle = 2000;
-        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/GenesiStudioParser.js
+++ b/plugin/js/parsers/GenesiStudioParser.js
@@ -9,10 +9,7 @@ class GenesiStudioParser extends Parser{
     constructor() {
         super();
         this.minimumThrottle = 2000;
-    }
-    
-    clampSimultanousFetchSize() {
-        return 1;
+        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/LightNovelBastionParser.js
+++ b/plugin/js/parsers/LightNovelBastionParser.js
@@ -5,7 +5,6 @@ parserFactory.register("lightnovelbastion.com", function() { return new LightNov
 class LightNovelBastionParser extends Parser {
     constructor() {
         super();
-        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/LightNovelBastionParser.js
+++ b/plugin/js/parsers/LightNovelBastionParser.js
@@ -5,6 +5,7 @@ parserFactory.register("lightnovelbastion.com", function() { return new LightNov
 class LightNovelBastionParser extends Parser {
     constructor() {
         super();
+        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom) {
@@ -37,10 +38,6 @@ class LightNovelBastionParser extends Parser {
     removeUnwantedElementsFromContentElement(element) {
         util.removeChildElementsMatchingCss(element, "div.lnbad-tag");
         super.removeUnwantedElementsFromContentElement(element);
-    }
-
-    clampSimultanousFetchSize() {
-        return 1;
     }
 
     findCoverImageUrl(dom) {

--- a/plugin/js/parsers/LightNovelWorldParser.js
+++ b/plugin/js/parsers/LightNovelWorldParser.js
@@ -16,10 +16,7 @@ parserFactory.register("pandanovel.co", () => new LightNovelWorldParser());
 class LightNovelWorldParser extends Parser{
     constructor() {
         super();
-    }
-
-    clampSimultanousFetchSize() {
-        return 1;
+        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom, chapterUrlsUI) {

--- a/plugin/js/parsers/LightNovelWorldParser.js
+++ b/plugin/js/parsers/LightNovelWorldParser.js
@@ -16,7 +16,6 @@ parserFactory.register("pandanovel.co", () => new LightNovelWorldParser());
 class LightNovelWorldParser extends Parser{
     constructor() {
         super();
-        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom, chapterUrlsUI) {

--- a/plugin/js/parsers/NobadnovelParser.js
+++ b/plugin/js/parsers/NobadnovelParser.js
@@ -9,7 +9,6 @@ class NobadnovelParser extends Parser{
     constructor() {
         super();
         this.minimumThrottle = 500;
-        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/NobadnovelParser.js
+++ b/plugin/js/parsers/NobadnovelParser.js
@@ -9,10 +9,7 @@ class NobadnovelParser extends Parser{
     constructor() {
         super();
         this.minimumThrottle = 500;
-    }
-    //it feels like one user with simutanfetch set to 8 can overhelm the server
-    clampSimultanousFetchSize() {
-        return 1;
+        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/NoblemtlParser.js
+++ b/plugin/js/parsers/NoblemtlParser.js
@@ -178,7 +178,6 @@ class MyNovelOnlineParser extends NoblemtlParser{
     constructor() {
         super();
         this.minimumThrottle = 3000;
-        this.maxSimultanousFetchSize = 1;
     }
 
     findChapterTitle(dom) {

--- a/plugin/js/parsers/NoblemtlParser.js
+++ b/plugin/js/parsers/NoblemtlParser.js
@@ -178,10 +178,7 @@ class MyNovelOnlineParser extends NoblemtlParser{
     constructor() {
         super();
         this.minimumThrottle = 3000;
-    }
-
-    clampSimultanousFetchSize() {
-        return 1;
+        this.maxSimultanousFetchSize = 1;
     }
 
     findChapterTitle(dom) {

--- a/plugin/js/parsers/RanobesParser.js
+++ b/plugin/js/parsers/RanobesParser.js
@@ -8,7 +8,6 @@ class RanobesParser extends Parser{
     constructor() {
         super();
         this.minimumThrottle = 2000;
-        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom, chapterUrlsUI) {

--- a/plugin/js/parsers/RanobesParser.js
+++ b/plugin/js/parsers/RanobesParser.js
@@ -8,10 +8,7 @@ class RanobesParser extends Parser{
     constructor() {
         super();
         this.minimumThrottle = 2000;
-    }
-    
-    clampSimultanousFetchSize() {
-        return 1;
+        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom, chapterUrlsUI) {

--- a/plugin/js/parsers/RoyalRoadParser.js
+++ b/plugin/js/parsers/RoyalRoadParser.js
@@ -9,10 +9,7 @@ parserFactory.register("royalroad.com", function() { return new RoyalRoadParser(
 class RoyalRoadParser extends Parser{
     constructor() {
         super();
-    }
-
-    clampSimultanousFetchSize() {
-        return 1;
+        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/RoyalRoadParser.js
+++ b/plugin/js/parsers/RoyalRoadParser.js
@@ -9,7 +9,6 @@ parserFactory.register("royalroad.com", function() { return new RoyalRoadParser(
 class RoyalRoadParser extends Parser{
     constructor() {
         super();
-        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/SpacebattlesParser.js
+++ b/plugin/js/parsers/SpacebattlesParser.js
@@ -13,7 +13,6 @@ class SpacebattlesParser extends Parser{
         super();
         this.cache = new FetchCache();
         this.minimumThrottle = 50; //182 at 20
-        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/SpacebattlesParser.js
+++ b/plugin/js/parsers/SpacebattlesParser.js
@@ -13,10 +13,7 @@ class SpacebattlesParser extends Parser{
         super();
         this.cache = new FetchCache();
         this.minimumThrottle = 50; //182 at 20
-    }
-
-    clampSimultanousFetchSize() {
-        return 1;
+        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/Template.js
+++ b/plugin/js/parsers/Template.js
@@ -34,7 +34,6 @@ class TemplateParser extends Parser{
         // Minimum delay (in ms) between page requests. Useful for 403 error prevention.
         // If the sites this parser accesses throttles requests or uses cloudflare, it is recommended to set this.
         this.minimumThrottle = 3000;
-        this.maxSimultanousFetchSize = 1;
         */
     }
 

--- a/plugin/js/parsers/Template.js
+++ b/plugin/js/parsers/Template.js
@@ -34,15 +34,9 @@ class TemplateParser extends Parser{
         // Minimum delay (in ms) between page requests. Useful for 403 error prevention.
         // If the sites this parser accesses throttles requests or uses cloudflare, it is recommended to set this.
         this.minimumThrottle = 3000;
+        this.maxSimultanousFetchSize = 1;
         */
     }
-
-    //overwrite Max web pages to fetch simultaneously mostly used on sites that block multiple requests
-    /*
-    clampSimultanousFetchSize() {
-        return 1;
-    }
-    */
 
     // returns promise with the URLs of the chapters to fetch
     // promise is used because may need to fetch the list of URLs from internet

--- a/plugin/js/parsers/WattpadParser.js
+++ b/plugin/js/parsers/WattpadParser.js
@@ -25,10 +25,7 @@ class WattpadImageCollector extends ImageCollector {
 class WattpadParser extends Parser{
     constructor() {
         super(new WattpadImageCollector());
-    }
-
-    clampSimultanousFetchSize() {
-        return 1;
+        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/WattpadParser.js
+++ b/plugin/js/parsers/WattpadParser.js
@@ -25,7 +25,6 @@ class WattpadImageCollector extends ImageCollector {
 class WattpadParser extends Parser{
     constructor() {
         super(new WattpadImageCollector());
-        this.maxSimultanousFetchSize = 1;
     }
 
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/WtrlabParser.js
+++ b/plugin/js/parsers/WtrlabParser.js
@@ -5,10 +5,7 @@ parserFactory.register("wtr-lab.com", () => new WtrlabParser());
 class WtrlabParser extends Parser{
     constructor() {
         super();
-    }
-
-    clampSimultanousFetchSize() {
-        return 1;
+        this.maxSimultanousFetchSize = 1;
     }
 
     populateUI(dom) {

--- a/plugin/js/parsers/WtrlabParser.js
+++ b/plugin/js/parsers/WtrlabParser.js
@@ -5,7 +5,6 @@ parserFactory.register("wtr-lab.com", () => new WtrlabParser());
 class WtrlabParser extends Parser{
     constructor() {
         super();
-        this.maxSimultanousFetchSize = 1;
     }
 
     populateUI(dom) {

--- a/plugin/js/parsers/XenforoBatchParser.js
+++ b/plugin/js/parsers/XenforoBatchParser.js
@@ -9,7 +9,6 @@ class XenforoBatchParser extends Parser{
         super();
         this.cache = new FetchCache();
         this.subParser = null;
-        this.maxSimultanousFetchSize = 1;
     }
 
     getSubParser(dom)

--- a/plugin/js/parsers/XenforoBatchParser.js
+++ b/plugin/js/parsers/XenforoBatchParser.js
@@ -9,6 +9,7 @@ class XenforoBatchParser extends Parser{
         super();
         this.cache = new FetchCache();
         this.subParser = null;
+        this.maxSimultanousFetchSize = 1;
     }
 
     getSubParser(dom)
@@ -74,10 +75,6 @@ class XenforoBatchParser extends Parser{
             newDoc.content.appendChild(chapterBody);
         });
         return newDoc.dom;
-    }
-
-    clampSimultanousFetchSize() {
-        return this.subParser.clampSimultanousFetchSize();
     }
 
     isLinkToChapter(link) {

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -393,17 +393,6 @@
                         <td>__MSG_label_Auto_Parser_Select_Includes_Baka_Tsuki_Series_Page_Parser__</td>
                         <td><button id="seriesPageHelpButton">__MSG_button_Help__</button></td>
                     </tr>
-                    <tr id="maxPagesToFetchSimultaneously">
-                        <td>
-                            <select id="maxPagesToFetchSimultaneouslyTag">
-                                <option value="1" selected>1</option>
-                                <option value="2">2</option>
-                                <option value="4">4</option>
-                                <option value="8">8</option>
-                            </select>
-                        </td>
-                        <td>__MSG_label_Max_pages_to_fetch_simultaneously__</td>
-                    </tr>
                     <tr id="skipChaptersThatFailFetch">
                         <td><input id="skipChaptersThatFailFetchCheckbox" type="checkbox" name="skipChaptersThatFailFetchCheckbox" value="false"></td>
                         <td>__MSG_label_Skip_Chapters_That_Fail_Fetch__</td>
@@ -422,29 +411,12 @@
                         </td>
                         <td>__MSG_label_Max_chapters_per_epub__</td>
                     </tr>
-                </table>
-                <table id="ThrottleTable">
                     <tr id="manualDelayPerChapter">
                         <td>
-                            <select id="manualDelayPerChapterTag">
-                                <option value="0" selected>Default (No Chapter Throttle/Delay)</option>
-                                <option value="3000">3 Secs/Chapter</option>
-                                <option value="5000">5 Secs/Chapter </option>
-                                <option value="10000">10 Secs/Chapter</option>
-                                <option value="20000">20 Secs/Chapter </option>
-                                <option value="30000">30 Secs/Chapter</option>
-                                <option value="60000">1 Min/Chapter</option>
-                                <option value="300000">5 Mins/Chapter</option>
-                                <option value="600000">10 Mins/Chapter</option>
-                                <option value="1800000">30 Mins/Chapter</option>
-                                <option value="3600000">60 Mins/Chapter</option>
-                                <option value="simulate_reading">Simulate Reading (7-15 Mins/Chapter)</option>
-                            </select>
+                            <input id="manualDelayPerChapterTag" type="number" name="manualDelayPerChapterTag" style="width: 61px;">
                         </td>
                         <td>__MSG_label_Manual_Delay_Per_Chapter__</td>
                     </tr>
-                </table>
-                <table id="advancedOptionsTable">
                     <tr id="overrideParserDelayWithManualDelay">
                         <td><input id="overrideMinimumDelayCheckbox" type="checkbox" name="overrideMinimumDelayCheckbox" value="false"></td>
                         <td>__MSG_label_Override_Default_Minimum_Delay__</td>


### PR DESCRIPTION
reference: #1468
this change sets the clampSimultanousFetchSize() for all to 1 and removes the option to increase it from the user.
It sets minimumThrottle=500 in the Parser constructor for all parsers.
The ms delay is now a input field instead of a selection.

I am not sure if removing the option for simultanous fetch is the right move. Thoughts @dteviot @Kiradien?
