### PR TITLE
Add image compression logic

### DIFF
--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -251,6 +251,14 @@
 		"message": "Add Page with Chapters to Chapters List",
 		"description": "Label for checkbox to toggle adding the page with chapters to list of pages to fetch"
 	},
+	"__MSG_label_Compress_Images__": {
+		"message": "Compress Images",
+		"description": "Label for checkbox and value to compress images to a certain size"
+	},
+	"__MSG_label_Compress_Images_Resolution__": {
+		"message": "Resolution",
+		"description": "Label for number input for maximum dimension size of pixel height or width in image"
+	},
 	"__MSG_label_Cover_from_URL__": {
 		"message": "Cover from URL:",
 		"description": "Label for checkbox to toggle between picking cover image from list or with a URL"

--- a/plugin/js/ImageCollector.js
+++ b/plugin/js/ImageCollector.js
@@ -354,11 +354,15 @@ class ImageCollector {
                 }
                 ctx.drawImage(img, 0, 0, c.width, c.height);
                 c.toBlob(async (cBlob) => {
-                    imageInfo.height = c.height;
-                    imageInfo.width = c.width;
-                    imageInfo.mediaType = "image/jpeg";
-                    imageInfo.arraybuffer = await cBlob.arrayBuffer();
-                    resolve();
+                    try {
+                        imageInfo.height = c.height;
+                        imageInfo.width = c.width;
+                        imageInfo.mediaType = "image/jpeg";
+                        imageInfo.arraybuffer = await cBlob.arrayBuffer();
+                        resolve();
+                    } catch (e) {
+                        reject();
+                    }
                 }, "image/jpeg", 0.9);
             }
             else

--- a/plugin/js/ImageCollector.js
+++ b/plugin/js/ImageCollector.js
@@ -352,7 +352,6 @@ class ImageCollector {
             }
             ctx.drawImage(img, 0, 0, c.width, c.height);
             c.toBlob(async (cBlob) => {
-                let url = c.toDataURL("image/jpeg", 0.9);
                 imageInfo.height = c.height;
                 imageInfo.width = c.width;
                 imageInfo.mediaType = "image/jpeg";

--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -103,6 +103,8 @@ class UserPreferences {
         this.addPreference("manualDelayPerChapter", "manualDelayPerChapterTag", "0");
         this.addPreference("overrideMinimumDelay", "overrideMinimumDelayCheckbox", false);
         this.addPreference("skipImages", "skipImagesCheckbox", false);
+        this.addPreference("compressImages", "compressImagesCheckbox", false);
+        this.addPreference("compressImagesMaxResolution", "compressImagesMaxResolutionTag", "1080");
         this.addPreference("overwriteExistingEpub", "overwriteEpubWhenDuplicateFilenameCheckbox", false);
         this.addPreference("themeColor", "themeColorTag", "");
         this.addPreference("useFullTitle", "useFullTitleAsFileNameCheckbox", false);

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -9,7 +9,6 @@
     <base />
 </head>
 <body>
-
     <div class="container">
         <section id="readingListSection" hidden="true">
             <button id="closeReadingList">__MSG_button_Close_ReadingList__</button>
@@ -339,6 +338,22 @@
                     <tr id="higestResolutionImagesRow" hidden="true">
                         <td><input id="higestResolutionImagesCheckboxInput" type="checkbox" name="higestResolutionImagesCheckboxInput" value="true"></td>
                         <td>__MSG_label_Fetch_Highest_Resolution_Images__</td>
+                    </tr>
+                    <tr id="compressImagesRow">
+                        <td><input id="compressImagesCheckbox" type="checkbox" name="compressImagesCheckbox" value="false"></td>
+                        <td>
+                            <table>
+                                <tr>
+                                    <td>__MSG_label_Compress_Images__</td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <input id="compressImagesMaxResolutionTag" type="number" name="compressImagesMaxResolutionTag" style="width: 61px;" value="1080" min="100">
+                        </td>
+                        <td>__MSG_label_Compress_Images_Resolution__</td>
                     </tr>
                     <tr id="unSuperScriptAlternateTranslations" hidden="true">
                         <td><input id="unSuperScriptCheckboxInput" type="checkbox" name="unSuperScriptCheckboxInput" value="true"></td>


### PR DESCRIPTION
- Added checkbox to choose to compress images
- Added field to choose maximum resolution (height/width)
- Passed image object generated to get image dimensions back for secondary usage
- Replaced image from arraybuffer to converted jpeg

Code has one flaw - the last chapters encoded may not be fully compressed. Images still remain, however at full size. Any suggestions to resolve the async issue would be appreciated. 