### PR TITLE
Fewer empty things in epub

### DIFF
--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -115,6 +115,8 @@ class Parser {
         util.makeHyperlinksRelative(webPage.rawDom.baseURI, content);
         util.setStyleToDefault(content);
         util.prepForConvertToXhtml(content);
+        util.removeEmptyAttributes(content);
+        util.removeSpansWithNoAttributes(content);
         util.removeEmptyDivElements(content);
         util.removeTrailingWhiteSpace(content);
         if (util.isElementWhiteSpace(content)) {
@@ -218,7 +220,7 @@ class Parser {
         return items;
     }
 
-    makePlacehoderEpubItem(webPage, epubItemIndex) {
+    makePlaceholderEpubItem(webPage, epubItemIndex) {
         let temp = Parser.makeEmptyDocForContent(webPage.sourceUrl);
         temp.content.textContent = chrome.i18n.getMessage("chapterPlaceholderMessage", 
             [webPage.sourceUrl, webPage.error]
@@ -338,8 +340,7 @@ class Parser {
     epubItemSupplier() {
         let epubItems = this.webPagesToEpubItems([...this.state.webPages.values()]);
         this.fixupHyperlinksInEpubItems(epubItems);
-        let supplier = new EpubItemSupplier(this, epubItems, this.imageCollector);
-        return supplier;
+        return new EpubItemSupplier(this, epubItems, this.imageCollector);
     }
 
     webPagesToEpubItems(webPages) {
@@ -355,7 +356,7 @@ class Parser {
         for(let webPage of webPages.filter(c => this.isWebPagePackable(c))) {
             let newItems = (webPage.error == null)
                 ? webPage.parser.webPageToEpubItems(webPage, index)
-                : this.makePlacehoderEpubItem(webPage, index);
+                : this.makePlaceholderEpubItem(webPage, index);
             epubItems = epubItems.concat(newItems);
             index += newItems.length;
             delete(webPage.rawDom);

--- a/plugin/js/parsers/NovelinguaParser.js
+++ b/plugin/js/parsers/NovelinguaParser.js
@@ -22,7 +22,7 @@ class NovelinguaParser extends Parser {
         content.querySelectorAll("*").forEach(element => {
             element.removeAttribute("dir");
             util.replaceSemanticInlineStylesWithTags(element, true);
-            if (element.tagName === "B" && element.hasAttribute("id")) {
+            if (element.id?.startsWith("docs-internal-guid-")) {
                 element.removeAttribute("id");
             }
         });

--- a/plugin/js/parsers/TapasParser.js
+++ b/plugin/js/parsers/TapasParser.js
@@ -5,7 +5,7 @@ parserFactory.register("tapas.io", () => new TapasParser());
 //dead url
 parserFactory.register("m.tapas.io", () => new TapasParser());
 
-class TapasParser extends Parser{
+class TapasParser extends Parser {
     constructor() {
         super();
     }
@@ -82,11 +82,19 @@ class TapasParser extends Parser{
 
     customRawDomToContentStep(chapter, content) {
         content.querySelectorAll("*").forEach(element => {
-            element.removeAttribute("dir");
-            element.removeAttribute("role");
+            util.removeAttributes(element, ["dir", "role", "lang"]);
             util.replaceSemanticInlineStylesWithTags(element, true);
-            if (element.tagName === "B" && element.hasAttribute("id")) {
+            if (element.id?.startsWith("docs-internal-guid-")) {
                 element.removeAttribute("id");
+            }
+            element.classList.remove("MsoNormal");
+
+            if (element.tagName?.toLowerCase() === "w:sdt") {
+                // tag <w:sdt> is not valid XHTML, convert it to span with class="sdttag"
+                util.removeAttributes(element, ["id", "sdttag"]);
+                const spanElement = element.ownerDocument.createElement("span");
+                spanElement.classList.add("sdttag");
+                util.convertElement(element, spanElement);
             }
         });
     }


### PR DESCRIPTION
I'm know I'm an outlier who edits every epub I touch, but it's nice not to see (and clean up) a ton of completely pointless spans. I also used to see style="" or class="" sometimes.

Plus some other clean up, a couple new util functions that can reduce lines of code elsewhere, and improvements to the TapasParser as I've been using it.