### PR TITLE
#2064 update kemono rule registration

### DIFF
--- a/plugin/js/parsers/KemonopartyParser.js
+++ b/plugin/js/parsers/KemonopartyParser.js
@@ -11,7 +11,7 @@ class KemonopartyParser extends Parser{
     }
     
     static isKemono(dom) {
-        return dom.querySelector('meta[name="og:title"]').content == "Kemono"
+        return dom.querySelector("meta[name='og:title']").content == "Kemono"
             && dom.querySelector("section.site-section div.card-list") != null;
     }
 


### PR DESCRIPTION
Fix for #2064 - Since this apparently isn't the first time the domain has changed TLD's (Was originally .party), changed recognition to use rule-based instead of domain based logic. 