### PR TITLE
update ScribblehubParser speedup walkTocPages

### DIFF
--- a/plugin/js/parsers/ScribblehubParser.js
+++ b/plugin/js/parsers/ScribblehubParser.js
@@ -19,12 +19,15 @@ class ScribblehubParser extends Parser {
                 ? `${baseUrl}?toc=${++nextTocIndex}`
                 : null;
         };
-
-        return (await this.walkTocPages(dom,
+        let saveThrottle = this.minimumThrottle;
+        this.minimumThrottle = 0;
+        let chapters = (await this.walkTocPages(dom,
             ScribblehubParser.getChapterUrlsFromTocPage,
             nextTocPageUrl,
             chapterUrlsUI
         )).reverse();
+        this.minimumThrottle = saveThrottle;
+        return chapters;
     };
 
     static getChapterUrlsFromTocPage(dom) {


### PR DESCRIPTION
scribblehub.com doesn't rate limit walkTocPages() only the download of the chapters.