### PR TITLE
Update KemonopartyParser.js

### DIFF
--- a/plugin/js/parsers/KemonopartyParser.js
+++ b/plugin/js/parsers/KemonopartyParser.js
@@ -48,7 +48,13 @@ class KemonopartyParser extends Parser{
 
     findCoverImageUrl(dom) {
         let cover = dom.querySelector(".user-header__avatar img");
-        return cover.src ?? null;
+        return cover?.src ?? KemonopartyParser.requestCoverImageUrl(dom);
+    }
+
+    static requestCoverImageUrl(dom) {
+        let uriRegex = new RegExp("(.*?//)(?:\\w+\\.)?(\\w+\\.\\w+)/(\\w+)/user/(\\w+)");
+        let reResults = uriRegex.exec(dom.baseURI);
+        return `${reResults[1]}img.${reResults[2]}/icons/${reResults[3]}/${reResults[4]}`;
     }
 
     async getUrlsOfTocPages(dom) {

--- a/plugin/js/parsers/KemonopartyParser.js
+++ b/plugin/js/parsers/KemonopartyParser.js
@@ -54,6 +54,10 @@ class KemonopartyParser extends Parser{
     static requestCoverImageUrl(dom) {
         let uriRegex = new RegExp("(.*?//)(?:\\w+\\.)?(\\w+\\.\\w+)/(\\w+)/user/(\\w+)");
         let reResults = uriRegex.exec(dom.baseURI);
+        if (!reResults || reResults.length < 5)
+        {
+            return null;
+        }
         return `${reResults[1]}img.${reResults[2]}/icons/${reResults[3]}/${reResults[4]}`;
     }
 


### PR DESCRIPTION
Fix Cover Image detection on Load&Analyze referenced in #2064

Not sure if we actually want this; Load & Analyze was throwing errors, though.