### PR TITLE
Fixed obfuscation issue on chrysantemungarden parser using  DeJumCG'

### DIFF
--- a/plugin/js/parsers/ChrysanthemumgardenParser.js
+++ b/plugin/js/parsers/ChrysanthemumgardenParser.js
@@ -1,8 +1,8 @@
 "use strict";
-
+parserFactory.registerManualSelect("Chrysanthemumgarden", () => new ChrysanthemumgardenParser());
 parserFactory.register("chrysanthemumgarden.com", () => new ChrysanthemumgardenParser());
 
-class ChrysanthemumgardenParser extends WordpressBaseParser{
+class ChrysanthemumgardenParser extends WordpressBaseParser {
     constructor() {
         super();
     }
@@ -41,8 +41,30 @@ class ChrysanthemumgardenParser extends WordpressBaseParser{
         return formData;
     }
 
+    // Mapeo de caracteres basado en DeJumCG
+    static dejumMapping = {
+        "A": "J", "B": "K", "C": "A", "D": "B", "E": "R", "F": "U", "G": "D", "H": "Q", "I": "Z", "J": "C",
+        "K": "T", "L": "H", "M": "F", "N": "V", "O": "L", "P": "I", "Q": "W", "R": "N", "S": "E", "T": "Y",
+        "U": "P", "V": "S", "W": "X", "X": "G", "Y": "O", "Z": "M",
+        "a": "t", "b": "o", "c": "n", "d": "q", "e": "u", "f": "e", "g": "r", "h": "z", "i": "l", "j": "a",
+        "k": "w", "l": "i", "m": "c", "n": "v", "o": "f", "p": "j", "q": "p", "r": "s", "s": "y", "t": "h",
+        "u": "g", "v": "d", "w": "m", "x": "k", "y": "b", "z": "x"
+    };
+
+    // Función para descifrar el texto
+    static dejumText(text) {
+        return text.split("").map(char => ChrysanthemumgardenParser.dejumMapping[char] || char).join("");
+    }
+
     preprocessRawDom(webPageDom) {
         let content = this.findContent(webPageDom);
+        let jumbledElements = webPageDom.querySelectorAll("span.jum"); 
+        jumbledElements.forEach(element => {
+            let originalText = element.textContent;
+            let decodedText = ChrysanthemumgardenParser.dejumText(originalText);
+            element.textContent = decodedText;
+        });
+
         if (!this.userPreferences.removeAuthorNotes.value) {
             let notes = [...webPageDom.querySelectorAll("div.tooltip-container")];
             for(let n of notes) {


### PR DESCRIPTION
- Text descrambling using the deJumCG mapping to handle obfuscated text in <span class="jum"> elements.
- Registration for both automatic and manual selection.
Files modified:
- Updated plugin/js/parsers/ChrysanthemumgardenParser.js
Tested and working for generating EPUBs from chrysanthemumgarden.com chapters without obsfuscation.