### PR TITLE
fix Library LibConvertDataUrlToBlob() for large epubs

### DIFF
--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -763,9 +763,13 @@ class Library {
             let BlobEpubZip = new zip.ZipWriter(BlobEpubWriter,{useWebWorkers: false,compressionMethod: 8});
             //Copy Base64Epub in BlobEpub
             for (let element of Base64EpubContent){
+                if (element.filename == "mimetype") {
+                    BlobEpubZip.add(element.filename, new zip.TextReader(await element.getData(new zip.TextWriter())), {compressionMethod: 0});
+                    continue;
+                }
                 BlobEpubZip.add(element.filename, new zip.BlobReader(await element.getData(new zip.BlobWriter())));
             }
-            retblob = await Base64EpubZip.close();
+            retblob = await BlobEpubZip.close();
         }
         return retblob;
     };


### PR DESCRIPTION
Should a epub be to big LibConvertDataUrlToBlob() falls back to another method and this sets the mime type wrong.
Example: add https://www.royalroad.com/fiction/64223/dungeon-diver-stealing-a-monsters-power to the library with all the pictures. -> unable to download the epub from the Library.