### PR TITLE
Add custom retry error

### DIFF
--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -73,6 +73,24 @@ class Parser {
     getPagesToFetch() {
         return this.state.webPages;
     }
+    
+    //Use this option if the parser isn't sending the correct HTTP header
+    isCustomError(response){
+        return false;
+    }
+
+    setCustomErrorResponse(url, wrapOptions, checkedresponse){
+        //example
+        let ret = {};
+        ret.url = url;
+        ret.wrapOptions = wrapOptions;
+        ret.response = {};
+        //URL that's get opened on 'Open URL for Captcha' click
+        ret.response.url = checkedresponse.response.url;
+        ret.response.status = 403;
+        //return empty to throw error
+        return {};
+    }
 
     onUserPreferencesUpdate(userPreferences) {
         this.userPreferences = userPreferences;

--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -75,7 +75,7 @@ class Parser {
     }
     
     //Use this option if the parser isn't sending the correct HTTP header
-    isCustomError(response){
+    isCustomError(response){  // eslint-disable-line no-unused-vars
         return false;
     }
 

--- a/plugin/js/parsers/WtrlabParser.js
+++ b/plugin/js/parsers/WtrlabParser.js
@@ -80,7 +80,7 @@ class WtrlabParser extends Parser{
     }
     
     isCustomError(response){
-        if (response.json.data?.data?.task?true:false) {
+        if (response.json.data?.data?.body?false:true) {
             return true;
         }
         return false;


### PR DESCRIPTION
reference: #1874
This adds two functions to the Parsers:
isCustomError()
take a look at the content and decide if it is really HTTP 200 (true=error; false=success)
setCustomErrorResponse() 
this function manipulates the response so that it is handled like an HTTP error
To make use of this the parser needs to be added to the "fetchOptions" or "wrapOptions".

I changed two parser that make use of this:
SangtacvietParser
It returns HTTP 200 but the json body doesn't contain the content.
WtrlabParser
If it is the first time someone requests a page the server returns HTTP 200 with missing content while the server is translating the content with the custom HTTP 999 error it is possible to set parser specific retry delay times.