### PR TITLE
Update download state icons and add tooltips

### DIFF
--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -527,6 +527,22 @@
 		"message": "You can select or unselect a range of chapters by clicking on the checkbox for the first chapter, then  hold down the shift key and click the last chapter in the range.",
 		"description": "Tell user how to shift-click to multiselect."
 	},
+	"__MSG_Tooltip_chapter_downloading__": {
+		"message": "Downloading chapter",
+		"description": "Tooltip for chapter download status icon: chapter is currently downloading"
+	},
+	"__MSG_Tooltip_chapter_downloaded__": {
+		"message": "Downloaded",
+		"description": "Tooltip for chapter download status icon: chapter download succeeded"
+	},
+	"__MSG_Tooltip_chapter_sleeping__": {
+		"message": "Waiting for chapter delay time to elapse",
+		"description": "Tooltip for chapter download status icon: waiting for chapter delay time to elapse"
+	},
+	"__MSG_Tooltip_chapter_previously_downloaded__": {
+		"message": "Chapter previously downloaded",
+		"description": "Tooltip for chapter download status icon: chapter has been downloaded before."
+	},
 	"chapterPlaceholderMessage": {
 		"message": "This is a placeholder.  Attempt to fetch chapter from '$url$' failed with error: \r\n $error$",
 		"description": "Warning message when try to fetch an image and instead get HTML",

--- a/plugin/css/default.css
+++ b/plugin/css/default.css
@@ -194,7 +194,6 @@ button {
     font-size: 12px;
     padding: 4px 8px;
     text-decoration: none;
-    text-shadow: 0px 1px 0px #ffffff;
     max-height: 30px;
 }
 

--- a/plugin/css/default.css
+++ b/plugin/css/default.css
@@ -71,10 +71,6 @@ section.minWidth {
     min-width: 600px;
 }
 
-img.downloadState {
-    height: 1em;
-}
-
 .withBorder {
     border: 1px solid black;
 }
@@ -130,10 +126,44 @@ textarea.allSpace {
     width: 100%;
 }
 
+    #chapterUrlsTable input[type=checkbox],
+    #chapterUrlsTable img,
+    #chapterUrlsTable .tooltip {
+        float: left;
+    }
+
+    img.downloadState {
+        height: 1em;
+        margin-top: 3px;
+    }
+
+    .downloadStateDiv {
+        position: relative;
+        display: inline-block;
+    }
+
+    .downloadStateDiv .tooltipText {
+        visibility: hidden;
+        width: 120px;
+        background-color: #808080;
+        color: white;
+        text-align: center;
+        padding: 5px;
+        border-radius: 5px;
+        position: absolute;
+        z-index: 1;
+        top: -5px;
+        left: 105%;
+    }
+
+    .downloadStateDiv:hover .tooltipText {
+        visibility: visible;
+    }
+
     #chapterUrlsTable input[type=text] {
         width: 101.5%;
         position: relative;
-        left: -17px;
+        left: -16px;
         max-width: 580px;
     }
 

--- a/plugin/images/FileEarmarkCheck.svg
+++ b/plugin/images/FileEarmarkCheck.svg
@@ -1,0 +1,9 @@
+<!-- source: https://icons.getbootstrap.com/icons/file-earmark-check/ -->
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="16" height="16"
+     fill="dodgerblue"
+     class="bi bi-file-earmark-check"
+     viewBox="0 0 16 16">
+    <path d="M10.854 7.854a.5.5 0 0 0-.708-.708L7.5 9.793 6.354 8.646a.5.5 0 1 0-.708.708l1.5 1.5a.5.5 0 0 0 .708 0z"/>
+    <path d="M14 14V4.5L9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2M9.5 3A1.5 1.5 0 0 0 11 4.5h2V14a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h5.5z"/>
+</svg>

--- a/plugin/images/FileEarmarkCheckFill.svg
+++ b/plugin/images/FileEarmarkCheckFill.svg
@@ -1,0 +1,8 @@
+<!-- source: https://icons.getbootstrap.com/icons/file-earmark-check-fill/ -->
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="16" height="16"
+     fill="green"
+     class="bi bi-file-earmark-check-fill"
+     viewBox="0 0 16 16">
+    <path d="M9.293 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V4.707A1 1 0 0 0 13.707 4L10 .293A1 1 0 0 0 9.293 0M9.5 3.5v-2l3 3h-2a1 1 0 0 1-1-1m1.354 4.354-3 3a.5.5 0 0 1-.708 0l-1.5-1.5a.5.5 0 1 1 .708-.708L7.5 9.793l2.646-2.647a.5.5 0 0 1 .708.708"/>
+</svg>

--- a/plugin/js/ReadingList.js
+++ b/plugin/js/ReadingList.js
@@ -42,6 +42,7 @@ class ReadingList {
                 if (oldUrl === chapterList[i].sourceUrl) {
                     for(let j = 0; j <= i; ++j) {
                         chapterList[j].isIncludeable = false;
+                        chapterList[j].previousDownload = true;
                     }
                     break;
                 }


### PR DESCRIPTION
The main goal of this PR is to add an icon (and tooltip) to help understand what is going on with the reading list, library, why things start out unchecked when you use them and what is going to be updated if you click "Add to Library" again.

I very much want to cache chapters downloaded and I read in a comment on an issue that the library kind of serves that purpose. But I couldn't understand how the library worked until I actually read the code and learned there was a reading list option and it was involved.

I still think there's more I want to do with caching that the library doesn't quite cover, but adding the icon for Previously downloaded chapters feels like step in the right direction to know what is even in the Library books.

Other changes in this PR are just because of fixes for spacing, typos, and editor warnings being made by me and my IDE that happened to be in the files for this change. I couldn't bring myself to delete them all when they make the code style more consistent.

Here's what it looks like when a book in your reading list or library is loaded with this PR:

![1-new-icon](https://github.com/user-attachments/assets/37743cf5-f0e3-4107-b5a7-63ded18ab2b1)

And here's how it looks when adding a subset of chapters to an existing library book. The download success icon I updated to match the new previously downloaded icon and look a bit more modern, but it could be reverted to the previous checkmark if you feel strongly about it.

![2-add-chapter-subset](https://github.com/user-attachments/assets/094f40c8-58f0-4235-b828-a4f120b937dd)

Also, I removed the text shadow on the buttons, because it's painful to look at in dark mode. This is before the shadow was removed:

![3-text-shadow-in-dark-mode-hurts](https://github.com/user-attachments/assets/ebe69a57-1d9e-4e4a-8534-1575acc3eb18)

Here's it removed:

![image](https://github.com/user-attachments/assets/f03aa33b-ee77-452a-b3fd-822963841a40)

And here's what the tooltips look like if you hover over the new state icons. I figured people would wonder what the heck it meant if they never saw it before:

![Screenshot 2025-05-16 161122](https://github.com/user-attachments/assets/a14c0f2e-09bf-4d45-aefe-99bbf9b62dc8)
![Screenshot 2025-05-16 161147](https://github.com/user-attachments/assets/f9c20538-4ab1-4629-a3bc-cc14154c790e)

I wasn't sure what to do about languages other than English though.


