### PR TITLE
Add secondary chapter title detection

### DIFF
--- a/plugin/js/parsers/MadaraParser.js
+++ b/plugin/js/parsers/MadaraParser.js
@@ -75,7 +75,7 @@ class MadaraParser extends WordpressBaseParser{
     }
 
     findChapterTitle(dom) {
-        return dom.querySelector("ol.breadcrumb li.active").textContent;
+        return dom.querySelector("ol.breadcrumb li.active, .wp-manga-chapter.reading a").textContent;
     }
  
     findCoverImageUrl(dom) {


### PR DESCRIPTION
Added secondary fallback for chapter title detection for Madara - Should fix #2083

Note: This affected multiple Madara sites, but I'm not sure if this was a new version or just a secondary layout. It may be worth keeping a log of all sites that use a particular parser in the future to help with devtesting.