### PR TITLE
create lint:fix command and add more eslint rules

### DIFF
--- a/eslint/.eslintrc.js
+++ b/eslint/.eslintrc.js
@@ -11,22 +11,36 @@ module.exports = {
     "rules": {
         "indent": [
             "error",
-            4
+            4,
+            { "SwitchCase": 1 }
         ],
         "linebreak-style": "off",
         "no-extra-semi": [
-            "off"
+            "error"
         ],
         "quotes": [
             "error",
             "double"
         ],
         "semi": [
-            "off",
-            "never"
+            "error",
+            "always"
         ],
+        "no-undef": "off",
+        "no-unused-vars": "off",
+        "space-before-blocks": ["error", "always"],
+        "space-before-function-paren": ["error", {
+            "anonymous": "never",    // function() {}
+            "named": "never",        // function foo() {}
+            "asyncArrow": "always"   // async () => {}
+        }],
+        // Space around keywords (if, for, etc.)
+        "keyword-spacing": ["error", {
+            "before": true,
+            "after": true
+        }],
     },
-	"globals": {
-		"zip": "readable",
-	}
+    "globals": {
+        "zip": "readable",
+    }
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "postinstall": "npm run -s postinstall-zip && npm run -s postinstall-DOMpurify",
     "test": "http-server -o unitTest/Tests.html",
     "lint": "cd eslint && node pack.js && eslint packed.js",
+    "lint:fix": "eslint --config eslint/.eslintrc.js --fix plugin/js",
     "web-ext": "cd eslint && cp *.xpi temp.xpi && web-ext lint -w -s temp.xpi && rm temp.xpi",
     "build": "cd eslint && node pack.js",
     "release": "node eslint/release.js"

--- a/plugin/js/ChapterUrlsUI.js
+++ b/plugin/js/ChapterUrlsUI.js
@@ -16,7 +16,7 @@ class ChapterUrlsUI {
 
         let formElement = document.getElementById("sbFiltersForm");
         if (formElement) {
-            document.getElementById("sbFiltersForm").onsubmit = function (event) {
+            document.getElementById("sbFiltersForm").onsubmit = function(event) {
                 event.preventDefault();
             };
         }
@@ -40,7 +40,7 @@ class ChapterUrlsUI {
         let rangeStart = ChapterUrlsUI.getRangeStartChapterSelect();
         let rangeEnd = ChapterUrlsUI.getRangeEndChapterSelect();
         let memberForTextOption = ChapterUrlsUI.textToShowInRange();
-        chapters.forEach(function (chapter) {
+        chapters.forEach(function(chapter) {
             let row = document.createElement("tr");
             ChapterUrlsUI.appendCheckBoxToRow(row, chapter);
             ChapterUrlsUI.appendInputTextToRow(row, chapter);
@@ -58,7 +58,7 @@ class ChapterUrlsUI {
 
     showTocProgress(chapters) {
         let linksTable = ChapterUrlsUI.getChapterUrlsTable();
-        chapters.forEach(function (chapter) {
+        chapters.forEach(function(chapter) {
             let row = document.createElement("tr");
             linksTable.appendChild(row);
             row.appendChild(document.createElement("td"));
@@ -136,7 +136,7 @@ class ChapterUrlsUI {
             let message = chrome.i18n.getMessage("__MSG_More_than_max_chapters_selected__", 
                 [selectedRows.length, max]);
             if (confirm(message) === false) {
-                for(let row of selectedRows.slice(max)) {
+                for (let row of selectedRows.slice(max)) {
                     ChapterUrlsUI.setRowCheckboxState(row, false);
                 }
             }
@@ -166,7 +166,7 @@ class ChapterUrlsUI {
         let endIndex = ChapterUrlsUI.selectionToRowIndex(ChapterUrlsUI.getRangeEndChapterSelect());
         let rc = new ChapterUrlsUI.RangeCalculator();
 
-        for(let row of ChapterUrlsUI.getTableRowsWithChapters()) {
+        for (let row of ChapterUrlsUI.getTableRowsWithChapters()) {
             let inRange = rc.rowInRange(row);
             ChapterUrlsUI.setRowCheckboxState(row, rc.rowInRange(row));
             row.hidden = !inRange;
@@ -231,11 +231,11 @@ class ChapterUrlsUI {
 
     /** @private */
     static setAllUrlsSelectState(select) {
-        for(let row of ChapterUrlsUI.getTableRowsWithChapters()) {
+        for (let row of ChapterUrlsUI.getTableRowsWithChapters()) {
             ChapterUrlsUI.setRowCheckboxState(row, select);
             row.hidden = false;
         }
-        ChapterUrlsUI.setRangeOptionsToFirstAndLastChapters()
+        ChapterUrlsUI.setRangeOptionsToFirstAndLastChapters();
     }
 
     /** @private */
@@ -419,7 +419,7 @@ class ChapterUrlsUI {
     showHideChapterUrlsColumn() {
         let hidden = !document.getElementById("showChapterUrlsCheckbox").checked;
         let table = ChapterUrlsUI.getChapterUrlsTable();
-        for(let t of table.querySelectorAll("th:nth-of-type(3), td:nth-of-type(3)")) {
+        for (let t of table.querySelectorAll("th:nth-of-type(3), td:nth-of-type(3)")) {
             t.hidden = hidden;
         }
     }
@@ -449,7 +449,7 @@ class ChapterUrlsUI {
 
     chaptersToHTML(chapters) {
         let doc = util.sanitize("<html><head><title></title><body></body></html>");
-        for(let chapter of chapters.filter(c => c.isIncludeable)) {
+        for (let chapter of chapters.filter(c => c.isIncludeable)) {
             doc.body.appendChild(this.makeLink(doc, chapter));
             doc.body.appendChild(doc.createTextNode("\r"));
         }
@@ -467,7 +467,7 @@ class ChapterUrlsUI {
     static updateRange(startRowIndex, endRowIndex, state) {
         let direction = startRowIndex < endRowIndex ? 1 : -1;
         let linkTable = ChapterUrlsUI.getChapterUrlsTable();
-        for(let rowIndex = startRowIndex; rowIndex != endRowIndex; rowIndex += direction) {
+        for (let rowIndex = startRowIndex; rowIndex != endRowIndex; rowIndex += direction) {
             let row = linkTable.rows[rowIndex];
             ChapterUrlsUI.setRowCheckboxState(row, state);
         }
@@ -541,7 +541,7 @@ class ChapterUrlsUI {
                 .filter(key => constantTerms.indexOf(key) == -1 && filterTermsFrequency[key] > minFilterTermCount)
                 .map(key => ({ key: key, value: filterTermsFrequency[key] } ));
 
-            var calcValue = function (filterTerm) {
+            var calcValue = function(filterTerm) {
                 return filterTerm.value * filterTerm.key.length;
             };
 
@@ -625,13 +625,13 @@ class ChapterUrlsUI {
             el.id = checkboxId;
             el.value = 1;
             el.onclick = onClickEvent;
-            el.onchange = function(event){
+            el.onchange = function(event) {
                 if (event == undefined || event == null) {
                     return;
                 }
                 event.target.parentElement.nextElementSibling.firstChild.disabled = !event.target.checked;
                 ChapterUrlsUI.Filters.Filter();
-            }
+            };
             col.appendChild(el);
             row.appendChild(col);
             col = document.createElement("td");
@@ -685,7 +685,7 @@ class ChapterUrlsUI {
             retVal.setAttribute("width", "100%");
             return retVal;
         }
-    }
+    };
 }
 ChapterUrlsUI.RangeCalculator = class {
     constructor()
@@ -697,7 +697,7 @@ ChapterUrlsUI.RangeCalculator = class {
         let index = row.rowIndex;
         return (this.startIndex <= index) && (index <= this.endIndex);
     }
-}
+};
 
 
 
@@ -719,7 +719,7 @@ ChapterUrlsUI.TooltipForSate = [
     chrome.i18n.getMessage("__MSG_Tooltip_chapter_downloaded__"),
     chrome.i18n.getMessage("__MSG_Tooltip_chapter_sleeping__"),
     chrome.i18n.getMessage("__MSG_Tooltip_chapter_previously_downloaded__")
-]
+];
 
 ChapterUrlsUI.lastSelectedRow = null;
 ChapterUrlsUI.ConsecutiveRowClicks = 0;

--- a/plugin/js/CoverImageUI.js
+++ b/plugin/js/CoverImageUI.js
@@ -34,7 +34,7 @@ class CoverImageUI {
     static clearImageTable() {
         let imagesTable = CoverImageUI.getImageTableElement();
         while (imagesTable.children.length > 0) {
-            imagesTable.removeChild(imagesTable.children[imagesTable.children.length - 1])
+            imagesTable.removeChild(imagesTable.children[imagesTable.children.length - 1]);
         }
     }
 
@@ -49,7 +49,7 @@ class CoverImageUI {
             imagesTable.parentElement.appendChild(document.createTextNode(chrome.i18n.getMessage("noImagesFoundLabel")));
         }
         else {
-            images.forEach(function (imageInfo) {
+            images.forEach(function(imageInfo) {
                 let row = document.createElement("tr");
         
                 // add checkbox
@@ -98,7 +98,7 @@ class CoverImageUI {
 
             // uncheck any other checked boxes
             let imagesTable = CoverImageUI.getImageTableElement();
-            for(let box of imagesTable.querySelectorAll("input")) {
+            for (let box of imagesTable.querySelectorAll("input")) {
                 if (box.id !== checkboxId) {
                     box.checked = false;
                 }

--- a/plugin/js/DebugUtil.js
+++ b/plugin/js/DebugUtil.js
@@ -4,7 +4,7 @@
 
 /** Functions to help debugging.  Not included in release product */
 class DebugUtil {
-    constructor () {
+    constructor() {
     }
 
     static byteToHex(e) {
@@ -14,7 +14,7 @@ class DebugUtil {
 
     static bufToHex(buf) {
         return new Uint8Array(buf)
-            .reduce((p, c) => p + DebugUtil.byteToHex(c), "")
+            .reduce((p, c) => p + DebugUtil.byteToHex(c), "");
     }
 }
 

--- a/plugin/js/DefaultParserUI.js
+++ b/plugin/js/DefaultParserUI.js
@@ -11,7 +11,7 @@ class DefaultParserSiteSettings {
         let config = window.localStorage.getItem(DefaultParserSiteSettings.storageName);
         this.configs = new Map();
         if (config != null) {
-            for(let e of JSON.parse(config)) {
+            for (let e of JSON.parse(config)) {
                 let selectors = e[1];
                 if (DefaultParserSiteSettings.isConfigValid(selectors)) {
                     this.configs.set(e[0], selectors);
@@ -59,7 +59,7 @@ class DefaultParserSiteSettings {
             findContent: dom => dom.querySelector("body"),
             findChapterTitle: () => null,
             removeUnwanted: () => null
-        }
+        };
         let config = this.getConfigForSite(hostname);
         if (config != null) {
             logic.findContent = dom => dom.querySelector(config.contentCss);
@@ -70,9 +70,9 @@ class DefaultParserSiteSettings {
             if (!util.isNullOrEmpty(config.removeCss))
             {
                 logic.removeUnwanted = function(element) {
-                    for(let e of element.querySelectorAll(config.removeCss)) {
+                    for (let e of element.querySelectorAll(config.removeCss)) {
                         e.remove();
-                    };
+                    }
                 };
             }
         }
@@ -89,13 +89,13 @@ class DefaultParserUI {
     static setupDefaultParserUI(hostname, parser) {
         DefaultParserUI.copyInstructions();
         DefaultParserUI.setDefaultParserUiVisibility(true);
-        DefaultParserUI.populateDefaultParserUI(hostname, parser)
+        DefaultParserUI.populateDefaultParserUI(hostname, parser);
         document.getElementById("testDefaultParserButton").onclick = DefaultParserUI.testDefaultParser.bind(null, parser);
         document.getElementById("finisheddefaultParserButton").onclick = DefaultParserUI.onFinishedClicked.bind(null, parser);
     }
 
     static onFinishedClicked(parser) {
-        DefaultParserUI.AddConfiguration(parser)
+        DefaultParserUI.AddConfiguration(parser);
         DefaultParserUI.setDefaultParserUiVisibility(false);
     }
 
@@ -146,18 +146,18 @@ class DefaultParserUI {
             alert(chrome.i18n.getMessage("warningNoChapterUrl"));
             return;
         }
-        return HttpClient.wrapFetch(config.testUrl).then(function (xhr) {
+        return HttpClient.wrapFetch(config.testUrl).then(function(xhr) {
             let webPage = { rawDom: util.sanitize(xhr.responseXML.querySelector("*")) };
             util.setBaseTag(config.testUrl, webPage.rawDom);
             let content = parser.findContent(webPage.rawDom);
             if (content === null) {
                 let errorMsg = chrome.i18n.getMessage("errorContentNotFound", [config.testUrl]);
                 throw new Error(errorMsg);
-            };
+            }
             parser.removeUnwantedElementsFromContentElement(content);
             parser.addTitleToContent(webPage, content);
             DefaultParserUI.showResult(content);
-        }).catch(function (err) {
+        }).catch(function(err) {
             ErrorLog.showErrorMessage(err);
         });
     }

--- a/plugin/js/Download.js
+++ b/plugin/js/Download.js
@@ -1,7 +1,7 @@
 "use strict";
 
 class Download {
-    constructor () {
+    constructor() {
     }
 
     static init() {
@@ -16,7 +16,7 @@ class Download {
     }
 
     static isFileNameIllegalOnWindows(fileName) {
-        for(let c of Download.illegalWindowsFileNameChars) {
+        for (let c of Download.illegalWindowsFileNameChars) {
             if (fileName.includes(c)) {
                 return true;
             }
@@ -27,7 +27,7 @@ class Download {
         return false;
     }
 
-    static CustomFilename(){
+    static CustomFilename() {
         let CustomFilename = document.getElementById("CustomFilenameInput").value;
         let ToReplace = {
             "%URL_hostname%": (new URL(document.getElementById("startingUrlInput").value))?.hostname,
@@ -92,7 +92,7 @@ class Download {
     static saveOnFirefox(options, cleanup) {
         return browser.runtime.getPlatformInfo().then(platformInfo => {
             if (Download.isAndroid(platformInfo)) {
-                Download.saveOnFirefoxForAndroid(options, cleanup)
+                Download.saveOnFirefoxForAndroid(options, cleanup);
             } else {
                 return browser.downloads.download(options).then(
                     // on Firefox, resolves when "Save As" dialog CLOSES, so no

--- a/plugin/js/EpubItem.js
+++ b/plugin/js/EpubItem.js
@@ -37,7 +37,7 @@ class EpubItem {
 
     hasSvg() {
         if (this.nodes != null) {
-            for(let n of this.nodes) {
+            for (let n of this.nodes) {
                 if ((n.nodeType === Node.ELEMENT_NODE) &&
                     (n.querySelector("svg") !== null)) {
                     return true;
@@ -67,12 +67,12 @@ class EpubItem {
     makeChapterDoc(emptyDocFactory) {
         let doc = emptyDocFactory();
         let body = doc.getElementsByTagName("body")[0];
-        for(let node of this.nodes) {
+        for (let node of this.nodes) {
             let clean = util.sanitizeNode(node);
             if (clean) {
                 body.appendChild(clean);
             }
-        };
+        }
         this.populateTitle(doc, body);
         delete(this.nodes);
         return doc;
@@ -95,25 +95,25 @@ class EpubItem {
 
     *chapterInfo() {
         let that = this;
-        for(let element of that.nodes) {
+        for (let element of that.nodes) {
             if (util.isHeaderTag(element)) {
                 yield {
                     depth: this.tagNameToTocDepth(element.tagName),
                     title: element.textContent,
                     src: that.getZipHref()
                 };
-            };
-        };
+            }
+        }
     }
 
     getHyperlinks() {
         let links = [];
-        for(let element of this.nodes) {
+        for (let element of this.nodes) {
             if (element.nodeType === Node.ELEMENT_NODE) {
                 if (element.tagName.toLowerCase() === "a") {
                     links.push(element);
                 }
-                for(let link of element.querySelectorAll("a")) {
+                for (let link of element.querySelectorAll("a")) {
                     links.push(link);
                 }
             }
@@ -143,7 +143,7 @@ class ChapterEpubItem extends EpubItem {
                 depth: 0,
                 title: that.newArc,
                 src: that.getZipHref()
-            }
+            };
         }
 
         if (typeof (that.chapterTitle) !== "undefined") {
@@ -151,7 +151,7 @@ class ChapterEpubItem extends EpubItem {
                 depth: 1,
                 title: that.chapterTitle,
                 src: that.getZipHref()
-            }
+            };
         }
     }
 }
@@ -221,7 +221,7 @@ class ImageInfo extends EpubItem {
     findImageSuffix(wrappingUrl) {
         let that = this;
         let suffix = "";
-        let fileName = that.extractImageFileNameFromUrl(wrappingUrl)
+        let fileName = that.extractImageFileNameFromUrl(wrappingUrl);
         if (fileName != null) {
             let index = fileName.lastIndexOf(".");
             suffix = fileName.substring(index + 1);
@@ -236,7 +236,7 @@ class ImageInfo extends EpubItem {
             if (suffix === "svg+xml") {
                 suffix = "svg";
             }
-        };
+        }
         return suffix;
     }
 
@@ -281,9 +281,9 @@ class ImageInfo extends EpubItem {
 
     getImageName(page) {
         let that = this;
-        if(page){
+        if (page) {
             let name = that.extractImageFileNameFromUrl(page);
-            if(name){
+            if (name) {
                 return name.split(/\./gi)[0];
             }
         }

--- a/plugin/js/EpubItemSupplier.js
+++ b/plugin/js/EpubItemSupplier.js
@@ -14,7 +14,7 @@ class EpubItemSupplier {
         imageCollector.imagesToPackInEpub().forEach(image => this.epubItems.push(image));
         epubItems.forEach(item => this.epubItems.push(item));
         this.coverImageId = () => this.coverImageInfo.getId();
-    };
+    }
 
 
     // used to populate manifest
@@ -34,9 +34,9 @@ class EpubItemSupplier {
 
     // used to populate table of contents
     *chapterInfo() {
-        for(let epubItem of this.epubItems) {
+        for (let epubItem of this.epubItems) {
             yield* epubItem.chapterInfo();
-        };
+        }
     }
 
     makeCoverImageXhtmlFile(emptyDocFactory) {

--- a/plugin/js/EpubMetaInfo.js
+++ b/plugin/js/EpubMetaInfo.js
@@ -14,7 +14,7 @@
     <param name="seriesIndex" type="string">If book is part of series, has index of book in series.  null if not part of a series</param>
 */
 class EpubMetaInfo {
-    constructor () {
+    constructor() {
         this.uuid = chrome.i18n.getMessage("defaultUUID");
         this.title = chrome.i18n.getMessage("defaultTitle");
         this.author = chrome.i18n.getMessage("defaultAuthor");
@@ -155,11 +155,11 @@ class EpubMetaInfo {
         "}";
     }
 
-    static getEpubMetaAddInfo(dom, url, allTags){
+    static getEpubMetaAddInfo(dom, url, allTags) {
         let metaAddInfo = new EpubAddMetaInfo();
 
         //novelupdates
-        if (url.includes("novelupdates.com") == true){
+        if (url.includes("novelupdates.com") == true) {
             metaAddInfo.subject = EpubMetaInfo.addSubjectNovelupdate(dom, allTags);
             metaAddInfo.description = EpubMetaInfo.addDescriptionNovelupdate(dom);
             metaAddInfo.author = EpubMetaInfo.addAuthorNovelupdate(dom);
@@ -170,7 +170,7 @@ class EpubMetaInfo {
         return metaAddInfo;
     }
     
-    static addSubjectNovelupdate(dom, allTags){
+    static addSubjectNovelupdate(dom, allTags) {
         let selector = "#seriesgenre .genre";
         if (allTags) {
             selector += ", #showtags .genre";
@@ -178,11 +178,11 @@ class EpubMetaInfo {
         return EpubMetaInfo.buildSubjectFromTags(dom, selector);
     }
 
-    static addDescriptionNovelupdate(dom){
+    static addDescriptionNovelupdate(dom) {
         return dom.querySelector("#editdescription").textContent.replace(/\n+/g, "\n").replace(/\n/g, "\n\n");
     }
     
-    static addAuthorNovelupdate(dom){
+    static addAuthorNovelupdate(dom) {
         return dom.querySelector("#authtag").textContent;
     }
 
@@ -194,7 +194,7 @@ class EpubMetaInfo {
 
     static decensor(tag) {
         if (tag.includes("*")) {
-            for(let j = 0; j < EpubMetaInfo.decensorList.length; j += 2) {
+            for (let j = 0; j < EpubMetaInfo.decensorList.length; j += 2) {
                 let cyphertext = EpubMetaInfo.decensorList[j];
                 let cleartext = EpubMetaInfo.decensorList[j + 1];
                 if (tag.includes(cyphertext)) {
@@ -246,7 +246,7 @@ EpubMetaInfo.decensorList = [
     "Virg*n", "Virgin"];
 
 class EpubAddMetaInfo {
-    constructor () {
+    constructor() {
         this.subject = "";
         this.description = "";
         this.author = "";

--- a/plugin/js/EpubPacker.js
+++ b/plugin/js/EpubPacker.js
@@ -131,17 +131,17 @@ class EpubPacker {
 
         if (epubItemSupplier.hasCoverImageFile()) {
             that.appendMetaContent(metadata, opf_ns, "cover", epubItemSupplier.coverImageId());
-        };
+        }
 
         if (that.metaInfo.seriesName !== null) {
             that.appendMetaContent(metadata, opf_ns, "calibre:series", that.metaInfo.seriesName);
             that.appendMetaContent(metadata, opf_ns, "calibre:series_index", that.metaInfo.seriesIndex);
         }
 
-        for(let i of epubItemSupplier.manifestItems()) {
+        for (let i of epubItemSupplier.manifestItems()) {
             let source = this.createAndAppendChildNS(metadata, dc_ns, "dc:source", i.sourceUrl);
             source.setAttributeNS(null, "id", "id." + i.getId());
-        };
+        }
     }
 
     addMetaProperty(metadata, element, propName, id, value) {
@@ -167,17 +167,17 @@ class EpubPacker {
     buildManifest(opf, ns, epubItemSupplier) {
         let that = this;
         let manifest = that.createAndAppendChildNS(opf.documentElement, ns, "manifest");
-        for(let i of epubItemSupplier.manifestItems()) {
+        for (let i of epubItemSupplier.manifestItems()) {
             let item = that.addManifestItem(manifest, ns, i.getZipHref(), i.getId(), i.getMediaType());
             this.setSvgPropertyForManifestItem(item, i.hasSvg());
-        };
+        }
 
         that.addManifestItem(manifest, ns, util.styleSheetFileName(), "stylesheet", "text/css");
         that.addManifestItem(manifest, ns, "OEBPS/toc.ncx", "ncx", "application/x-dtbncx+xml");
         if (epubItemSupplier.hasCoverImageFile()) {
             let item = that.addManifestItem(manifest, ns, EpubPacker.coverImageXhtmlHref(), EpubPacker.coverImageXhtmlId(), "application/xhtml+xml");
             this.setSvgPropertyForManifestItem(item, this.doesCoverHaveSvg(epubItemSupplier));
-        };
+        }
         if (this.version === EpubPacker.EPUB_VERSION_3) {
             let item = this.addManifestItem(manifest, ns, "OEBPS/toc.xhtml", "nav", "application/xhtml+xml");
             item.setAttributeNS(null, "properties", "nav");
@@ -215,10 +215,10 @@ class EpubPacker {
         spine.setAttributeNS(null, "toc", "ncx");
         if (epubItemSupplier.hasCoverImageFile()) {
             that.addSpineItemRef(spine, ns, EpubPacker.coverImageXhtmlId());
-        };
-        for(let item of epubItemSupplier.spineItems()) {
+        }
+        for (let item of epubItemSupplier.spineItems()) {
             that.addSpineItemRef(spine, ns, item.getId());
-        };
+        }
     }
 
     addSpineItemRef(spine, ns, idref) {
@@ -233,7 +233,7 @@ class EpubPacker {
             reference.setAttributeNS(null, "href", that.makeRelative(EpubPacker.coverImageXhtmlHref()));
             reference.setAttributeNS(null, "title", "Cover");
             reference.setAttributeNS(null, "type", "cover");
-        };
+        }
     }
 
     buildTableOfContents(epubItemSupplier) {
@@ -296,12 +296,12 @@ class EpubPacker {
     populateNavElement(nav, ns, epubItemSupplier) {
         let rootParent = this.createAndAppendChildNS(nav, ns, "ol");
         let parents = new NavPointParentElementsStack(rootParent);
-        for(let chapterInfo of epubItemSupplier.chapterInfo()) {
+        for (let chapterInfo of epubItemSupplier.chapterInfo()) {
             let parent = parents.findParentElement(chapterInfo.depth);
             let nextLevel = this.buildNavListItem(parent, ns, chapterInfo);
             parents.addElement(chapterInfo.depth, nextLevel);
         }
-        this.removeEmptyNavLists(rootParent)
+        this.removeEmptyNavLists(rootParent);
     }
 
     buildNavListItem(parent, ns, chapterInfo) {
@@ -327,15 +327,15 @@ class EpubPacker {
         let playOrder = 0;
         let id = 0;
         let lastChapterSrc = null;
-        for(let chapterInfo of epubItemSupplier.chapterInfo()) {
+        for (let chapterInfo of epubItemSupplier.chapterInfo()) {
             let parent = parents.findParentElement(chapterInfo.depth);
-            if(lastChapterSrc !== chapterInfo.src){
+            if (lastChapterSrc !== chapterInfo.src) {
                 ++playOrder;
             }
             let navPoint = that.buildNavPoint(parent, ns, playOrder, ++id, chapterInfo);
             lastChapterSrc = chapterInfo.src;
             parents.addElement(chapterInfo.depth, navPoint);
-        };
+        }
         return parents.maxDepth;
     }
 
@@ -351,13 +351,13 @@ class EpubPacker {
     }
 
     packContentFiles(zipWriter, epubItemSupplier) {
-        for(let file of epubItemSupplier.files()) {
+        for (let file of epubItemSupplier.files()) {
             file.packInEpub(zipWriter, this.emptyDocFactory, this.contentValidator);
-        };
+        }
         if (epubItemSupplier.hasCoverImageFile()) {
             let fileContent = epubItemSupplier.makeCoverImageXhtmlFile(this.emptyDocFactory);
             zipWriter.add(EpubPacker.coverImageXhtmlHref(), new zip.TextReader(fileContent));
-        };
+        }
     }
 
     createAndAppendChildNS(element, ns, name, data) {
@@ -409,7 +409,7 @@ class NavPointParentElementsStack {
         let index = that.parents.length - 1;
         while (depth <= that.parents[index].depth) {
             --index;
-        };
+        }
         return that.parents[index].element;
     }
 

--- a/plugin/js/ErrorLog.js
+++ b/plugin/js/ErrorLog.js
@@ -18,7 +18,7 @@ class ErrorLog {
         ErrorLog.queue.push(msg);
         if (1 < ErrorLog.queue.length) {
             return;
-        };
+        }
 
         let sections = ErrorLog.hideAllSectionsSavingVisibility();
         ErrorLog.getErrorSection().hidden = false;
@@ -34,7 +34,7 @@ class ErrorLog {
         } else {
             ErrorLog.setErrorMessageText(ErrorLog.queue[0]);
             ErrorLog.setErrorMessageButtons(ErrorLog.queue[0], sections);
-        };
+        }
     }
 
     static showLogToUser() {
@@ -61,10 +61,10 @@ class ErrorLog {
     /** private */
     static hideAllSectionsSavingVisibility() {
         let sections = new Map();
-        for(let section of document.querySelectorAll("section")) {
+        for (let section of document.querySelectorAll("section")) {
             sections.set(section, section.hidden);
             section.hidden = true;
-        };
+        }
         return sections;
     }
 
@@ -110,7 +110,7 @@ class ErrorLog {
             cancelButton.textContent = chrome.i18n.getMessage("__MSG_button_error_Cancel__");
             if (msg.cancelLabel !== undefined) {
                 cancelButton.textContent =  msg.cancelLabel;
-            };
+            }
             if (msg.openurl !== undefined) {
                 OpenURLButton.hidden = false;
                 OpenURLButton.onclick = function() {
@@ -140,9 +140,9 @@ class ErrorLog {
 
     /** private */
     static restoreSectionVisibility(sections) {
-        for(let [key,value] of sections) {
+        for (let [key,value] of sections) {
             key.hidden = value;
-        };
+        }
     }
 }
 

--- a/plugin/js/Firefox.js
+++ b/plugin/js/Firefox.js
@@ -4,7 +4,7 @@
 
 /** Functions specific to Firefox version of plug-in */
 class Firefox {
-    constructor () {
+    constructor() {
     }
 
     /** fetch() calls on Firefox include an origin header.
@@ -28,10 +28,10 @@ class Firefox {
 
     static injectContentScript(tabId) {
         chrome.tabs.executeScript(tabId, { file: "js/ContentScript.js", runAt: "document_end" },
-            function (result) {   // eslint-disable-line no-unused-vars
+            function(result) {   // eslint-disable-line no-unused-vars
                 if (chrome.runtime.lastError) {
                     util.log(chrome.runtime.lastError.message);
-                };
+                }
             }
         );
     }

--- a/plugin/js/HttpClient.js
+++ b/plugin/js/HttpClient.js
@@ -85,37 +85,37 @@ class FetchErrorHandler {
     static getAutomaticRetryBehaviourForStatus(response) {
         // seconds to wait before each retry (note: order is reversed)
         let retryDelay = [120, 60, 30, 15];
-        switch(response.status) {
-        case 403:
-            return {retryDelay: [1], promptUser: true, HTTP: 403};
-        case 429:
-            FetchErrorHandler.show429Error(response);
-            return {retryDelay: retryDelay, promptUser: true};
-        case 445:
+        switch (response.status) {
+            case 403:
+                return {retryDelay: [1], promptUser: true, HTTP: 403};
+            case 429:
+                FetchErrorHandler.show429Error(response);
+                return {retryDelay: retryDelay, promptUser: true};
+            case 445:
             //Random Unique exception thrown on Webnovel/Qidian. Not part of w3 spec.
-            return {retryDelay: retryDelay, promptUser: false};
-        case 509:
+                return {retryDelay: retryDelay, promptUser: false};
+            case 509:
             // server asked for rate limiting
-            return {retryDelay: retryDelay, promptUser: true};
-        case 500:
+                return {retryDelay: retryDelay, promptUser: true};
+            case 500:
             // is fault at server, retry might clear
-            return {retryDelay: retryDelay, promptUser: false};
-        case 502: 
-        case 503: 
-        case 504:
-        case 520:
-        case 522:
+                return {retryDelay: retryDelay, promptUser: false};
+            case 502: 
+            case 503: 
+            case 504:
+            case 520:
+            case 522:
             // intermittant fault
-            return {retryDelay: retryDelay, promptUser: true};
-        case 524:
+                return {retryDelay: retryDelay, promptUser: true};
+            case 524:
             // claudflare random error
-            return {retryDelay: [1], promptUser: true};
-        case 999:
+                return {retryDelay: [1], promptUser: true};
+            case 999:
             // custom WebToEpub error (some api's fail and a few seconds later it is a success)
-            return {retryDelay: response.retryDelay, promptUser: false};
-        default:
+                return {retryDelay: response.retryDelay, promptUser: false};
+            default:
             // it's dead Jim
-            return {retryDelay: [], promptUser: false};
+                return {retryDelay: [], promptUser: false};
         }
     }
 
@@ -129,7 +129,7 @@ class FetchErrorHandler {
 }
 FetchErrorHandler.rateLimitedHosts = new Set();
 
-class FetchImageErrorHandler extends FetchErrorHandler{
+class FetchImageErrorHandler extends FetchErrorHandler {
     constructor(parentPageUrl) {
         super();
         this.parentPageUrl = parentPageUrl;
@@ -156,7 +156,7 @@ class HttpClient {
         if (wrapOptions == null) {
             wrapOptions = {
                 errorHandler: new FetchErrorHandler()
-            }
+            };
         }
         if (wrapOptions.errorHandler == null) {
             wrapOptions.errorHandler = new FetchErrorHandler();
@@ -222,7 +222,7 @@ class HttpClient {
     }
 
     static checkResponseAndGetData(url, wrapOptions, response) {
-        if(!response.ok) {
+        if (!response.ok) {
             return wrapOptions.errorHandler.onResponseError(url, wrapOptions, response);
         } else {
             let handler = wrapOptions.responseHandler;
@@ -231,7 +231,7 @@ class HttpClient {
         }
     }
 
-    static async setDeclarativeNetRequestRules(RulesArray){
+    static async setDeclarativeNetRequestRules(RulesArray) {
         let url = chrome.runtime.getURL("").split("/").filter(a => a != "");
         let id = url[url.length - 1];
         for (let i = 0; i < RulesArray.length; i++) {
@@ -266,7 +266,7 @@ class HttpClient {
             let cookies = "";
             if (!util.isFirefox()) {
                 cookies = await chrome.cookies.getAll({domain: urlparts[urlparts.length-2]+"."+urlparts[urlparts.length-1],partitionKey: {}});
-            }else{
+            } else {
                 cookies = await browser.cookies.getAll({domain: urlparts[urlparts.length-2]+"."+urlparts[urlparts.length-1],partitionKey: {}});
             }
             cookies = cookies.filter(item => item.partitionKey != undefined);

--- a/plugin/js/ImageCollector.js
+++ b/plugin/js/ImageCollector.js
@@ -22,7 +22,7 @@ class ImageCollector {
         return {
             coverImageInfo: null,
             imagesToPackInEpub: function() { return []; }
-        }
+        };
     }
 
     reset() {
@@ -64,7 +64,7 @@ class ImageCollector {
             } else {
                 this.imagesToFetch.push(imageInfo);
             }
-        };           
+        }           
         this.urlIndex.set(wrappingUrl, index);
         this.urlIndex.set(sourceUrl, index);
         if (dataOrigFileUrl != null) {
@@ -82,10 +82,10 @@ class ImageCollector {
             let info = that.imageInfoByUrl(url);
             if (info === null) {
                 info = that.addImageInfo(url, url, null, true);
-            };
+            }
             info.isCover = true;
             that.coverImageInfo = info;
-        };
+        }
     }
 
     imageInfoByUrl(url) {
@@ -102,7 +102,7 @@ class ImageCollector {
     }
 
     async fetchImages(progressIndicator, parentPageUrl) {
-        for(let imageInfo of this.imagesToFetch) {
+        for (let imageInfo of this.imagesToFetch) {
             if (!imageInfo.queuedForFetch) {
                 imageInfo.queuedForFetch = true;
                 await this.fetchImage(imageInfo, progressIndicator, parentPageUrl);
@@ -125,12 +125,12 @@ class ImageCollector {
         } else {
             // duplicate bitmap, use previous version
             let wrongIndex = imageInfo.index;
-            for(let [key, value] of that.urlIndex) {
+            for (let [key, value] of that.urlIndex) {
                 if (value === wrongIndex) {
                     that.urlIndex.set(key, index);
-                };
-            };
-        };
+                }
+            }
+        }
     }
 
     /**
@@ -140,7 +140,7 @@ class ImageCollector {
         let hash = 0;
         let byteArray = new Uint8Array(arraybuffer);
         if (byteArray.length !== 0) {
-            for(let i = 0; i < byteArray.length; ++i) {
+            for (let i = 0; i < byteArray.length; ++i) {
                 hash = ((hash << 5) - hash) + byteArray[i];
                 hash |= 0;
             }
@@ -219,19 +219,19 @@ class ImageCollector {
     }
 
     findImagesUsedInDocument(content) {
-        for(let imageElement of content.querySelectorAll("img")) {
+        for (let imageElement of content.querySelectorAll("img")) {
             this.fixLazyLoadImageSource(imageElement);
             let src = this.findHighestResImage(imageElement);
             let wrappingElement = this.findImageWrappingElement(imageElement);
             let wrappingUrl = this.extractWrappingUrl(wrappingElement);
             let existing = this.imageInfoByUrl(wrappingUrl);
-            if(existing == null){
+            if (existing == null) {
                 let dataOrigFileUrl = this.findDataOrigFileUrl(imageElement, wrappingUrl);
                 this.addImageInfo(wrappingUrl, src, dataOrigFileUrl, false);
             } else {
                 existing.isOutsideGallery = true;
-            };
-        };
+            }
+        }
     }
 
     findHighestResImage(img) {
@@ -251,7 +251,7 @@ class ImageCollector {
         let pairs = srcset.split(",")
             .map(o => o.trim().split(" "))
             .filter(o => (o.length == 2) && o[0].startsWith("http"));
-        for(let pair of pairs) {
+        for (let pair of pairs) {
             let size = parseInt(pair[1]);
             if (max < size) {
                 max = size;
@@ -262,7 +262,7 @@ class ImageCollector {
     }
 
     fixLazyLoadImageSource(img) {
-        for(let attrib of ["data-lazy-srcset", "data-srcset"]) {
+        for (let attrib of ["data-lazy-srcset", "data-srcset"]) {
             let lazySrcset = img.getAttribute(attrib);
             if (lazySrcset != null) {
                 img.setAttribute("srcset", lazySrcset);
@@ -270,7 +270,7 @@ class ImageCollector {
             }
         }
 
-        for(let attrib of ["data-lazy-src", "data-src"]) {
+        for (let attrib of ["data-lazy-src", "data-src"]) {
             let lazySrc = img.getAttribute(attrib);
             if (lazySrc != null) {
                 img.src = lazySrc;
@@ -283,7 +283,7 @@ class ImageCollector {
     findDataOrigFileUrl(imageElement, wrappingUrl) {
         let dataOrigFile = imageElement.getAttribute("data-orig-file");
         if ((dataOrigFile != null) && (dataOrigFile != imageElement.src)
-            && (dataOrigFile != wrappingUrl)){
+            && (dataOrigFile != wrappingUrl)) {
             let baseUrl = imageElement.ownerDocument.baseURI;
             return util.resolveRelativeUrl(baseUrl, dataOrigFile);
         }
@@ -296,14 +296,14 @@ class ImageCollector {
     replaceImageTags(element) {
         let that = this;
         let converters = [];
-        for(let currentNode of element.querySelectorAll("img")) {
+        for (let currentNode of element.querySelectorAll("img")) {
             converters.push(that.makeImageTagReplacer(currentNode));
-        };
+        }
         converters.forEach(c => c.replaceTag(that.imageInfoByUrl(c.wrappingUrl)));
     }
 
     getImageDimensions(imageInfo) {
-        return new Promise(function(resolve, reject){ // eslint-disable-line no-unused-vars
+        return new Promise(function(resolve, reject) { // eslint-disable-line no-unused-vars
             let img = new Image();
             let options = {type: imageInfo.mediaType};
             let blob = new Blob([new Uint8Array(imageInfo.arraybuffer)], options);
@@ -313,14 +313,14 @@ class ImageCollector {
                 imageInfo.width = img.width;
                 URL.revokeObjectURL(dataUrl);
                 resolve(img);
-            }
-            img.onerror = function(){
+            };
+            img.onerror = function() {
                 // If the image gives an error then set a general height and width
                 imageInfo.height = 1200;
                 imageInfo.width = 1600;
                 URL.revokeObjectURL(dataUrl);
                 reject(img);
-            }
+            };
             // start downloading image after event handlers are set
             img.src = dataUrl;
         });
@@ -328,7 +328,7 @@ class ImageCollector {
 
     runCompression(imageInfo, img) {
         var that = this;
-        return new Promise(function(resolve, reject){
+        return new Promise(function(resolve, reject) {
             if (that.userPreferences.compressImages.value) 
             {
                 let c = document.createElement("canvas");
@@ -388,7 +388,7 @@ class ImageCollector {
                 await this.runCompression(imageInfo, img);
             }
             progressIndicator();
-            this.addToPackList(imageInfo)
+            this.addToPackList(imageInfo);
         }
         catch (error)
         {
@@ -517,7 +517,7 @@ class ImageCollector {
 
     static replaceHyperlinksToImagesWithImages(content, parentPageUrl) {
         let toReplace = util.getElements(content, "a", ImageCollector.isHyperlinkToImage);
-        for(let hyperlink of toReplace.filter(h => !ImageCollector.linkContainsImageTag(h))) {
+        for (let hyperlink of toReplace.filter(h => !ImageCollector.linkContainsImageTag(h))) {
             ImageCollector.replaceHyperlinkWithImg(hyperlink);
         }
         return Imgur.expandGalleries(content, parentPageUrl);
@@ -565,7 +565,7 @@ class VariableSizeImageCollector extends ImageCollector {
             this.initialUrlToTry = (imageInfo) => imageInfo.wrappingUrl;
         } else {
             this.initialUrlToTry = (imageInfo) => imageInfo.sourceUrl;
-        };
+        }
     }
 }
 
@@ -597,8 +597,8 @@ class ImageTagReplacer {
                 that.wrappingElement.remove();
             } else {
                 that.insertImageInLegalParent(parent, imageInfo);
-            };
-        };
+            }
+        }
     }
 
     /** @private */
@@ -614,7 +614,7 @@ class ImageTagReplacer {
     isImageInline(imageInfo) {
         const MAX_INLINE_IMAGE_HEIGHT = 200;
         let parent = this.wrappingElement;
-        while((parent != null) && util.isInlineElement(parent)) {
+        while ((parent != null) && util.isInlineElement(parent)) {
             parent = parent.parentNode;
         }
         return this.isParagraph(parent) &&
@@ -624,7 +624,7 @@ class ImageTagReplacer {
 
     /** @private */
     isParagraph(element) {
-        return (element != null) && (element.tagName.toLowerCase() === "p")
+        return (element != null) && (element.tagName.toLowerCase() === "p");
     }
 
     /** @private */
@@ -640,10 +640,10 @@ class ImageTagReplacer {
         while (util.isInlineElement(parent) && (parent.parentNode != null)) {
             nodeAfter = parent;
             parent = parent.parentNode;
-        };
+        }
         if (this.isParagraph(parent)) {
             nodeAfter = parent;
-        };
+        }
         let newImage = imageInfo.createImageElement(this.userPreferences);
         nodeAfter.parentNode.insertBefore(newImage, nodeAfter);
         util.removeHeightAndWidthStyleFromParents(newImage);
@@ -653,8 +653,8 @@ class ImageTagReplacer {
 
     copyCaption(newImage, oldWrapper) {
         let thumbCaption = oldWrapper.querySelector("div.thumbcaption");
-        if (thumbCaption != null){
-            for(let magnify of thumbCaption.querySelectorAll("div.magnify")){
+        if (thumbCaption != null) {
+            for (let magnify of thumbCaption.querySelectorAll("div.magnify")) {
                 magnify.remove();
             }
             if (!util.isNullOrEmpty(thumbCaption.textContent)) {

--- a/plugin/js/Imgur.js
+++ b/plugin/js/Imgur.js
@@ -9,21 +9,21 @@ class Imgur {
 
     static expandGalleries(content, parentPageUrl) {
         let sequence = Promise.resolve();
-        for(let link of Imgur.getGalleryLinksToReplace(content)) {
-            sequence = sequence.then(function () {
+        for (let link of Imgur.getGalleryLinksToReplace(content)) {
+            sequence = sequence.then(function() {
                 let href = Imgur.fixupImgurGalleryUrl(link.href);
-                return HttpClient.wrapFetch(href).then(function (xhr) {
+                return HttpClient.wrapFetch(href).then(function(xhr) {
                     Imgur.replaceGalleryHyperlinkWithImages(link, xhr.responseXML);
                     return Promise.resolve();
-                }).catch(function (err) {
+                }).catch(function(err) {
                     let errorMsg = chrome.i18n.getMessage("imgurFetchFailed", 
                         [link.href, parentPageUrl, err]);
                     ErrorLog.log(errorMsg);
                     return Promise.resolve();
                 });
-            })
-        };
-        sequence = sequence.then(function () {
+            });
+        }
+        sequence = sequence.then(function() {
             return Promise.resolve(content);
         });
         return sequence; 
@@ -47,12 +47,12 @@ class Imgur {
         let doc = document.implementation.createHTMLDocument();
         let div = doc.createElement("div");
         doc.body.appendChild(div);
-        for(let item of imagesList) {
+        for (let item of imagesList) {
             let img = doc.createElement("img");
             // ToDo: use real image to build URI
             img.src = "http://i.imgur.com/" + item.hash + item.ext;
             div.appendChild(img);
-        };
+        }
         return div;
     }
 
@@ -70,12 +70,12 @@ class Imgur {
     static findImagesJson(dom) {
         // Ugly hack, need to find the list of images as image links are created dynamically in HTML.
         // Obviously this will break each time imgur change their scripts.
-        for(let text of Imgur.scriptsWithRunSlots(dom)) {
+        for (let text of Imgur.scriptsWithRunSlots(dom)) {
             let json = util.locateAndExtractJson(text, "item:");
             if (json != null) {
                 return json;
             }
-        };
+        }
         return null;
     }
 

--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -13,7 +13,7 @@ class Library {
         Library.userPreferences = userPreferences;
     }
     
-    async LibAddToLibrary(AddEpub, fileName, startingUrlInput, overwriteExisting, backgroundDownload){
+    async LibAddToLibrary(AddEpub, fileName, startingUrlInput, overwriteExisting, backgroundDownload) {
         Library.LibShowLoadingText();
         if (document.getElementById("includeInReadingListCheckbox").checked != true) {
             document.getElementById("includeInReadingListCheckbox").click();
@@ -31,7 +31,7 @@ class Library {
             Library.LibHandelUpdate(-1, AddEpub, document.getElementById("startingUrlInput").value, fileName.replace(".epub", ""), LibidURL);
             if (document.getElementById("LibDownloadEpubAfterUpdateCheckbox").checked) {
                 return Download.save(AddEpub, fileName, overwriteExisting, backgroundDownload);
-            }else{
+            } else {
                 return new Promise((resolve) => {resolve();});
             }
         }
@@ -47,17 +47,17 @@ class Library {
                 return;
             }
             return Download.save(MergedEpub, fileName, overwriteExisting, backgroundDownload);
-        }else{
+        } else {
             return new Promise((resolve) => {resolve();});
         }
     }
 
-    static LibHighestFileNumber(Content, Regex, String){
+    static LibHighestFileNumber(Content, Regex, String) {
         let array = Content.map(a => a = a.filename).filter(a => a.match(Regex)).map(a => a = parseInt(a.substring(String.length, String.length + 4)));
         return Math.max(...array);
     }
 
-    static async LibMergeEpub(PreviousEpubBase64, AddEpubBlob, LibidURL){
+    static async LibMergeEpub(PreviousEpubBase64, AddEpubBlob, LibidURL) {
         Library.LibShowLoadingText();
 
         let PreviousEpubReader = await new zip.Data64URIReader(PreviousEpubBase64);
@@ -73,7 +73,7 @@ class Library {
         let MergedEpubWriter = new zip.BlobWriter("application/epub+zip");
         let MergedEpubZip = new zip.ZipWriter(MergedEpubWriter,{useWebWorkers: false,compressionMethod: 8, extendedTimestamp: false});
         //Copy PreviousEpub in MergedEpub
-        for (let element of PreviousEpubContent.filter(a => a.filename != "OEBPS/content.opf" && a.filename != "OEBPS/toc.ncx" && a.filename != "OEBPS/toc.xhtml")){
+        for (let element of PreviousEpubContent.filter(a => a.filename != "OEBPS/content.opf" && a.filename != "OEBPS/toc.ncx" && a.filename != "OEBPS/toc.xhtml")) {
             if (element.filename == "mimetype") {
                 MergedEpubZip.add(element.filename, new zip.TextReader(await element.getData(new zip.TextWriter())), {compressionMethod: 0});
                 continue;
@@ -197,15 +197,15 @@ class Library {
         return content;
     }
 
-    static LibManipulateContentFromTO(ContentFrom = "", ContentTo = "", regexFrom1 = "", stringTo1 = "", regexFrom2 = "", stringTo2 = "", regexFrom3 = "", stringTo3 = "", regexFrom4 = "", stringTo4 = ""){
+    static LibManipulateContentFromTO(ContentFrom = "", ContentTo = "", regexFrom1 = "", stringTo1 = "", regexFrom2 = "", stringTo2 = "", regexFrom3 = "", stringTo3 = "", regexFrom4 = "", stringTo4 = "") {
         return ContentTo.replace(stringTo1, ContentFrom.match(regexFrom1)[0].replace(regexFrom2, stringTo2).replace(regexFrom3, stringTo3).replace(regexFrom4, stringTo4)+stringTo1);
     }
 
     static async LibSaveCoverImgInStorage(idfromepub) {
         return new Promise((resolve) => {
             chrome.storage.local.get("LibEpub" + idfromepub, async function(items, ) {
-                try{
-                    let EpubReader = await new zip.Data64URIReader(items["LibEpub" + idfromepub])
+                try {
+                    let EpubReader = await new zip.Data64URIReader(items["LibEpub" + idfromepub]);
                     let EpubZip = new zip.ZipReader(EpubReader, {useWebWorkers: false});
                     let EpubContent =  await EpubZip.getEntries();
                     EpubContent = EpubContent.filter(a => a.directory == false);
@@ -236,7 +236,7 @@ class Library {
         });
     }
 
-    static Libdeleteall(){
+    static Libdeleteall() {
         Library.LibShowLoadingText();
         chrome.storage.local.get(null, async function(items) {
             let CurrentLibKeys = await Library.LibGetAllLibStorageKeys("LibEpub", Object.keys(items));
@@ -255,7 +255,7 @@ class Library {
         });
     }
 
-    static async LibChangeOrder(libepubid, change){
+    static async LibChangeOrder(libepubid, change) {
         let LibArray = [];
         LibArray = await Library.LibGetFromStorage("LibArray");
         for (let i = 0; i < LibArray.length; i++) {
@@ -275,15 +275,15 @@ class Library {
         Library.LibRenderSavedEpubs();
     }
 
-    static LibChangeOrderUp(objbtn){
+    static LibChangeOrderUp(objbtn) {
         Library.LibChangeOrder(objbtn.dataset.libepubid, -1);
     }
 
-    static LibChangeOrderDown(objbtn){
+    static LibChangeOrderDown(objbtn) {
         Library.LibChangeOrder(objbtn.dataset.libepubid, 1);
     }
 
-    static async LibCreateStorageIDs(AppendID){
+    static async LibCreateStorageIDs(AppendID) {
         let LibArray = [];
         if (AppendID == undefined) {
             let CurrentLibKeys = await Library.LibGetAllLibStorageKeys("LibEpub");
@@ -302,7 +302,7 @@ class Library {
         });
     }
 
-    static async LibRemoveStorageIDs(RemoveID){
+    static async LibRemoveStorageIDs(RemoveID) {
         let LibArray = await Library.LibGetFromStorage("LibArray");
         if (LibArray == undefined) {
             await Library.LibCreateStorageIDs();
@@ -314,7 +314,7 @@ class Library {
         });
     }
 
-    static async LibGetStorageIDs(){
+    static async LibGetStorageIDs() {
         let LibArray = await Library.LibGetFromStorage("LibArray");
         if (LibArray == undefined) {
             await Library.LibCreateStorageIDs();
@@ -323,7 +323,7 @@ class Library {
         return LibArray;
     }
 
-    static async LibRenderSavedEpubs(){
+    static async LibRenderSavedEpubs() {
         let LibArray = await Library.LibGetStorageIDs();
         let ShowAdvancedOptions = document.getElementById("LibShowAdvancedOptionsCheckbox").checked;
         let ShowCompactView = document.getElementById("LibShowCompactViewCheckbox").checked;
@@ -397,9 +397,9 @@ class Library {
             LibRenderString += "</table>";
             LibRenderString += "</div>";
             Library.AppendHtmlInDiv(LibRenderString, LibRenderResult, "LibDivRenderWraper");
-            document.getElementById("libupdateall").addEventListener("click", function(){Library.Libupdateall()});
+            document.getElementById("libupdateall").addEventListener("click", function() {Library.Libupdateall();});
             for (let i = 0; i < CurrentLibKeys.length; i++) {
-                document.getElementById("LibCover"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibDownload(this)});
+                document.getElementById("LibCover"+CurrentLibKeys[i]).addEventListener("click", function() {Library.LibDownload(this);});
             }
             for (let i = 0; i < CurrentLibKeys.length; i++) {
                 document.getElementById("LibCover"+CurrentLibKeys[i]).src = await Library.LibGetFromStorage("LibCover" + CurrentLibKeys[i]);
@@ -463,34 +463,34 @@ class Library {
             }
             LibRenderString += "</div>";
             Library.AppendHtmlInDiv(LibRenderString, LibRenderResult, "LibDivRenderWraper");
-            document.getElementById("libupdateall").addEventListener("click", function(){Library.Libupdateall()});
+            document.getElementById("libupdateall").addEventListener("click", function() {Library.Libupdateall();});
             if (ShowAdvancedOptions) {
-                document.getElementById("libdeleteall").addEventListener("click", function(){Library.Libdeleteall()});
-                document.getElementById("libexportall").addEventListener("click", function(){Library.Libexportall()});
-                document.getElementById("LibImportLibraryLabel").addEventListener("mouseover", function(){Library.LibMouseoverButtonUpload(this)});
-                document.getElementById("LibImportLibraryLabel").addEventListener("mouseout", function(){Library.LibMouseoutButtonUpload(this)});
-                document.getElementById("LibImportLibraryFile").addEventListener("change", function(){Library.LibHandelImport(this)});
-                document.getElementById("LibUploadEpubLabel").addEventListener("mouseover", function(){Library.LibMouseoverButtonUpload(this)});
-                document.getElementById("LibUploadEpubLabel").addEventListener("mouseout", function(){Library.LibMouseoutButtonUpload(this)});
-                document.getElementById("LibEpubNewUploadFile").addEventListener("change", function(){Library.LibHandelUpdate(this, -1, "", "", -1)});
-                document.getElementById("LibAddListToLibraryButton").addEventListener("click", function(){Library.LibAddListToLibrary()});
+                document.getElementById("libdeleteall").addEventListener("click", function() {Library.Libdeleteall();});
+                document.getElementById("libexportall").addEventListener("click", function() {Library.Libexportall();});
+                document.getElementById("LibImportLibraryLabel").addEventListener("mouseover", function() {Library.LibMouseoverButtonUpload(this);});
+                document.getElementById("LibImportLibraryLabel").addEventListener("mouseout", function() {Library.LibMouseoutButtonUpload(this);});
+                document.getElementById("LibImportLibraryFile").addEventListener("change", function() {Library.LibHandelImport(this);});
+                document.getElementById("LibUploadEpubLabel").addEventListener("mouseover", function() {Library.LibMouseoverButtonUpload(this);});
+                document.getElementById("LibUploadEpubLabel").addEventListener("mouseout", function() {Library.LibMouseoutButtonUpload(this);});
+                document.getElementById("LibEpubNewUploadFile").addEventListener("change", function() {Library.LibHandelUpdate(this, -1, "", "", -1);});
+                document.getElementById("LibAddListToLibraryButton").addEventListener("click", function() {Library.LibAddListToLibrary();});
             }
             for (let i = 0; i < CurrentLibKeys.length; i++) {
-                document.getElementById("LibDeleteEpub"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibDeleteEpub(this)});
-                document.getElementById("LibUpdateNewChapter"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibUpdateNewChapter(this)});
-                document.getElementById("LibDownload"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibDownload(this)});
-                document.getElementById("LibStoryURL"+CurrentLibKeys[i]).addEventListener("change", function(){Library.LibSaveTextURLChange(this)});
-                document.getElementById("LibStoryURL"+CurrentLibKeys[i]).addEventListener("focusin", function(){Library.LibShowTextURLWarning(this)});
-                document.getElementById("LibStoryURL"+CurrentLibKeys[i]).addEventListener("focusout", function(){Library.LibHideTextURLWarning(this)});
-                document.getElementById("LibFilename"+CurrentLibKeys[i]).addEventListener("change", function(){Library.LibSaveTextURLChange(this)});
+                document.getElementById("LibDeleteEpub"+CurrentLibKeys[i]).addEventListener("click", function() {Library.LibDeleteEpub(this);});
+                document.getElementById("LibUpdateNewChapter"+CurrentLibKeys[i]).addEventListener("click", function() {Library.LibUpdateNewChapter(this);});
+                document.getElementById("LibDownload"+CurrentLibKeys[i]).addEventListener("click", function() {Library.LibDownload(this);});
+                document.getElementById("LibStoryURL"+CurrentLibKeys[i]).addEventListener("change", function() {Library.LibSaveTextURLChange(this);});
+                document.getElementById("LibStoryURL"+CurrentLibKeys[i]).addEventListener("focusin", function() {Library.LibShowTextURLWarning(this);});
+                document.getElementById("LibStoryURL"+CurrentLibKeys[i]).addEventListener("focusout", function() {Library.LibHideTextURLWarning(this);});
+                document.getElementById("LibFilename"+CurrentLibKeys[i]).addEventListener("change", function() {Library.LibSaveTextURLChange(this);});
                 if (ShowAdvancedOptions) {
-                    document.getElementById("LibChangeOrderUp"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibChangeOrderUp(this)});
-                    document.getElementById("LibChangeOrderDown"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibChangeOrderDown(this)});
-                    document.getElementById("LibMergeUpload"+CurrentLibKeys[i]).addEventListener("change", function(){Library.LibMergeUpload(this)});
-                    document.getElementById("LibMergeUploadLabel"+CurrentLibKeys[i]).addEventListener("mouseover", function(){Library.LibMouseoverButtonUpload(this)});
-                    document.getElementById("LibMergeUploadLabel"+CurrentLibKeys[i]).addEventListener("mouseout", function(){Library.LibMouseoutButtonUpload(this)});
-                    document.getElementById("LibSearchNewChapter"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibSearchNewChapter(this)});
-                    document.getElementById("LibEditMetadata"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibEditMetadata(this)});
+                    document.getElementById("LibChangeOrderUp"+CurrentLibKeys[i]).addEventListener("click", function() {Library.LibChangeOrderUp(this);});
+                    document.getElementById("LibChangeOrderDown"+CurrentLibKeys[i]).addEventListener("click", function() {Library.LibChangeOrderDown(this);});
+                    document.getElementById("LibMergeUpload"+CurrentLibKeys[i]).addEventListener("change", function() {Library.LibMergeUpload(this);});
+                    document.getElementById("LibMergeUploadLabel"+CurrentLibKeys[i]).addEventListener("mouseover", function() {Library.LibMouseoverButtonUpload(this);});
+                    document.getElementById("LibMergeUploadLabel"+CurrentLibKeys[i]).addEventListener("mouseout", function() {Library.LibMouseoutButtonUpload(this);});
+                    document.getElementById("LibSearchNewChapter"+CurrentLibKeys[i]).addEventListener("click", function() {Library.LibSearchNewChapter(this);});
+                    document.getElementById("LibEditMetadata"+CurrentLibKeys[i]).addEventListener("click", function() {Library.LibEditMetadata(this);});
                 }
             }
             for (let i = 0; i < CurrentLibKeys.length; i++) {
@@ -511,12 +511,12 @@ class Library {
         }
     }
 
-    static LibMouseoverButtonUpload(objbtn){
+    static LibMouseoverButtonUpload(objbtn) {
         let i,j, sel = /button:hover/, aProperties = [];
-        for(i = 0; i < document.styleSheets.length; ++i){
-            if(document.styleSheets[i]. cssRules !== null) {
-                for(j = 0; j < document.styleSheets[i].cssRules.length; ++j){    
-                    if(sel.test(document.styleSheets[i].cssRules[j].selectorText)){
+        for (i = 0; i < document.styleSheets.length; ++i) {
+            if (document.styleSheets[i]. cssRules !== null) {
+                for (j = 0; j < document.styleSheets[i].cssRules.length; ++j) {    
+                    if (sel.test(document.styleSheets[i].cssRules[j].selectorText)) {
                         aProperties.push(document.styleSheets[i].cssRules[j].style.cssText);
                     }
                 }
@@ -526,11 +526,11 @@ class Library {
         document.getElementById(objbtn.dataset.libbuttonid+objbtn.dataset.libepubid).style.cssText = aProperties.join(" ");
     }
 
-    static LibMouseoutButtonUpload(objbtn){
+    static LibMouseoutButtonUpload(objbtn) {
         document.getElementById(objbtn.dataset.libbuttonid+objbtn.dataset.libepubid).style.cssText ="pointer-events: none;";
     }
     
-    static async LibBytesInUse(){
+    static async LibBytesInUse() {
         return new Promise((resolve) => {
             chrome.storage.local.getBytesInUse(null, function(BytesInUse) {
                 resolve(Library.LibCalcBytesToReadable(BytesInUse) + "Bytes");
@@ -538,26 +538,26 @@ class Library {
         });
     }
 
-    static LibCalcBytesToReadable(bytes){
+    static LibCalcBytesToReadable(bytes) {
         let units = ["", "K", "M", "G", "T", "P", "E", "Z", "Y"];
         let l = 0, n = parseInt(bytes, 10) || 0;
-        while(n >= 1024 && ++l){
+        while (n >= 1024 && ++l) {
             n = n/1024;
         }
-        return(n.toFixed(n < 10 && l > 0 ? 1 : 0) + " " + units[l]);
+        return (n.toFixed(n < 10 && l > 0 ? 1 : 0) + " " + units[l]);
     }
 
-    static LibMergeUploadButton(objbtn){
+    static LibMergeUploadButton(objbtn) {
         document.getElementById("LibMergeUpload"+objbtn.dataset.libepubid).click();
     }
     
-    static async LibMergeUpload(objbtn){
+    static async LibMergeUpload(objbtn) {
         let PreviousEpubBase64 = await Library.LibGetFromStorage("LibEpub" + objbtn.dataset.libepubid);
         let AddEpubBlob = objbtn.files[0];
         Library.LibMergeEpub(PreviousEpubBase64, AddEpubBlob, objbtn.dataset.libepubid);
     }
     
-    static async LibEditMetadata(objbtn){
+    static async LibEditMetadata(objbtn) {
         let LibTemplateMetadataSave = document.getElementById("LibTemplateMetadataSave").innerHTML;
         let LibTemplateMetadataTitle = document.getElementById("LibTemplateMetadataTitle").innerHTML;
         let LibTemplateMetadataAuthor = document.getElementById("LibTemplateMetadataAuthor").innerHTML;
@@ -602,10 +602,10 @@ class Library {
         LibRenderString += "</table>";
         LibRenderString += "</div>";
         Library.AppendHtmlInDiv(LibRenderString, LibRenderResult, "LibDivRenderWraper");
-        document.getElementById("LibMetadataSave"+objbtn.dataset.libepubid).addEventListener("click", function(){Library.LibSaveMetadataChange(this)});
+        document.getElementById("LibMetadataSave"+objbtn.dataset.libepubid).addEventListener("click", function() {Library.LibSaveMetadataChange(this);});
     }
 
-    static async LibSaveMetadataChange(obj){
+    static async LibSaveMetadataChange(obj) {
         let LibTitleInput = document.getElementById("LibTitleInput"+obj.dataset.libepubid).value;
         let LibAutorInput = document.getElementById("LibAutorInput"+obj.dataset.libepubid).value;
         let LibLanguageInput = document.getElementById("LibLanguageInput"+obj.dataset.libepubid).value;
@@ -614,7 +614,7 @@ class Library {
         Library.LibShowLoadingText();
         let LibDateCreated = new EpubPacker().getDateForMetaData();
         try {
-            let EpubReader = await new zip.Data64URIReader(await Library.LibGetFromStorage("LibEpub"+obj.dataset.libepubid))
+            let EpubReader = await new zip.Data64URIReader(await Library.LibGetFromStorage("LibEpub"+obj.dataset.libepubid));
             let EpubZipRead = new zip.ZipReader(EpubReader, {useWebWorkers: false});
             let EpubContent =  await EpubZipRead.getEntries();
             EpubContent = EpubContent.filter(a => a.directory == false);
@@ -623,7 +623,7 @@ class Library {
             let EpubWriter = new zip.BlobWriter("application/epub+zip");
             let EpubZipWrite = new zip.ZipWriter(EpubWriter,{useWebWorkers: false,compressionMethod: 8});
             //Copy Epub in NewEpub
-            for (let element of EpubContent.filter(a => a.filename != "OEBPS/content.opf")){
+            for (let element of EpubContent.filter(a => a.filename != "OEBPS/content.opf")) {
                 EpubZipWrite.add(element.filename, new zip.BlobReader(await element.getData(new zip.BlobWriter())));
             }
             
@@ -653,8 +653,8 @@ class Library {
     
     static async LibGetMetadata(libepubid) {
         let LibMetadata = [];
-        try{
-            let EpubReader = await new zip.Data64URIReader(await Library.LibGetFromStorage("LibEpub"+libepubid))
+        try {
+            let EpubReader = await new zip.Data64URIReader(await Library.LibGetFromStorage("LibEpub"+libepubid));
             let EpubZip = new zip.ZipReader(EpubReader, {useWebWorkers: false});
             let EpubContent =  await EpubZip.getEntries();
             let opfFile = await EpubContent.filter(a => a.filename == "OEBPS/content.opf")[0].getData(new zip.TextWriter());
@@ -668,12 +668,12 @@ class Library {
                 }
             });
             return LibMetadata;
-        }catch {
+        } catch {
             return LibMetadata;
         }
     }
 
-    static LibShowLoadingText(){
+    static LibShowLoadingText() {
         let LibRenderResult = document.getElementById("LibRenderResult");
         let LibRenderString = "";
         LibRenderString += "<div class='LibDivRenderWraper'>";
@@ -684,7 +684,7 @@ class Library {
         Library.AppendHtmlInDiv(LibRenderString, LibRenderResult, "LibDivRenderWraper");
     }
 
-    static async LibHandelUpdate(objbtn, Blobdata, StoryURL, Filename, Id, NewChapterCount){
+    static async LibHandelUpdate(objbtn, Blobdata, StoryURL, Filename, Id, NewChapterCount) {
         Library.LibShowLoadingText();
         Library.LibFileReaderAddListeners();
         if (objbtn != -1) {
@@ -701,7 +701,7 @@ class Library {
         LibFileReader.readAsDataURL(Blobdata);
     }
 
-    static async LibFileReaderload(){
+    static async LibFileReaderload() {
         if (-1 == LibFileReader.LibStorageValueId) {
             let CurrentLibKeys = await Library.LibGetAllLibStorageKeys("LibEpub");
             let HighestLibEpub = 0;
@@ -737,13 +737,13 @@ class Library {
     }
     
     static async LibGetSourceURL(EpubAsDataURL) {
-        try{
-            let EpubReader = await new zip.Data64URIReader(EpubAsDataURL)
+        try {
+            let EpubReader = await new zip.Data64URIReader(EpubAsDataURL);
             let EpubZip = new zip.ZipReader(EpubReader, {useWebWorkers: false});
             let EpubContent =  await EpubZip.getEntries();
             let opfFile = await EpubContent.filter(a => a.filename == "OEBPS/content.opf")[0].getData(new zip.TextWriter());
             return (opfFile.match(/<dc:identifier id="BookId" opf:scheme="URI">.+?<\/dc:identifier>/)[0].replace(/<dc:identifier id="BookId" opf:scheme="URI">/,"").replace(/<\/dc:identifier>/,""));
-        }catch {
+        } catch {
             return "Paste URL here!";
         }
     }
@@ -769,7 +769,7 @@ class Library {
             let BlobEpubWriter = new zip.BlobWriter("application/epub+zip");
             let BlobEpubZip = new zip.ZipWriter(BlobEpubWriter,{useWebWorkers: false,compressionMethod: 8});
             //Copy Base64Epub in BlobEpub
-            for (let element of Base64EpubContent){
+            for (let element of Base64EpubContent) {
                 if (element.filename == "mimetype") {
                     BlobEpubZip.add(element.filename, new zip.TextReader(await element.getData(new zip.TextWriter())), {compressionMethod: 0});
                     continue;
@@ -779,21 +779,21 @@ class Library {
             retblob = await BlobEpubZip.close();
         }
         return retblob;
-    };
-
-    static LibFileReaderAddListeners(){
-        LibFileReader.removeEventListener("load", Library.LibFileReaderloadImport);
-        LibFileReader.removeEventListener("error", function(event){Library.LibFileReadererror(event)});
-        LibFileReader.removeEventListener("abort", function(event){Library.LibFileReaderabort(event)});
-        LibFileReader.addEventListener("load", Library.LibFileReaderload);
-        LibFileReader.addEventListener("error", function(event){Library.LibFileReadererror(event)});
-        LibFileReader.addEventListener("abort", function(event){Library.LibFileReaderabort(event)});
     }
 
-    static LibFileReadererror(event){ErrorLog.showErrorMessage(event);}
-    static LibFileReaderabort(event){ErrorLog.showErrorMessage(event);}
+    static LibFileReaderAddListeners() {
+        LibFileReader.removeEventListener("load", Library.LibFileReaderloadImport);
+        LibFileReader.removeEventListener("error", function(event) {Library.LibFileReadererror(event);});
+        LibFileReader.removeEventListener("abort", function(event) {Library.LibFileReaderabort(event);});
+        LibFileReader.addEventListener("load", Library.LibFileReaderload);
+        LibFileReader.addEventListener("error", function(event) {Library.LibFileReadererror(event);});
+        LibFileReader.addEventListener("abort", function(event) {Library.LibFileReaderabort(event);});
+    }
+
+    static LibFileReadererror(event) {ErrorLog.showErrorMessage(event);}
+    static LibFileReaderabort(event) {ErrorLog.showErrorMessage(event);}
     
-    static async LibDeleteEpub(objbtn){
+    static async LibDeleteEpub(objbtn) {
         await Library.LibRemoveStorageIDs(objbtn.dataset.libepubid);
         let LibRemove = ["LibEpub" + objbtn.dataset.libepubid, "LibStoryURL" + objbtn.dataset.libepubid, "LibFilename" + objbtn.dataset.libepubid, "LibCover" + objbtn.dataset.libepubid, "LibNewChapterCount" + objbtn.dataset.libepubid];
         Library.userPreferences.readingList.tryDeleteEpubAndSave(document.getElementById("LibStoryURL" + objbtn.dataset.libepubid).value);
@@ -801,7 +801,7 @@ class Library {
         Library.LibRenderSavedEpubs();
     }
 
-    static async LibUpdateNewChapter(objbtn){
+    static async LibUpdateNewChapter(objbtn) {
         let LibGetURL = ["LibStoryURL" + objbtn.dataset.libepubid];
         Library.LibClearFields();
         let obj = {};
@@ -820,7 +820,7 @@ class Library {
         Library.LibClearFields();
     }
 
-    static LibSearchNewChapter(objbtn){
+    static LibSearchNewChapter(objbtn) {
         let LibGetURL = ["LibStoryURL" + objbtn.dataset.libepubid];
         chrome.storage.local.get(LibGetURL, function(items) {
             Library.LibClearFields();
@@ -837,7 +837,7 @@ class Library {
         });
     }
 
-    static LibDownload(objbtn){
+    static LibDownload(objbtn) {
         let LibGetFileAndName = ["LibEpub" + objbtn.dataset.libepubid, "LibFilename" + objbtn.dataset.libepubid];
         chrome.storage.local.get(LibGetFileAndName, async function(items) {
             let userPreferences = UserPreferences.readFromLocalStorage();
@@ -851,11 +851,11 @@ class Library {
         });
     }
 
-    static LibClearFields(){
+    static LibClearFields() {
         main.resetUI();
     }
     
-    static async Libupdateall(){
+    static async Libupdateall() {
         if (document.getElementById("LibDownloadEpubAfterUpdateCheckbox").checked == true) {
             document.getElementById("LibDownloadEpubAfterUpdateCheckbox").click();
         }
@@ -886,7 +886,7 @@ class Library {
         return lines;
     }
     
-    static async LibAddListToLibrary(){
+    static async LibAddListToLibrary() {
         if (document.getElementById("LibDownloadEpubAfterUpdateCheckbox").checked == true) {
             document.getElementById("LibDownloadEpubAfterUpdateCheckbox").click();
         }
@@ -913,7 +913,7 @@ class Library {
         ErrorLog.SuppressErrorLog =  false;
     }
     
-    static Libexportall(){
+    static Libexportall() {
         Library.LibShowLoadingText();
         chrome.storage.local.get(null, async function(items) {
             let CurrentLibKeys = items["LibArray"];
@@ -929,7 +929,7 @@ class Library {
             fileReadingList.ReadingList.epubs = fileReadingList.ReadingList.epubs.filter(a => storyurls.includes(a.toc));
             
             let zipFileWriter = new zip.BlobWriter("application/zip");
-            let zipWriter = new zip.ZipWriter(zipFileWriter,{useWebWorkers: false,compressionMethod: 8});;
+            let zipWriter = new zip.ZipWriter(zipFileWriter,{useWebWorkers: false,compressionMethod: 8});
             //in case for future changes to differntiate between different export versions
             zipWriter.add("LibraryVersion.txt", new zip.TextReader("2"));
             zipWriter.add("LibraryCountEntries.txt", new zip.TextReader(CurrentLibKeys.length));
@@ -947,7 +947,7 @@ class Library {
         });
     }
 
-    static async LibHandelImport(objbtn){
+    static async LibHandelImport(objbtn) {
         Library.LibShowLoadingText();
         Library.LibFileReaderAddListenersImport();
         let Blobdata = objbtn.files[0];
@@ -960,16 +960,16 @@ class Library {
         }
     }
 
-    static LibFileReaderAddListenersImport(){
+    static LibFileReaderAddListenersImport() {
         LibFileReader.removeEventListener("load", Library.LibFileReaderload);
-        LibFileReader.removeEventListener("error", function(event){Library.LibFileReadererror(event)});
-        LibFileReader.removeEventListener("abort", function(event){Library.LibFileReaderabort(event)});
+        LibFileReader.removeEventListener("error", function(event) {Library.LibFileReadererror(event);});
+        LibFileReader.removeEventListener("abort", function(event) {Library.LibFileReaderabort(event);});
         LibFileReader.addEventListener("load", Library.LibFileReaderloadImport);
-        LibFileReader.addEventListener("error", function(event){Library.LibFileReadererror(event)});
-        LibFileReader.addEventListener("abort", function(event){Library.LibFileReaderabort(event)});
+        LibFileReader.addEventListener("error", function(event) {Library.LibFileReadererror(event);});
+        LibFileReader.addEventListener("abort", function(event) {Library.LibFileReaderabort(event);});
     }
 
-    static async LibFileReaderloadImport(){
+    static async LibFileReaderloadImport() {
         let regex = new RegExp("zip$");
         if (!regex.test(LibFileReader.name)) {
             let json = JSON.parse(LibFileReader.result);
@@ -1030,32 +1030,32 @@ class Library {
         }
     }
 
-    static LibSaveTextURLChange(obj){
+    static LibSaveTextURLChange(obj) {
         let LibGetFileAndName = obj.id;
         chrome.storage.local.set({
             [LibGetFileAndName]: obj.value
         });
     }
 
-    static LibShowTextURLWarning(obj){
+    static LibShowTextURLWarning(obj) {
         let LibTemplateWarningURLChange = document.getElementById("LibTemplateWarningURLChange").innerHTML;
         let LibWarningElement = document.getElementById("LibURLWarning"+obj.dataset.libepubid);
         LibWarningElement.innerHTML = "<tr><td style='color:yellow;'></td></tr>";
         LibWarningElement.firstChild.firstChild.textContent = LibTemplateWarningURLChange;
     }
 
-    static LibHideTextURLWarning(obj){
+    static LibHideTextURLWarning(obj) {
         document.getElementById("LibURLWarning"+obj.dataset.libepubid).innerHTML = "<tr><td></td></tr>";
     }
 
-    static async LibGetAllLibStorageKeys(Substring, AllStorageKeysList){
+    static async LibGetAllLibStorageKeys(Substring, AllStorageKeysList) {
         return new Promise((resolve) => {
             if (AllStorageKeysList == undefined) {
-                chrome.storage.local.get(null, function(items){
+                chrome.storage.local.get(null, function(items) {
                     let AllStorageKeys = Object.keys(items);
                     let AllLibStorageKeys = [];
                     for (let i = 0, end = AllStorageKeys.length; i < end; i++) {
-                        if(AllStorageKeys[i].includes(Substring)){
+                        if (AllStorageKeys[i].includes(Substring)) {
                             AllLibStorageKeys.push(AllStorageKeys[i]);
                         }   
                     }
@@ -1064,7 +1064,7 @@ class Library {
             } else {
                 let AllLibStorageKeys = [];
                 for (let i = 0, end = AllStorageKeysList.length; i < end; i++) {
-                    if(AllStorageKeysList[i].includes(Substring)){
+                    if (AllStorageKeysList[i].includes(Substring)) {
                         AllLibStorageKeys.push(AllStorageKeysList[i]);
                     }   
                 }
@@ -1073,23 +1073,23 @@ class Library {
         });
     }
 
-    static async LibGetFromStorageArray(Keys){
+    static async LibGetFromStorageArray(Keys) {
         return new Promise((resolve) => {
-            chrome.storage.local.get(Keys, function(items){
+            chrome.storage.local.get(Keys, function(items) {
                 resolve(items);
             });
         });
     }
 
-    static async LibGetFromStorage(Key){
+    static async LibGetFromStorage(Key) {
         return new Promise((resolve) => {
-            chrome.storage.local.get(Key, function(item){
+            chrome.storage.local.get(Key, function(item) {
                 resolve(item[Key]);
             });
         });
     }
 
-    static AppendHtmlInDiv(HTMLstring, DivObjectInject, DivClassWraper ){
+    static AppendHtmlInDiv(HTMLstring, DivObjectInject, DivClassWraper ) {
         let parsed = util.sanitize(HTMLstring);
         let tags = parsed.getElementsByClassName(DivClassWraper);
         DivObjectInject.innerHTML = "";

--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -38,11 +38,11 @@ class ParserState {
     setPagesToFetch(urls) {
         let nextPrevChapters = new Set();
         this.webPages = new Map();
-        for(let i = 0; i < urls.length; ++i) {
+        for (let i = 0; i < urls.length; ++i) {
             let page = urls[i];
             if (i < urls.length - 1) {
                 nextPrevChapters.add(util.normalizeUrlForCompare(urls[i + 1].sourceUrl));
-            };
+            }
             page.nextPrevChapters = nextPrevChapters;
             this.webPages.set(page.sourceUrl, page);
             nextPrevChapters = new Set();
@@ -75,11 +75,11 @@ class Parser {
     }
     
     //Use this option if the parser isn't sending the correct HTTP header
-    isCustomError(response){  // eslint-disable-line no-unused-vars
+    isCustomError(response) {  // eslint-disable-line no-unused-vars
         return false;
     }
 
-    setCustomErrorResponse(url, wrapOptions, checkedresponse){
+    setCustomErrorResponse(url, wrapOptions, checkedresponse) {
         //example
         let ret = {};
         ret.url = url;
@@ -174,7 +174,7 @@ class Parser {
         util.removeMicrosoftWordCrapElements(element);
         util.removeShareLinkElements(element);
         util.removeLeadingWhiteSpace(element);
-    };
+    }
 
     customRawDomToContentStep(chapter, content) { // eslint-disable-line no-unused-vars
         // override for any custom processing
@@ -201,9 +201,9 @@ class Parser {
                 let cover = content.querySelector("img");
                 if (cover != null) {
                     return cover.src;
-                };
-            };
-        };
+                }
+            }
+        }
         return null;
     }
 
@@ -245,11 +245,11 @@ class Parser {
     static extractTitleDefault(dom) {
         let title = dom.querySelector("meta[property='og:title']");
         return (title === null) ? dom.title : title.getAttribute("content");
-    };
+    }
 
     extractTitleImpl(dom) {
         return Parser.extractTitleDefault(dom);
-    };
+    }
 
     extractTitle(dom) {
         let title = this.extractTitleImpl(dom);
@@ -260,7 +260,7 @@ class Parser {
             title = title.textContent;
         }
         return title.trim();
-    };
+    }
 
     /**
     * default implementation
@@ -308,48 +308,48 @@ class Parser {
     extractSeriesInfo(dom, metaInfo) {  // eslint-disable-line no-unused-vars
     }
 
-    async loadEpubMetaInfo(dom){  // eslint-disable-line no-unused-vars
+    async loadEpubMetaInfo(dom) {  // eslint-disable-line no-unused-vars
         return;
     }
 
-    getEpubMetaInfo(dom, useFullTitle){
+    getEpubMetaInfo(dom, useFullTitle) {
         let that = this;
         let metaInfo = new EpubMetaInfo();
         metaInfo.uuid = dom.baseURI;
         try {
             metaInfo.title = that.extractTitle(dom);
         }
-        catch(err) {
+        catch (err) {
             metaInfo.title = "";
         }
         try {
             metaInfo.author = that.extractAuthor(dom).trim();
         }
-        catch(err) {
+        catch (err) {
             metaInfo.author = "";
         }
         try {
             metaInfo.language = that.extractLanguage(dom);
         }
-        catch(err) {
+        catch (err) {
             metaInfo.language = "";
         }
         try {
             metaInfo.fileName = that.makeSaveAsFileNameWithoutExtension(metaInfo.title, useFullTitle);
         }
-        catch(err) {
+        catch (err) {
             metaInfo.fileName = "web.epub";
         }
         try {
             metaInfo.subject = that.extractSubject(dom);
         }
-        catch(err) {
+        catch (err) {
             metaInfo.subject = "";
         }
         try {
             metaInfo.description = that.extractDescription(dom);
         }
-        catch(err) {
+        catch (err) {
             metaInfo.description = "";
         }
         that.extractSeriesInfo(dom, metaInfo);
@@ -393,7 +393,7 @@ class Parser {
             ++index;
         }
 
-        for(let webPage of webPages.filter(c => this.isWebPagePackable(c))) {
+        for (let webPage of webPages.filter(c => this.isWebPagePackable(c))) {
             let newItems = (webPage.error == null)
                 ? webPage.parser.webPageToEpubItems(webPage, index)
                 : this.makePlaceholderEpubItem(webPage, index);
@@ -427,7 +427,7 @@ class Parser {
     }
 
     populateInfoDiv(infoDiv, dom) {
-        for(let n of this.getInformationEpubItemChildNodes(dom).filter(n => n != null)) {
+        for (let n of this.getInformationEpubItemChildNodes(dom).filter(n => n != null)) {
             let clone = util.sanitizeNode(n);
             if (clone) {
                 this.cleanInformationNode(clone);
@@ -469,7 +469,7 @@ class Parser {
             }
             that.state.setPagesToFetch(chapters);
             chapterUrlsUI.connectButtonHandlers();
-        }).catch(function (err) {
+        }).catch(function(err) {
             ErrorLog.showErrorMessage(err);
         });
     }
@@ -482,7 +482,7 @@ class Parser {
                 foundUrls.add(webPage.sourceUrl);
             }
             return unique;
-        }
+        };
 
         return webPages
             .map(this.fixupImgurGalleryUrl)
@@ -573,7 +573,7 @@ class Parser {
         await this.rateLimitDelay();
         ChapterUrlsUI.showDownloadState(webPage.row, ChapterUrlsUI.DOWNLOAD_STATE_DOWNLOADING);
         let pageParser = webPage.parser;
-        return pageParser.fetchChapter(webPage.sourceUrl).then(function (webPageDom) {
+        return pageParser.fetchChapter(webPage.sourceUrl).then(function(webPageDom) {
             delete webPage.error;
             webPage.rawDom = webPageDom;
             pageParser.preprocessRawDom(webPageDom);
@@ -584,7 +584,7 @@ class Parser {
                 throw new Error(errorMsg);
             }
             return pageParser.fetchImagesUsedInDocument(content, webPage);
-        }).catch(function (error) {
+        }).catch(function(error) {
             if (that.userPreferences.skipChaptersThatFailFetch.value) {
                 ErrorLog.log(error);
                 webPage.error = error;
@@ -598,10 +598,10 @@ class Parser {
     fetchImagesUsedInDocument(content, webPage) {
         let that = this;
         return this.imageCollector.preprocessImageTags(content, webPage.sourceUrl)
-            .then(function (revisedContent) {
+            .then(function(revisedContent) {
                 that.imageCollector.findImagesUsedInDocument(revisedContent);
                 return that.imageCollector.fetchImages(() => { }, webPage.sourceUrl);
-            }).then(function () {
+            }).then(function() {
                 that.updateLoadState(webPage);
             });
     }
@@ -641,8 +641,8 @@ class Parser {
 
     fixupHyperlinksInEpubItems(epubItems) {
         let targets = this.sourceUrlToEpubItemUrl(epubItems);
-        for(let item of epubItems) {
-            for(let link of item.getHyperlinks().filter(this.isUnresolvedHyperlink)) {
+        for (let item of epubItems) {
+            for (let link of item.getHyperlinks().filter(this.isUnresolvedHyperlink)) {
                 if (!this.hyperlinkToEpubItemUrl(link, targets)) {
                     this.makeHyperlinkAbsolute(link);
                 }
@@ -652,7 +652,7 @@ class Parser {
 
     sourceUrlToEpubItemUrl(epubItems) {
         let targets = new Map();
-        for(let item of epubItems) {
+        for (let item of epubItems) {
             let key = util.normalizeUrlForCompare(item.sourceUrl);
             
             // Some source URLs may generate multiple epub items.
@@ -693,7 +693,7 @@ class Parser {
     }
 
     tagAuthorNotes(elements) {
-        for(let e of elements) {
+        for (let e of elements) {
             e.classList.add("webToEpub-author-note");
         }
     }
@@ -750,7 +750,7 @@ class Parser {
         if (0 < chapters.length) {
             chapterUrlsUI.showTocProgress(chapters);
         }
-        for(let url of urlsOfTocPages) {
+        for (let url of urlsOfTocPages) {
             await this.rateLimitDelay();
             let newDom = (await HttpClient.wrapFetch(url, wrapOptions)).responseXML;
             let partialList = extractPartialChapterList(newDom);
@@ -778,7 +778,7 @@ class Parser {
     moveFootnotes(dom, content, footnotes) {
         if (0 < footnotes.length) {
             let list = dom.createElement("ol");
-            for(let f of footnotes) {
+            for (let f of footnotes) {
                 let item = dom.createElement("li");
                 f.removeAttribute("style");
                 item.appendChild(f);
@@ -796,7 +796,7 @@ class Parser {
         let count = 2;
         let nextUrl = moreChapterTextUrl(dom, url, count);
         let oldContent = this.findContent(dom);
-        while(nextUrl != null) {
+        while (nextUrl != null) {
             await this.rateLimitDelay();
             let nextDom = (await HttpClient.wrapFetch(nextUrl)).responseXML;
             let newContent = this.findContent(nextDom);

--- a/plugin/js/ParserFactory.js
+++ b/plugin/js/ParserFactory.js
@@ -4,13 +4,13 @@
 
 "use strict";
 
-class ParserFactory{
+class ParserFactory {
     constructor() {
         this.parsers = new Map();
         this.parserRules = [];
         this.parserUrlRules = [];
         this.manualSelection = [];
-        this.registerManualSelect("", function() { return undefined });
+        this.registerManualSelect("", function() { return undefined; });
     }
 
     static isWebArchive(url) {
@@ -38,7 +38,7 @@ class ParserFactory{
             this.parsers.set(ParserFactory.stripLeadingWww(hostName), constructor);
         } else {
             throw new Error("Duplicate parser registered for hostName " + hostName);
-        };
+        }
     }
 
     reregister(hostName, constructor) {
@@ -47,7 +47,7 @@ class ParserFactory{
 
     registerManualSelect(name, constructor) {
         this.manualSelection.push({name, constructor});
-    };
+    }
 
     /*
     *  @param {function} test predicate that checks if parser can handle URL & DOM
@@ -115,14 +115,14 @@ class ParserFactory{
     populateManualParserSelectionTag(selectTag) {
         let options = selectTag.options;
         if (options.length === 0) {
-            for(let p of this.manualSelection) {
+            for (let p of this.manualSelection) {
                 options.add(new Option(p.name));
             }
         }
     }
 
     manuallySelectParser(parserName) {
-        for(let m of this.manualSelection) {
+        for (let m of this.manualSelection) {
             if (m.name === parserName) {
                 return m.constructor();
             }
@@ -130,10 +130,10 @@ class ParserFactory{
     }
 
     async addParsersToPages(initialParser, webPages) {
-        let pagesByHost = new Map()
+        let pagesByHost = new Map();
         let initialUrl = initialParser.state.chapterListUrl;
         let initialHostName = ParserFactory.hostNameForParserSelection(initialUrl);
-        for(let page of webPages) {
+        for (let page of webPages) {
             let key = ParserFactory.hostNameForParserSelection(page.sourceUrl);
             if (key === initialHostName) {
                 page.parser = initialParser;
@@ -147,7 +147,7 @@ class ParserFactory{
             pages.push(page);
         }
 
-        for(let pair of pagesByHost) {
+        for (let pair of pagesByHost) {
             await this.assignParserToPages(pair[1], initialParser);
         }
     }
@@ -164,7 +164,7 @@ class ParserFactory{
 
     static copyParserToPages(parser, webPages, initialParser) {
         parser.copyState(initialParser);
-        for(let page of webPages) {
+        for (let page of webPages) {
             page.parser = parser;
         }
     }

--- a/plugin/js/ProgressBar.js
+++ b/plugin/js/ProgressBar.js
@@ -6,7 +6,7 @@
 */
 class ProgressBar {
     constructor() {
-    };
+    }
 
     static getUiElement() {
         return document.getElementById("fetchProgress");
@@ -37,7 +37,7 @@ class ProgressBar {
         document.getElementById("progressString").textContent = text;
     }
 
-    static updateTabTitle(value, max){
+    static updateTabTitle(value, max) {
         value = (value*100/max).toFixed(1);
         if (value == "100.0") {
             value = "100";

--- a/plugin/js/ReadingList.js
+++ b/plugin/js/ReadingList.js
@@ -7,7 +7,7 @@
  * Can't hold all URLs.  So just record last chapter for each story.
 */
 class ReadingList {
-    constructor () {
+    constructor() {
         this.epubs = new Map();
     }
 
@@ -23,7 +23,7 @@ class ReadingList {
     }
 
     tryDeleteEpubAndSave(url) {
-        if (this.getEpub(url)){
+        if (this.getEpub(url)) {
             this.deleteEpub(url);
             this.writeToLocalStorage();
             return true;
@@ -38,9 +38,9 @@ class ReadingList {
     deselectOldChapters(url, chapterList) {
         let oldUrl = this.epubs.get(url);
         if (oldUrl != null) {
-            for(let i = 0; i < chapterList.length; ++i) {
+            for (let i = 0; i < chapterList.length; ++i) {
                 if (oldUrl === chapterList[i].sourceUrl) {
-                    for(let j = 0; j <= i; ++j) {
+                    for (let j = 0; j <= i; ++j) {
                         chapterList[j].isIncludeable = false;
                         chapterList[j].previousDownload = true;
                     }
@@ -72,23 +72,23 @@ class ReadingList {
     }
 
     static replacer(key, value) {
-        switch(key) {
-        case "epubs":
-            return [...value].map(v => ({ toc: v[0], lastUrl: v[1] }));
-        default:
-            return value;
+        switch (key) {
+            case "epubs":
+                return [...value].map(v => ({ toc: v[0], lastUrl: v[1] }));
+            default:
+                return value;
         }
     }
 
     static reviver(key, value) {
-        switch(key) {
-        case "epubs":
-            return new Map([...value].map(ReadingList.reviveEpub));
-        case "history": {
-            return value[value.length - 1];
-        }
-        default:
-            return value;
+        switch (key) {
+            case "epubs":
+                return new Map([...value].map(ReadingList.reviveEpub));
+            case "history": {
+                return value[value.length - 1];
+            }
+            default:
+                return value;
         }
     }
 
@@ -130,7 +130,7 @@ class ReadingList {
 
     showReadingList(table) {
         util.removeChildElementsMatchingSelector(table, "tr");
-        for(let e of this.epubs.keys()) {
+        for (let e of this.epubs.keys()) {
             let row = document.createElement("tr");
             table.appendChild(row);
             let link = document.createElement("a");

--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -121,7 +121,7 @@ class UserPreferences {
         this.readingList = new ReadingList();
 
         document.getElementById("themeColorTag").addEventListener("change", UserPreferences.SetTheme);
-    };
+    }
 
     /** @private */
     addPreference(storageName, uiElementName, defaultValue) {
@@ -131,9 +131,9 @@ class UserPreferences {
 
         let preference = null;
         if (typeof(defaultValue) === "boolean") {
-            preference = new BoolUserPreference(storageName, uiElementName, defaultValue)
+            preference = new BoolUserPreference(storageName, uiElementName, defaultValue);
         } else if (typeof(defaultValue) === "string") {
-            preference = new StringUserPreference(storageName, uiElementName, defaultValue)
+            preference = new StringUserPreference(storageName, uiElementName, defaultValue);
         } else {
             throw new Error("Unknown preference type");
         }
@@ -143,7 +143,7 @@ class UserPreferences {
 
     static readFromLocalStorage() {
         let newPreferences = new UserPreferences();
-        for(let p of newPreferences.preferences) {
+        for (let p of newPreferences.preferences) {
             p.readFromLocalStorage();
         }
         newPreferences.readingList.readFromLocalStorage();
@@ -151,7 +151,7 @@ class UserPreferences {
     }
 
     writeToLocalStorage() {
-        for(let p of this.preferences) {
+        for (let p of this.preferences) {
             p.writeToLocalStorage();
         }
         this.readingList.writeToLocalStorage();
@@ -163,7 +163,7 @@ class UserPreferences {
     }
 
     readFromUi() {
-        for(let p of this.preferences) {
+        for (let p of this.preferences) {
             p.readFromUi();
         }
 
@@ -173,13 +173,13 @@ class UserPreferences {
 
     notifyObserversOfChange() {
         let that = this;
-        for(let observer of that.observers) {
+        for (let observer of that.observers) {
             observer.onUserPreferencesUpdate(that);
-        };
+        }
     }
 
     writeToUi() {
-        for(let p of this.preferences) {
+        for (let p of this.preferences) {
             p.writeToUi();
         }
         UserPreferences.SetTheme();
@@ -187,7 +187,7 @@ class UserPreferences {
 
     hookupUi() {
         let readFromUi = this.readFromUi.bind(this);
-        for(let p of this.preferences) {
+        for (let p of this.preferences) {
             p.hookupUi(readFromUi);
         }
 
@@ -201,7 +201,7 @@ class UserPreferences {
             obj[DefaultParserSiteSettings.storageName] = JSON.parse(serialized);
         }
         obj[ReadingList.storageName] = JSON.parse(this.readingList.toJson());
-        for(let p of this.preferences) {
+        for (let p of this.preferences) {
             obj[p.storageName] = p.value; 
         }
         serialized = JSON.stringify(obj);
@@ -228,15 +228,15 @@ class UserPreferences {
                 this.loadDefaultParserFromJson(json);
                 this.loadReadingListFromJson(json);
                 populateControls();
-            } catch(err) {
+            } catch (err) {
                 ErrorLog.showErrorMessage(err);
             }
-        }
+        };
         reader.readAsText(file);
     }
 
     loadOpionsFromJson(json) {
-        for(let p of this.preferences) {
+        for (let p of this.preferences) {
             let val = json[p.storageName];
             if (val !== undefined && (p.value !== val)) {
                 p.value = val;

--- a/plugin/js/Util.js
+++ b/plugin/js/Util.js
@@ -223,7 +223,7 @@ const util = (function() {
         }
     }
 
-    function removeHTMLUnknownElement(nodes){
+    function removeHTMLUnknownElement(nodes) {
         let children = nodes.childNodes;
         for (let i = 0; i < children.length; i++) {
             if (children[i] instanceof HTMLUnknownElement) {
@@ -678,10 +678,10 @@ const util = (function() {
 
     function isElementWhiteSpace(element) {
         switch (element.nodeType) {
-        case Node.TEXT_NODE:
-            return isStringWhiteSpace(element.textContent);
-        case Node.COMMENT_NODE:
-            return true;
+            case Node.TEXT_NODE:
+                return isStringWhiteSpace(element.textContent);
+            case Node.COMMENT_NODE:
+                return true;
         }
         if ((element.tagName === "IMG") || (element.tagName === "image")) {
             return false;

--- a/plugin/js/debugging/FakeParser.js
+++ b/plugin/js/debugging/FakeParser.js
@@ -6,16 +6,16 @@
   Note, need to open the by looking at site rtd.moe
 */
 
-parserFactory.register("rtd.moe", function() { return new FakeParser() });
+parserFactory.register("rtd.moe", function() { return new FakeParser(); });
 
-class FakeParser extends Parser{
+class FakeParser extends Parser {
     constructor() {
         super();
     }
 
     async getChapterUrls( /* dom */ ) {
         let chapters = [];
-        for(let i = 1; i < 30; ++i) {
+        for (let i = 1; i < 30; ++i) {
             chapters.push({
                 sourceUrl:  `https://rtd.moe/Chapter/${i}.html`,
                 title: `Chapter ${i}`,
@@ -23,15 +23,15 @@ class FakeParser extends Parser{
             });
         }
         return chapters;
-    };
+    }
 
     findContent(dom) {
         return Parser.findConstrutedContent(dom);
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("h1");
-    };
+    }
 
     async fetchChapter(url) {
         let newDoc = Parser.makeEmptyDocForContent(url);

--- a/plugin/js/main.js
+++ b/plugin/js/main.js
@@ -2,7 +2,7 @@
     Main processing handler for popup.html
 
 */
-var main = (function () {
+var main = (function() {
     "use strict";
 
     // this will be called when message listener fires
@@ -15,7 +15,7 @@ var main = (function () {
             let dom = new DOMParser().parseFromString(message.document, "text/html");
             populateControlsWithDom(message.url, dom);
         }
-    };
+    }
 
     // details 
     let initalWebPage = null;
@@ -152,9 +152,9 @@ var main = (function () {
         main.getPackEpubButton().disabled = true;
         replaceLibAddToLibrary();
         parser.onStartCollecting();
-        await parser.fetchContent().then(function () {
+        await parser.fetchContent().then(function() {
             return packEpub(metaInfo);
-        }).then(function (content) {
+        }).then(function(content) {
             // Enable button here.  If user cancels save dialog
             // the promise never returns
             window.workInProgress = false;
@@ -167,7 +167,7 @@ var main = (function () {
                 return library.LibAddToLibrary(content, fileName, document.getElementById("startingUrlInput").value, overwriteExisting, backgroundDownload);
             }
             return Download.save(content, fileName, overwriteExisting, backgroundDownload);
-        }).then(function () {
+        }).then(function() {
             parser.updateReadingList();
             if (util.sleepControler.signal.aborted) {
                 util.sleepControler = new AbortController;
@@ -179,7 +179,7 @@ var main = (function () {
                 ErrorLog.showLogToUser();
                 dumpErrorLogToFile();
             }
-        }).catch(function (err) {
+        }).catch(function(err) {
             window.workInProgress = false;
             main.getPackEpubButton().disabled = false;
             if (util.sleepControler.signal.aborted) {
@@ -190,14 +190,14 @@ var main = (function () {
         });
     }
 
-    function replaceLibAddToLibrary(){
+    function replaceLibAddToLibrary() {
         let el = document.getElementById("LibAddToLibrary");
         el.hidden = !el.hidden;
         el = document.getElementById("LibPauseToLibrary");
         el.hidden = !el.hidden;
     }
 
-    function pauseToLibarary(){
+    function pauseToLibarary() {
         util.sleepControler.abort();
     }
 
@@ -245,7 +245,7 @@ var main = (function () {
         } catch {
             if (chrome.runtime.lastError) {
                 util.log(chrome.runtime.lastError.message);
-            };
+            }
         }
     }
 
@@ -316,12 +316,12 @@ var main = (function () {
         section.hidden = true;
     }
 
-    function onShowMoreMetadataOptionsClick(){
+    function onShowMoreMetadataOptionsClick() {
         let section = getAdditionalMetadataSection();
         section.hidden = !section.hidden;
     }
 
-    function onLibraryClick(){
+    function onLibraryClick() {
         let section =  getLibrarySection();
         section.hidden = !section.hidden;
         if (!section.hidden) {
@@ -338,13 +338,13 @@ var main = (function () {
 
     function openTabWindow() {
         // open new tab window, passing ID of open tab with content to convert to epub as query parameter.
-        getActiveTab().then(function (tabId) {
+        getActiveTab().then(function(tabId) {
             let url = chrome.runtime.getURL("popup.html") + "?id=";
             url += tabId;
             try {
                 chrome.tabs.create({ url: url, openerTabId: tabId });
             }
-            catch(err) {
+            catch (err) {
                 //firefox android catch
                 chrome.tabs.create({ url: url});
             }
@@ -353,13 +353,13 @@ var main = (function () {
     }
 
     function getActiveTab() {
-        return new Promise(function (resolve, reject) {
-            chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
+        return new Promise(function(resolve, reject) {
+            chrome.tabs.query({ currentWindow: true, active: true }, function(tabs) {
                 if ((tabs != null) && (0 < tabs.length)) {
                     resolve(tabs[0].id);
                 } else {
                     reject();
-                };
+                }
             });
         });
     }
@@ -368,10 +368,10 @@ var main = (function () {
         // load page via XmlHTTPRequest
         let url = getValueFromUiField("startingUrlInput");
         getLoadAndAnalyseButton().disabled = true;
-        return HttpClient.wrapFetch(url).then(async function (xhr) {
+        return HttpClient.wrapFetch(url).then(async function(xhr) {
             await populateControlsWithDom(url, xhr.responseXML);
             getLoadAndAnalyseButton().disabled = false;
-        }).catch(function (error) {
+        }).catch(function(error) {
             getLoadAndAnalyseButton().disabled = false;
             ErrorLog.showErrorMessage(error);
         });
@@ -418,14 +418,14 @@ var main = (function () {
         let localized = chrome.i18n.getMessage(element.textContent.trim());
         if (!util.isNullOrEmpty(localized)) {
             element.innerText = localized;
-        };
+        }
     }
 
     function localizeHtmlPage()
     {
         // can't use a single select, because there are buttons in td elements
-        for(let selector of ["button, option", "td, th", ".i18n"]) {
-            for(let element of [...document.querySelectorAll(selector)]) {
+        for (let selector of ["button, option", "td, th", ".i18n"]) {
+            for (let element of [...document.querySelectorAll(selector)]) {
                 if (element.textContent.startsWith("__MSG_")) {
                     localize(element);
                 }
@@ -504,8 +504,8 @@ var main = (function () {
         [...sections.keys()].forEach(s => s.hidden = true);
 
         document.getElementById("readingListSection").hidden = false;
-        document.getElementById("closeReadingList").onclick = function () {
-            [...sections].forEach(s => s[0].hidden = s[1])
+        document.getElementById("closeReadingList").onclick = function() {
+            [...sections].forEach(s => s[0].hidden = s[1]);
         };
 
         let table = document.getElementById("readingListTable");
@@ -532,8 +532,8 @@ var main = (function () {
         getManuallySelectParserTag().onchange = populateControls;
         document.getElementById("advancedOptionsButton").onclick = onAdvancedOptionsClick;
         document.getElementById("hiddenBibButton").onclick = onLibraryClick;
-        document.getElementById("ShowMoreMetadataOptionsCheckbox").addEventListener("change", function(){onShowMoreMetadataOptionsClick()});
-        document.getElementById("LibShowAdvancedOptionsCheckbox").addEventListener("change", function(){Library.LibRenderSavedEpubs()});
+        document.getElementById("ShowMoreMetadataOptionsCheckbox").addEventListener("change", function() {onShowMoreMetadataOptionsClick();});
+        document.getElementById("LibShowAdvancedOptionsCheckbox").addEventListener("change", function() {Library.LibRenderSavedEpubs();});
         document.getElementById("LibAddToLibrary").addEventListener("click", fetchContentAndPackEpub);
         document.getElementById("LibPauseToLibrary").addEventListener("click", pauseToLibarary);
         document.getElementById("stylesheetToDefaultButton").onclick = onStylesheetToDefaultClick;
@@ -556,47 +556,47 @@ var main = (function () {
 	
 	
     // Additional metadata
-    function autosearchadditionalmetadata(){
+    function autosearchadditionalmetadata() {
         getPackEpubButton().disabled = true;
         document.getElementById("LibAddToLibrary").disabled = true;
         let titelname = getValueFromUiField("titleInput");
         let url ="https://www.novelupdates.com/series-finder/?sf=1&sh="+titelname;
-        if (getValueFromUiField("subjectInput")==null){
+        if (getValueFromUiField("subjectInput")==null) {
             autosearchnovelupdates(url, titelname);
         }   
         getPackEpubButton().disabled = false; 
         document.getElementById("LibAddToLibrary").disabled = false;    
     }
 	
-    function autosearchnovelupdates(url, titelname){
-        return HttpClient.wrapFetch(url).then(function (xhr) {
+    function autosearchnovelupdates(url, titelname) {
+        return HttpClient.wrapFetch(url).then(function(xhr) {
             findnovelupdatesurl(url, xhr.responseXML, titelname);
-        }).catch(function (error) {
+        }).catch(function(error) {
             getLoadAndAnalyseButton().disabled = false;
             ErrorLog.showErrorMessage(error);
         });
     }
 
-    function findnovelupdatesurl(url, dom, titelname){
-        try{    
+    function findnovelupdatesurl(url, dom, titelname) {
+        try {    
             let searchurl = [...dom.querySelectorAll("a")].filter(a => a.textContent==titelname)[0];
             setUiFieldToValue("metadataUrlInput", searchurl.href);
             url = getValueFromUiField("metadataUrlInput");
-            if (url.includes("novelupdates.com") == true){
+            if (url.includes("novelupdates.com") == true) {
                 onLoadMetadataButtonClick();
             }
-        }catch{
+        } catch {
             //
         }
     }
 	
-    function onLoadMetadataButtonClick(){
+    function onLoadMetadataButtonClick() {
         getPackEpubButton().disabled = true;
         document.getElementById("LibAddToLibrary").disabled = true;
         let url = getValueFromUiField("metadataUrlInput");
-        return HttpClient.wrapFetch(url).then(function (xhr) {
+        return HttpClient.wrapFetch(url).then(function(xhr) {
             populateMetadataAddWithDom(url, xhr.responseXML);
-        }).catch(function (error) {
+        }).catch(function(error) {
             getLoadAndAnalyseButton().disabled = false;
             ErrorLog.showErrorMessage(error);
         });
@@ -608,7 +608,7 @@ var main = (function () {
             let metaAddInfo = EpubMetaInfo.getEpubMetaAddInfo(dom, url, allTags);
             setUiFieldToValue("subjectInput", metaAddInfo.subject);
             setUiFieldToValue("descriptionInput", metaAddInfo.description);
-            if (getValueFromUiField("authorInput")=="<unknown>"){
+            if (getValueFromUiField("authorInput")=="<unknown>") {
                 setUiFieldToValue("authorInput", metaAddInfo.author);
             }
             getPackEpubButton().disabled = false;
@@ -621,7 +621,7 @@ var main = (function () {
     }
 
     // actions to do when window opened
-    window.onload = function () {
+    window.onload = function() {
         userPreferences = UserPreferences.readFromLocalStorage();
         if (isRunningInTabMode()) { 
             ErrorLog.SuppressErrorLog =  false;
@@ -636,7 +636,7 @@ var main = (function () {
         } else {
             openTabWindow();
         }
-    }
+    };
 
     return {
         getPackEpubButton: getPackEpubButton,

--- a/plugin/js/parsers/230BookParser.js
+++ b/plugin/js/parsers/230BookParser.js
@@ -4,7 +4,7 @@
 parserFactory.register("230book.net", () => new _230BookParser() );
 parserFactory.register("38xs.com", () => new _38xsParser() );
 
-class _230BookBaseParser extends Parser{
+class _230BookBaseParser extends Parser {
     constructor() {
         super();
     }
@@ -16,11 +16,11 @@ class _230BookBaseParser extends Parser{
 
     findContent(dom) {
         return dom.querySelector("#content");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("#info h1").textContent;
-    };
+    }
 
     findChapterTitle(dom) {
         return dom.querySelector(".bookname h1");
@@ -41,7 +41,7 @@ class _230BookBaseParser extends Parser{
     }
 }
 
-class _230BookParser extends _230BookBaseParser{
+class _230BookParser extends _230BookBaseParser {
     constructor() {
         super();
     }
@@ -52,7 +52,7 @@ class _230BookParser extends _230BookBaseParser{
     }
 }
 
-class _38xsParser extends _230BookBaseParser{
+class _38xsParser extends _230BookBaseParser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/27kParser.js
+++ b/plugin/js/parsers/27kParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("27k.net", () => new _27kParser());
 
-class _27kParser extends Parser{
+class _27kParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/4kswParser.js
+++ b/plugin/js/parsers/4kswParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("4ksw.com", () => new _4kswParser());
 
-class _4kswParser extends Parser{
+class _4kswParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/69shuParser.js
+++ b/plugin/js/parsers/69shuParser.js
@@ -6,7 +6,7 @@ parserFactory.registerUrlRule(
 );
 parserFactory.register("69yuedu.net", () => new _69yueduParser());
 
-class ShuParser extends Parser{
+class ShuParser extends Parser {
     constructor() {
         super();
         this.minimumThrottle = 1000;
@@ -21,11 +21,11 @@ class ShuParser extends Parser{
 
     findContent(dom) {
         return dom.querySelector("div.txtnav");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.booknav2 h1").textContent;
-    };
+    }
 
     findCoverImageUrl(dom) {
         return util.getFirstImgSrc(dom, "div.bookbox");
@@ -57,7 +57,7 @@ class ShuParser extends Parser{
     }
 }
 
-class _69yueduParser extends ShuParser{
+class _69yueduParser extends ShuParser {
     constructor() {
         super();
     }
@@ -81,5 +81,5 @@ class _69yueduParser extends ShuParser{
 
     findContent(dom) {
         return dom.querySelector("div.content");
-    };
+    }
 }

--- a/plugin/js/parsers/888novelParser.js
+++ b/plugin/js/parsers/888novelParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("888novel.com", () => new _888novelParser());
 
-class _888novelParser extends Parser{
+class _888novelParser extends Parser {
     constructor() {
         super();
     }
@@ -14,7 +14,7 @@ class _888novelParser extends Parser{
             _888novelParser.getUrlsOfTocPages,
             chapterUrlsUI
         );
-    };
+    }
 
     static getUrlsOfTocPages(dom) {
         let pagination = dom.querySelector("ul.pagination");
@@ -28,7 +28,7 @@ class _888novelParser extends Parser{
                 let base = maxPageUrl.substring(0, index + 1);
                 let maxPage = parseInt(maxPageUrl.substring(index + 1).replace("#dsc", ""));
                 if (1 < maxPage) {
-                    for(let i = 2; i <= maxPage; ++i) {
+                    for (let i = 2; i <= maxPage; ++i) {
                         tocUrls.push(`${base}${i}/`);
                     }
                 }
@@ -60,7 +60,7 @@ class _888novelParser extends Parser{
 
     getInformationEpubItemChildNodes(dom) {
         let nodes = [...dom.querySelectorAll("div.tabs1")];
-        for(let n of nodes) {
+        for (let n of nodes) {
             n.setAttribute("style", null);
         }
         return nodes;

--- a/plugin/js/parsers/88xiaoshuoParser.js
+++ b/plugin/js/parsers/88xiaoshuoParser.js
@@ -14,7 +14,7 @@ parserFactory.register("m.qbxsw.com", () => new _88xiaoshuoParser());
 parserFactory.register("qbxsw.com", () => new _88xiaoshuoParser());
 parserFactory.register("m.38xs.com", () => new _88xiaoshuoParser());
 
-class _88xiaoshuoParser extends Parser{
+class _88xiaoshuoParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/ActiveTranslationsParser.js
+++ b/plugin/js/parsers/ActiveTranslationsParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("a-t.nu", () => new ActiveTranslationsParser());
 
-class ActiveTranslationsParser extends Parser{
+class ActiveTranslationsParser extends Parser {
     constructor() {
         super();
     }
@@ -43,7 +43,7 @@ class ActiveTranslationsParser extends Parser{
         }
         let rules = this.parseStyle(content);
         let spans = new Map();
-        for(let span of [...content.querySelectorAll("p span")]) {
+        for (let span of [...content.querySelectorAll("p span")]) {
             spans.set(span.className.trim(), span);
         }
         this.addRuleContent(dom, spans, rules);
@@ -55,7 +55,7 @@ class ActiveTranslationsParser extends Parser{
         let lines = style.textContent.split(/;\s*}/)
             .map(l => l.trim())
             .filter(l => !util.isNullOrEmpty(l));
-        for(let line of lines) {
+        for (let line of lines) {
             let index = line.indexOf("::before {");
             if (0 < index) {
                 this.addPsudoElement(line, index, rules, "before");
@@ -91,7 +91,7 @@ class ActiveTranslationsParser extends Parser{
 
     addRuleContent(dom, spans, rules)
     {
-        for(let span of spans.entries()) {
+        for (let span of spans.entries()) {
             let rule = rules.get(span[0]);
             if (rule != null) {
                 let text = span[1].textContent;

--- a/plugin/js/parsers/AdultfanfictionParser.js
+++ b/plugin/js/parsers/AdultfanfictionParser.js
@@ -5,13 +5,13 @@ parserFactory.registerRule(
     () => new AdultfanfictionParser()
 );
 
-class AdultfanfictionParser extends Parser{
+class AdultfanfictionParser extends Parser {
     constructor() {
         super();
     }
 
     static isAdultFanFiction(url) {
-        return (util.extractHostName(url).indexOf(".adult-fanfiction.org") != -1)
+        return (util.extractHostName(url).indexOf(".adult-fanfiction.org") != -1);
     }
 
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/AerialrainParser.js
+++ b/plugin/js/parsers/AerialrainParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("aerialrain.com", () => new AerialrainParser());
 
-class AerialrainParser extends WordpressBaseParser{
+class AerialrainParser extends WordpressBaseParser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/AkknovelParser.js
+++ b/plugin/js/parsers/AkknovelParser.js
@@ -1,6 +1,6 @@
 "use strict";
 
-parserFactory.register("akknovel.com", function () {return new AkknovelParser();});
+parserFactory.register("akknovel.com", function() {return new AkknovelParser();});
 
 class AkknovelParser extends Parser {
     constructor() {

--- a/plugin/js/parsers/AlphapolisParser.js
+++ b/plugin/js/parsers/AlphapolisParser.js
@@ -1,6 +1,6 @@
 "use strict";
 parserFactory.register("alphapolis.co.jp", () => new AlphapolisParser());
-class AlphapolisParser extends Parser{
+class AlphapolisParser extends Parser {
     constructor() {
         super();
         this.minimumThrottle = 15000;
@@ -18,7 +18,7 @@ class AlphapolisParser extends Parser{
     extractAuthor(dom) {
         let authorLink = dom.querySelector("div.author a");
         return (authorLink === null) ? super.extractAuthor(dom) : authorLink.textContent;
-    };
+    }
     extractLanguage() {
         return "jp";
     }

--- a/plugin/js/parsers/AmoryaoiParser.js
+++ b/plugin/js/parsers/AmoryaoiParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("amor-yaoi.com", () => new AmoryaoiParser());
 
-class AmoryaoiParser extends Parser{
+class AmoryaoiParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/AnythingNovelParser.js
+++ b/plugin/js/parsers/AnythingNovelParser.js
@@ -1,9 +1,9 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("anythingnovel.com", function() { return new AnythingNovelParser() });
+parserFactory.register("anythingnovel.com", function() { return new AnythingNovelParser(); });
 
-class AnythingNovelParser extends Parser{
+class AnythingNovelParser extends Parser {
     constructor() {
         super();
     }
@@ -13,15 +13,15 @@ class AnythingNovelParser extends Parser{
             .reverse()
             .map(link => util.hyperLinkToChapter(link));
         return Promise.resolve(links);        
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div#content");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div#content h1");
-    };
+    }
 
     removeUnwantedElementsFromContentElement(element) {
         super.removeUnwantedElementsFromContentElement(element);

--- a/plugin/js/parsers/AppYoruWorldParser.js
+++ b/plugin/js/parsers/AppYoruWorldParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("app.yoru.world", () => new AppYoruWorldParser());
 
-class AppYoruWorldParser extends Parser{
+class AppYoruWorldParser extends Parser {
     constructor() {
         super();
     }
@@ -22,7 +22,7 @@ class AppYoruWorldParser extends Parser{
         return ChapterArrayFree.reverse();
     }
     
-    async loadEpubMetaInfo(dom){
+    async loadEpubMetaInfo(dom) {
         // eslint-disable-next-line
         let regex = new RegExp("\/story\/[0-9]+");
         let bookid = dom.baseURI.match(regex)?.[0].slice(7);

--- a/plugin/js/parsers/ArchiveOfOurOwnParser.js
+++ b/plugin/js/parsers/ArchiveOfOurOwnParser.js
@@ -1,8 +1,8 @@
 "use strict";
 
-parserFactory.register("archiveofourown.org", function() { return new ArchiveOfOurOwnParser() });
+parserFactory.register("archiveofourown.org", function() { return new ArchiveOfOurOwnParser(); });
 
-class ArchiveOfOurOwnParser extends Parser{
+class ArchiveOfOurOwnParser extends Parser {
     constructor() {
         super();
     }
@@ -12,7 +12,7 @@ class ArchiveOfOurOwnParser extends Parser{
         if (isSeries) {
             let chapters = [];
             let works = [...dom.querySelectorAll("ul.series.work > li")];
-            for(let work of works) {
+            for (let work of works) {
                 let partialList = await this.processWorkElement(work);
                 chapterUrlsUI.showTocProgress(partialList);
                 chapters = chapters.concat(partialList);
@@ -28,7 +28,7 @@ class ArchiveOfOurOwnParser extends Parser{
             let chaptersUrl = dom.querySelector("ul#chapter_index a");
             return this.fetchChapterUrls(chaptersUrl);
         }
-    };
+    }
 
     async processWorkElement(work) {
         let chaptersLink = work.querySelector("dd.chapters a");
@@ -74,24 +74,24 @@ class ArchiveOfOurOwnParser extends Parser{
     // find the node(s) holding the story content
     findContent(dom) {
         return dom.querySelector("div#chapters");
-    };
+    }
 
     populateUIImpl() {
         document.getElementById("removeAuthorNotesRow").hidden = false; 
     }
 
     extractTitleImpl(dom) {
-        return dom.querySelector("h2.heading")
-    };
+        return dom.querySelector("h2.heading");
+    }
 
     extractAuthor(dom) {
         let author = dom.querySelector("a[rel='author']")?.innerText;
         return author ?? super.extractAuthor(dom);
-    };
+    }
 
     extractLanguage(dom) {
         return dom.querySelector("meta[name='language']").getAttribute("content");
-    };
+    }
 
     extractSubject(dom) {
         let tags = ([...dom.querySelectorAll(".meta .tags a")]);

--- a/plugin/js/parsers/AsianHobbyistParser.js
+++ b/plugin/js/parsers/AsianHobbyistParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("asianhobbyist.com", () => new AsianHobbyistParser());
 
-class AsianHobbyistParser extends WordpressBaseParser{
+class AsianHobbyistParser extends WordpressBaseParser {
     constructor() {
         super();
     }
@@ -10,11 +10,11 @@ class AsianHobbyistParser extends WordpressBaseParser{
     async getChapterUrls(dom) {
         return [...dom.querySelectorAll("div.releases-wrap a")]
             .map(a => util.hyperLinkToChapter(a));
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector(".post-title.entry-title a");
-    };
+    }
 
     findContent(dom) {
         let content = super.findContent(dom);

--- a/plugin/js/parsers/AsianfanficsParser.js
+++ b/plugin/js/parsers/AsianfanficsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("asianfanfics.com", () => new AsianfanficsParser());
 
-class AsianfanficsParser extends Parser{
+class AsianfanficsParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/AsianovelParser.js
+++ b/plugin/js/parsers/AsianovelParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("asianovel.net", () => new AsianovelParser());
 
-class AsianovelParser extends Parser{
+class AsianovelParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/AsstrParser.js
+++ b/plugin/js/parsers/AsstrParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("asstr.org", () => new AsstrParser());
 
-class AsstrParser extends Parser{
+class AsstrParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/BabelChainParser.js
+++ b/plugin/js/parsers/BabelChainParser.js
@@ -5,7 +5,7 @@ parserFactory.register("novel.babelchain.org", () => new BabelChainParser());
 //dead url
 parserFactory.register("babelnovel.com", () => new BabelChainParser());
 
-class BabelChainParser extends Parser{
+class BabelChainParser extends Parser {
     constructor() {
         super();
     }
@@ -79,7 +79,7 @@ class BabelChainParser extends Parser{
             .filter(p => !util.isNullOrEmpty(p));
         for (let text of paragraphs) {
             let p = newDoc.dom.createElement("p");
-            p.appendChild(newDoc.dom.createTextNode(text))
+            p.appendChild(newDoc.dom.createTextNode(text));
             newDoc.content.appendChild(p);
         }
         return newDoc.dom;

--- a/plugin/js/parsers/BakaTsukiParser.js
+++ b/plugin/js/parsers/BakaTsukiParser.js
@@ -5,7 +5,7 @@
 
 parserFactory.registerManualSelect(
     "Baka-Tsuki Full Text Page", 
-    function() { return new BakaTsukiParser(new BakaTsukiImageCollector()) }
+    function() { return new BakaTsukiParser(new BakaTsukiImageCollector()); }
 );
 
 class BakaTsukiImageCollector extends ImageCollector {
@@ -19,8 +19,8 @@ class BakaTsukiImageCollector extends ImageCollector {
         if (userPreferences.higestResolutionImages.value) {
             this.selectImageUrlFromImagePage = this.getHighestResImageUrlFromImagePage;
         } else {
-            this.selectImageUrlFromImagePage = this.getReducedResImageUrlFromImagePage
-        };
+            this.selectImageUrlFromImagePage = this.getReducedResImageUrlFromImagePage;
+        }
     }
 
     getReducedResImageUrlFromImagePage(dom) {
@@ -36,7 +36,7 @@ class BakaTsukiImageCollector extends ImageCollector {
 
 //==============================================================
 
-class BakaTsukiParser extends Parser{
+class BakaTsukiParser extends Parser {
     constructor(imageCollector) {
         super(imageCollector);
         this.state.firstPageDom = null;
@@ -44,7 +44,7 @@ class BakaTsukiParser extends Parser{
 
     static register() {
         parserFactory.reregister("baka-tsuki.org", function() { 
-            return new BakaTsukiParser(new BakaTsukiImageCollector()) 
+            return new BakaTsukiParser(new BakaTsukiImageCollector()); 
         });      
     }
 
@@ -66,14 +66,14 @@ class BakaTsukiParser extends Parser{
     static splitContentOnHeadingTags(content) {
         let items = [];
         let nodesInItem = [];
-        for(let i = 0; i < content.childNodes.length; ++i) {
+        for (let i = 0; i < content.childNodes.length; ++i) {
             let node = util.wrapRawTextNode(content.childNodes[i]);
             if (BakaTsukiParser.isChapterStart(node)) {
                 BakaTsukiParser.appendToItems(items, nodesInItem);
                 nodesInItem = [];
-            };
+            }
             nodesInItem.push(node);
-        };
+        }
         BakaTsukiParser.appendToItems(items, nodesInItem);
         return items;
     }
@@ -86,7 +86,7 @@ class BakaTsukiParser extends Parser{
         BakaTsukiParser.removeTrailingWhiteSpace(nodesInItem);
         if (0 < nodesInItem.length) {
             items.push({ nodes: nodesInItem});
-        };
+        }
     }
 
     static removeTrailingWhiteSpace(nodesInItem) {
@@ -94,7 +94,7 @@ class BakaTsukiParser extends Parser{
         while ((0 <= i) && util.isElementWhiteSpace(nodesInItem[i])) {
             nodesInItem.pop();
             --i;
-        };
+        }
     }
 
     static itemsToEpubItems(items, startAt, sourceUrl) {
@@ -121,16 +121,16 @@ class BakaTsukiParser extends Parser{
         if (0 < splitIndex) {
             metaInfo.seriesName = title.substring(0, splitIndex);
             metaInfo.seriesIndex = that.extractVolumeIndex(title.substring(splitIndex));
-        };
+        }
     }
 
     extractVolumeIndex(volumeString) {
         let volumeIndex = "";
-        for(let ch of volumeString) {
+        for (let ch of volumeString) {
             if (("0" <= ch) && (ch <= "9")) {
                 volumeIndex += ch;
-            };
-        };    
+            }
+        }    
         return volumeIndex;
     }
 
@@ -149,7 +149,7 @@ class BakaTsukiParser extends Parser{
         that.populateImageTable();
     }
 
-    populateUIImpl(){
+    populateUIImpl() {
         document.getElementById("higestResolutionImagesRow").hidden = false; 
         document.getElementById("unSuperScriptAlternateTranslations").hidden = false; 
         document.getElementById("imageSection").hidden = false;
@@ -204,11 +204,11 @@ class BakaTsukiParser extends Parser{
                 node = node.parentNode;
                 if (node.tagName === "TABLE") {
                     endTable = node;
-                };
-            };
+                }
+            }
             if (BakaTsukiParser.isTableContainsHyperLinks(endTable)) {
                 endTable.remove();
-            };
+            }
         }
     }
 
@@ -231,7 +231,7 @@ class BakaTsukiParser extends Parser{
 
         // move images out of the <ul> gallery
         let garbage = new Set();
-        for(let listItem of galleryBoxes) {
+        for (let listItem of galleryBoxes) {
             util.removeElements(listItem.querySelectorAll("div.gallerytext"));
 
             let gallery = listItem.parentNode;
@@ -240,7 +240,7 @@ class BakaTsukiParser extends Parser{
         }
 
         // throw away rest of gallery  (note sometimes there are multiple galleries)
-        for(let node of garbage) {
+        for (let node of garbage) {
             node.remove();
         }
     }
@@ -268,7 +268,7 @@ class BakaTsukiParser extends Parser{
     flattenContent(content) {
         // most pages have all header tags as immediate children of the content element
         // where this is not the case, flatten them so that they are.
-        for(let i = 0; i < content.childNodes.length; ++i) {
+        for (let i = 0; i < content.childNodes.length; ++i) {
             let node = content.childNodes[i];
             if (this.nodeNeedsToBeFlattened(node)) {
                 util.flattenNode(node);
@@ -289,7 +289,7 @@ class BakaTsukiParser extends Parser{
         do {
             if (BakaTsukiParser.isChapterStart(walker.currentNode)) {
                 ++count;
-            };
+            }
         } while (walker.nextNode());
         return count;
     }
@@ -350,26 +350,26 @@ class BakaTsukiParser extends Parser{
     }
 
     static walkEpubItemsWithElements(epubItems, targets, processFoundNode) {
-        for(let epubItem of epubItems) {
-            for(let element of epubItem.nodes.filter(e => e.nodeType === Node.ELEMENT_NODE)) {
+        for (let epubItem of epubItems) {
+            for (let element of epubItem.nodes.filter(e => e.nodeType === Node.ELEMENT_NODE)) {
                 let walker = document.createTreeWalker(
                     element, 
                     NodeFilter.SHOW_ELEMENT
                 );
                 
                 // assume first header tag we find is title of the chapter.
-                if(util.isHeaderTag(element) && (epubItem.chapterTitle === null)){
+                if (util.isHeaderTag(element) && (epubItem.chapterTitle === null)) {
                     epubItem.chapterTitle = element.textContent;
                 }
                 do {
                     processFoundNode(walker.currentNode, targets, util.makeRelative(epubItem.getZipHref()));
                 } while (walker.nextNode());
-            };
-        };
+            }
+        }
     }
 
     static unSuperScriptAlternateTranslations(element) {
-        for(let s of util.getElements(element, "span", s => BakaTsukiParser.isPsudoSuperScriptSpan(s))) {
+        for (let s of util.getElements(element, "span", s => BakaTsukiParser.isPsudoSuperScriptSpan(s))) {
             let sibling = s.nextSibling;
             if ((sibling !== null) && (sibling.tagName.toLowerCase() === "span")) {
                 sibling.textContent = sibling.textContent + " (" + s.textContent + ")";
@@ -386,7 +386,7 @@ class BakaTsukiParser extends Parser{
     static recordTarget(node, targets, zipHref) {
         if (node.id != "") {
             targets.set(node.id, zipHref);
-        };
+        }
     }
 
     static fixHyperlink(node, targets, unused) { // eslint-disable-line no-unused-vars
@@ -414,7 +414,7 @@ class BakaTsukiParser extends Parser{
         return this.imageCollector.fetchImages(() => this.updateProgressBarOneStep(), this.state.firstPageDom.baseURI)
             .then(function() {
                 main.getPackEpubButton().disabled = false;
-            }).catch(function (err) {
+            }).catch(function(err) {
                 ErrorLog.log(err);
             });
     }

--- a/plugin/js/parsers/BakaTsukiSeriesPageParser.js
+++ b/plugin/js/parsers/BakaTsukiSeriesPageParser.js
@@ -9,7 +9,7 @@ parserFactory.registerManualSelect(
     function() { return new BakaTsukiSeriesPageParser(); }
 );
 
-class BakaTsukiSeriesPageParser extends Parser{
+class BakaTsukiSeriesPageParser extends Parser {
     constructor() {
         super(new BakaTsukiImageCollector());
     }
@@ -44,7 +44,7 @@ class BakaTsukiSeriesPageParser extends Parser{
         let menu = dom.querySelector("div#content");
         return Promise.resolve(util.hyperlinksToChapterList(menu, 
             BakaTsukiSeriesPageParser.possibleChapterLink));
-    };
+    }
 
     static possibleChapterLink(link) {
         let href = link.href;
@@ -53,7 +53,7 @@ class BakaTsukiSeriesPageParser extends Parser{
 
     findContent(dom) {
         return dom.querySelector("div#mw-content-text");
-    };
+    }
 
     populateUIImpl() {
         document.getElementById("higestResolutionImagesRow").hidden = false; 
@@ -65,7 +65,7 @@ class BakaTsukiSeriesPageParser extends Parser{
     // title of the story  (not to be confused with title of each chapter)
     extractTitleImpl(dom) {
         return dom.querySelector("#firstHeading");
-    };
+    }
 
     customRawDomToContentStep(chapter, content) {
         BakaTsukiParser.stripGalleryBox(content);

--- a/plugin/js/parsers/BetwixtedbutterflyParser.js
+++ b/plugin/js/parsers/BetwixtedbutterflyParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("betwixtedbutterfly.com", () => new BetwixtedbutterflyParser());
 
-class BetwixtedbutterflyParser extends Parser{
+class BetwixtedbutterflyParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/BlogspotParser.js
+++ b/plugin/js/parsers/BlogspotParser.js
@@ -3,7 +3,7 @@
 */
 "use strict";
 
-parserFactory.register("sousetsuka.com", function() { return new BlogspotParser() });
+parserFactory.register("sousetsuka.com", function() { return new BlogspotParser(); });
 
 parserFactory.registerUrlRule(
     url => (util.extractHostName(url).indexOf(".blogspot.") != -1),
@@ -21,7 +21,7 @@ parserFactory.registerRule(
 
 parserFactory.registerManualSelect(
     "Blogspot", 
-    function() { return new BlogspotParser() }
+    function() { return new BlogspotParser(); }
 );
 
 class BlogspotParserImageCollector extends ImageCollector {

--- a/plugin/js/parsers/BnatranslationsParser.js
+++ b/plugin/js/parsers/BnatranslationsParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("bnatranslations.com", () => new BnatranslationsParser());
 
-class BnatranslationsParser extends Parser{
+class BnatranslationsParser extends Parser {
     constructor() {
         super();
     }
@@ -34,7 +34,7 @@ class BnatranslationsParser extends Parser{
         let containers = [...chapterDom.querySelectorAll("article .post__content .elementor-widget-container")];
         let container = containers[0];
         let i = 0;
-        while(++i < containers.length) {
+        while (++i < containers.length) {
             let hasFollowButton = containers[i].querySelector(".wordpress-follow-button") != null;
             if (hasFollowButton) {
                 break;

--- a/plugin/js/parsers/Book18Parser.js
+++ b/plugin/js/parsers/Book18Parser.js
@@ -5,7 +5,7 @@
 
 parserFactory.register("book18.org", () => new Book18Parser());
 
-class Book18Parser extends Parser{
+class Book18Parser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/BookswithqianyaParser.js
+++ b/plugin/js/parsers/BookswithqianyaParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("bookswithqianya.com", () => new BookswithqianyaParser());
 
-class BookswithqianyaParser extends WordpressBaseParser{
+class BookswithqianyaParser extends WordpressBaseParser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/Booktoki152Parser.js
+++ b/plugin/js/parsers/Booktoki152Parser.js
@@ -5,7 +5,7 @@ parserFactory.registerUrlRule(
     () => new Booktoki152Parser()
 );
 
-class Booktoki152Parser extends Parser{
+class Booktoki152Parser extends Parser {
     constructor() {
         super();
         this.minimumThrottle = 1500;

--- a/plugin/js/parsers/BotitranslationParser.js
+++ b/plugin/js/parsers/BotitranslationParser.js
@@ -3,7 +3,7 @@
 parserFactory.register("botitranslation.com", () => new BotitranslationParser());
 parserFactory.register("mystorywave.com", () => new BotitranslationParser());
 
-class BotitranslationParser extends Parser{
+class BotitranslationParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/BoxnovelOrgParser.js
+++ b/plugin/js/parsers/BoxnovelOrgParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("boxnovel.org", () => new BoxnovelOrgParser());
 
-class BoxnovelOrgParser extends Parser{
+class BoxnovelOrgParser extends Parser {
     constructor() {
         super();
     }
@@ -24,14 +24,14 @@ class BoxnovelOrgParser extends Parser{
     }
 
     static getUrlsOfTocPages(dom) {
-        let urls = []
+        let urls = [];
         let paginateUrls = [...dom.querySelectorAll("ul.pagination li a:not([rel])")];
         if (0 < paginateUrls.length) {
             let lastUrl = paginateUrls.pop().href;
             let index = lastUrl.lastIndexOf("=");
             let maxPage = parseInt(lastUrl.substring(index + 1));
-            let prefix = lastUrl.substring(0, index + 1)
-            for(let i = 2; i <= maxPage; ++i) {
+            let prefix = lastUrl.substring(0, index + 1);
+            for (let i = 2; i <= maxPage; ++i) {
                 urls.push(`${prefix}${i}`);
             }
         }

--- a/plugin/js/parsers/BoyloveParser.js
+++ b/plugin/js/parsers/BoyloveParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("boylove.cc", () => new BoyloveParser());
 
-class BoyloveParser extends Parser{
+class BoyloveParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/Bqg225Parser.js
+++ b/plugin/js/parsers/Bqg225Parser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("m.bqg225.com", () => new Bqg225Parser());
 
-class Bqg225Parser extends Parser{
+class Bqg225Parser extends Parser {
     constructor() {
         super();
     }
@@ -17,7 +17,7 @@ class Bqg225Parser extends Parser{
     }
     
     removeToToBottomOfPageLink(menu) {
-        menu.querySelector("a[style]")?.remove()
+        menu.querySelector("a[style]")?.remove();
     }
 
     findContent(dom) {

--- a/plugin/js/parsers/Brittanypage43Parser.js
+++ b/plugin/js/parsers/Brittanypage43Parser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("brittanypage43.com", () => new Brittanypage43Parser());
 
-class Brittanypage43Parser extends Parser{
+class Brittanypage43Parser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/BuntlsParser.js
+++ b/plugin/js/parsers/BuntlsParser.js
@@ -1,8 +1,8 @@
 "use strict";
 
-parserFactory.register("buntls.com", function() { return new BuntlsParser() });
+parserFactory.register("buntls.com", function() { return new BuntlsParser(); });
 
-class BuntlsParser extends Parser{
+class BuntlsParser extends Parser {
     constructor() {
         super();
         this.minimumThrottle = 2600;
@@ -43,7 +43,7 @@ class BuntlsParser extends Parser{
         for (let element of toremove) {
             element.remove();
         }
-        this.makeHiddenElementsVisible(content)
+        this.makeHiddenElementsVisible(content);
         super.removeUnwantedElementsFromContentElement(content);
     }
 

--- a/plugin/js/parsers/CangjiParser.js
+++ b/plugin/js/parsers/CangjiParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("cangji.net", () => new CangjiParser());
 
-class CangjiParser extends Parser{
+class CangjiParser extends Parser {
     constructor() {
         super();
     }
@@ -21,7 +21,7 @@ class CangjiParser extends Parser{
     }
 
     static nextTocPageUrl(dom) {
-        let link = dom.querySelector("a.next")
+        let link = dom.querySelector("a.next");
         return link === null ? null : link.href;
     }
 

--- a/plugin/js/parsers/ChaleuriaParser.js
+++ b/plugin/js/parsers/ChaleuriaParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("chaleuria.com", () => new ChaleuriaParser());
 
-class ChaleuriaParser extends WordpressBaseParser{
+class ChaleuriaParser extends WordpressBaseParser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/ChichipephParser.js
+++ b/plugin/js/parsers/ChichipephParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("chichipeph.com", () => new ChichipephParser());
 
-class ChichipephParser extends Parser{
+class ChichipephParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/ChickengegeParser.js
+++ b/plugin/js/parsers/ChickengegeParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("chickengege.org", () => new ChickengegeParser());
 
-class ChickengegeParser extends Parser{
+class ChickengegeParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/ChineseFantasyNovelsParser.js
+++ b/plugin/js/parsers/ChineseFantasyNovelsParser.js
@@ -1,9 +1,9 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("m.chinesefantasynovels.com", function() { return new ChineseFantasyNovelsParser() });
+parserFactory.register("m.chinesefantasynovels.com", function() { return new ChineseFantasyNovelsParser(); });
 
-class ChineseFantasyNovelsParser extends Parser{
+class ChineseFantasyNovelsParser extends Parser {
     constructor() {
         super();
     }
@@ -11,15 +11,15 @@ class ChineseFantasyNovelsParser extends Parser{
     getChapterUrls(dom) {
         let menu = dom.querySelector("dl.chapterlist");
         return Promise.resolve(util.hyperlinksToChapterList(menu).reverse());
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div#BookText");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.btitle h1");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("div.status");
@@ -31,10 +31,10 @@ class ChineseFantasyNovelsParser extends Parser{
             }
         }
         return super.extractAuthor(dom);
-    };
+    }
 
     removeUnwantedElementsFromContentElement(element) {
-        for(let e of element.querySelectorAll("div.ads, div.link, div.adsb")) {
+        for (let e of element.querySelectorAll("div.ads, div.link, div.adsb")) {
             e.remove();
         }
         super.removeUnwantedElementsFromContentElement(element);

--- a/plugin/js/parsers/ChosentwofanficParser.js
+++ b/plugin/js/parsers/ChosentwofanficParser.js
@@ -1,8 +1,8 @@
 "use strict";
 
-parserFactory.register("chosentwofanfic.com", function() { return new ChosentwofanficParser() });
+parserFactory.register("chosentwofanfic.com", function() { return new ChosentwofanficParser(); });
 
-class ChosentwofanficParser extends Parser{
+class ChosentwofanficParser extends Parser {
     constructor() {
         super();
         this.ChacheChapterTitle = new Map();
@@ -20,7 +20,7 @@ class ChosentwofanficParser extends Parser{
         return ret;
     }
     
-    async loadEpubMetaInfo(dom){
+    async loadEpubMetaInfo(dom) {
         let urlparams = new URL(dom.baseURI).searchParams;
         let bookid = urlparams.get("sid");
         let bookinfo = (await HttpClient.wrapFetch("https://chosentwofanfic.com/viewstory.php?sid="+bookid+"&index=1")).responseXML;

--- a/plugin/js/parsers/ChrysanthemumgardenParser.js
+++ b/plugin/js/parsers/ChrysanthemumgardenParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("chrysanthemumgarden.com", () => new ChrysanthemumgardenParser());
 
-class ChrysanthemumgardenParser extends WordpressBaseParser{
+class ChrysanthemumgardenParser extends WordpressBaseParser {
     constructor() {
         super();
     }
@@ -44,7 +44,7 @@ class ChrysanthemumgardenParser extends WordpressBaseParser{
         let content = this.findContent(webPageDom);
         if (!this.userPreferences.removeAuthorNotes.value) {
             let notes = [...webPageDom.querySelectorAll("div.tooltip-container")];
-            for(let n of notes) {
+            for (let n of notes) {
                 content.appendChild(n);
             }
         }

--- a/plugin/js/parsers/ChyoaParser.js
+++ b/plugin/js/parsers/ChyoaParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("chyoa.com", () => new ChyoaParser());
 
-class ChyoaParser extends Parser{
+class ChyoaParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/ComrademaoParser.js
+++ b/plugin/js/parsers/ComrademaoParser.js
@@ -1,9 +1,9 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("comrademao.com", function() { return new ComrademaoParser() });
+parserFactory.register("comrademao.com", function() { return new ComrademaoParser(); });
 
-class ComrademaoParser extends Parser{
+class ComrademaoParser extends Parser {
     constructor() {
         super();
     }
@@ -22,7 +22,7 @@ class ComrademaoParser extends Parser{
             ComrademaoParser.getUrlsOfTocPages,
             chapterUrlsUI
         ).then(urls => urls.reverse());
-    };
+    }
 
     static getUrlsOfTocPages(dom) {
         let pagination = dom.querySelector("nav.pagination");
@@ -36,7 +36,7 @@ class ComrademaoParser extends Parser{
                 let base = maxPageUrl.substring(0, index + 1);
                 let maxPage = parseInt(maxPageUrl.substring(index + 1));
                 if (1 < maxPage) {
-                    for(let i = 2; i <= maxPage; ++i) {
+                    for (let i = 2; i <= maxPage; ++i) {
                         tocUrls.push(`${base}${i}/`);
                     }
                 }
@@ -52,11 +52,11 @@ class ComrademaoParser extends Parser{
 
     findContent(dom) {
         return dom.querySelector(".site-main article");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector(".entry-title");
-    };
+    }
 
     removeUnwantedElementsFromContentElement(element) {
         util.removeChildElementsMatchingSelector(element, "button, nav, div#comments");

--- a/plugin/js/parsers/CoronatranslationParser.js
+++ b/plugin/js/parsers/CoronatranslationParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("coronatranslation.com", () => new CoronatranslationParser());
 
-class CoronatranslationParser extends Parser{
+class CoronatranslationParser extends Parser {
     constructor() {
         super();
     }
@@ -21,7 +21,7 @@ class CoronatranslationParser extends Parser{
     }
 
     static nextTocPageUrl(dom) {
-        let link = dom.querySelector("div.wp-pagenavi a.nextpostslink")
+        let link = dom.querySelector("div.wp-pagenavi a.nextpostslink");
         return link === null ? null : link.href;
     }
 

--- a/plugin/js/parsers/CreativeNovelsParser.js
+++ b/plugin/js/parsers/CreativeNovelsParser.js
@@ -1,6 +1,6 @@
 "use strict";
-parserFactory.register("creativenovels.com", function() { return new CreativeNovelsParser() });
-class CreativeNovelsParser extends Parser{
+parserFactory.register("creativenovels.com", function() { return new CreativeNovelsParser(); });
+class CreativeNovelsParser extends Parser {
     constructor() {
         super();
     }
@@ -12,7 +12,7 @@ class CreativeNovelsParser extends Parser{
 
     findContent(dom) {
         return dom.querySelector("div.entry-content.content");
-    };
+    }
 
     removeUnwantedElementsFromContentElement(element) {
         util.removeElements(element.querySelectorAll("div.team, div.x-donate-1,"+

--- a/plugin/js/parsers/CrimsontranslationsParser.js
+++ b/plugin/js/parsers/CrimsontranslationsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("crimsontranslations.com", () => new CrimsontranslationsParser());
 
-class CrimsontranslationsParser extends Parser{
+class CrimsontranslationsParser extends Parser {
     constructor() {
         super();
     }
@@ -48,14 +48,14 @@ class CrimsontranslationsParser extends Parser{
             let header = dom.createElement("h2");
             header.textContent = title;
             content.appendChild(header);
-            this.insertParagraphs(paragraphs, content, dom)
+            this.insertParagraphs(paragraphs, content, dom);
         }
     }
 
     insertParagraphs(paragraphs, content, dom) {
         for (let text of paragraphs.replace(/\n\n/g, "\r\n").split("\r\n")) {
             let p = dom.createElement("p");
-            p.appendChild(dom.createTextNode(text))
+            p.appendChild(dom.createTextNode(text));
             content.appendChild(p);
         }
     }

--- a/plugin/js/parsers/CzbooksParser.js
+++ b/plugin/js/parsers/CzbooksParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("czbooks.net", () => new CzbooksParser());
 
-class CzbooksParser extends Parser{
+class CzbooksParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/DaoDivineTlParser.js
+++ b/plugin/js/parsers/DaoDivineTlParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("dao-divine-tl.com", () => new DaoDivineTlParser());
 
-class DaoDivineTlParser extends Parser{
+class DaoDivineTlParser extends Parser {
     constructor() {
         super();
         this.minimumThrottle = 500;
@@ -31,7 +31,7 @@ class DaoDivineTlParser extends Parser{
         return chapters;
     }
 
-    chaptersFromJson(json){
+    chaptersFromJson(json) {
         return json.result.map(a => ({
             sourceUrl: "https://www.dao-divine-tl.com/book/" + a.b_name + "/" + a.chapter_no, 
             title: a.title, 
@@ -39,7 +39,7 @@ class DaoDivineTlParser extends Parser{
         }));
     }
     
-    async loadEpubMetaInfo(dom){
+    async loadEpubMetaInfo(dom) {
         // eslint-disable-next-line
         let regex = new RegExp("\/book\/.+");
         let title = dom.baseURI.match(regex)?.[0].slice(6);

--- a/plugin/js/parsers/DarkNovelsParser.js
+++ b/plugin/js/parsers/DarkNovelsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("dark-novels.ru", () => new DarkNovelsParser());
 
-class DarkNovelsParser extends Parser{
+class DarkNovelsParser extends Parser {
     constructor() {
         super();
     }
@@ -11,15 +11,15 @@ class DarkNovelsParser extends Parser{
         let chapters = [...dom.querySelectorAll("tr.chapter a")]
             .map(a => util.hyperLinkToChapter(a));
         return Promise.resolve(chapters);
-    };
+    }
 
     findContent(dom) {
         return Parser.findConstrutedContent(dom);
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.book-info-container h2");
-    };
+    }
 
     findCoverImageUrl(dom) {
         return util.getFirstImgSrc(dom, "div.book-cover-container");
@@ -66,7 +66,7 @@ class DarkNovelsParser extends Parser{
         let Zip = new zip.ZipReader(zipreader, {useWebWorkers: false});
         let ZipContent = await Zip.getEntries();
         ZipContent = ZipContent.filter(a => a.directory == false);
-        for (let element of ZipContent){
+        for (let element of ZipContent) {
             theFile = await element.getData(new zip.TextWriter());
         }
         return theFile;

--- a/plugin/js/parsers/DasuitlParser.js
+++ b/plugin/js/parsers/DasuitlParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("dasuitl.com", () => new DasuitlParser());
 
-class DasuitlParser extends WordpressBaseParser{
+class DasuitlParser extends WordpressBaseParser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/DdxsParser.js
+++ b/plugin/js/parsers/DdxsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("ddxs.com", () => new DdxsParser());
 
-class DdxsParser extends Parser{
+class DdxsParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/DefaultParser.js
+++ b/plugin/js/parsers/DefaultParser.js
@@ -5,7 +5,7 @@
 
 parserFactory.registerManualSelect(
     "Default", 
-    function() { return new DefaultParser() }
+    function() { return new DefaultParser(); }
 );
 
 class DefaultParser extends Parser {
@@ -38,7 +38,7 @@ class DefaultParser extends Parser {
         util.removeUnwantedWordpressElements(element);
         util.removeMicrosoftWordCrapElements(element);
         this.logic.removeUnwanted(element);
-    };
+    }
 
     findChapterTitle(dom) {
         return this.logic.findChapterTitle(dom);

--- a/plugin/js/parsers/DeviantArtParser.js
+++ b/plugin/js/parsers/DeviantArtParser.js
@@ -1,8 +1,8 @@
 "use strict";
 
-parserFactory.register("deviantart.com", function() { return new DeviantArtParser() });
+parserFactory.register("deviantart.com", function() { return new DeviantArtParser(); });
 
-class DeviantArtParser extends Parser{
+class DeviantArtParser extends Parser {
     constructor() {
         super();
     }
@@ -11,23 +11,23 @@ class DeviantArtParser extends Parser{
         let chapters = [...dom.querySelectorAll("div.folderview-art a.torpedo-thumb-link")]
             .map(DeviantArtParser.linkToChapter);
         return Promise.resolve(chapters);
-    };
+    }
 
     static linkToChapter(link) {
         return {
             sourceUrl:  link.href,
             title: link.href.split("/").pop(),
             newArc: null
-        }
+        };
     }
 
     findContent(dom) {
         let content = dom.querySelector("div.dev-view-deviation");
         if (content != null) {
-            DeviantArtParser.removeUnwantedImages(content)
+            DeviantArtParser.removeUnwantedImages(content);
         }
         return content;
-    };
+    }
 
     static removeUnwantedImages(content) {
         let images = [...content.querySelectorAll("img")];
@@ -38,7 +38,7 @@ class DeviantArtParser extends Parser{
         if (wanted === null) {
             wanted = images[0];
         }
-        for(let i of images) {
+        for (let i of images) {
             i.remove();
         }
         content.appendChild(wanted);
@@ -46,10 +46,10 @@ class DeviantArtParser extends Parser{
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.folderview-top h1");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("a.username");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 }

--- a/plugin/js/parsers/DiurnisParser.js
+++ b/plugin/js/parsers/DiurnisParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("diurnis.com", () => new DiurnisParser());
 
-class DiurnisParser extends Parser{
+class DiurnisParser extends Parser {
     constructor() {
         super();
     }
@@ -21,7 +21,7 @@ class DiurnisParser extends Parser{
         let baseUrl = dom.baseURI;
         let max = this.extractMaxToc(dom);
         let tocUrls = [];
-        for(let i = 2; i <= max; ++i) {
+        for (let i = 2; i <= max; ++i) {
             tocUrls.push(`${baseUrl}?page=${i}`);
         }
         return tocUrls;

--- a/plugin/js/parsers/DummynovelsParser.js
+++ b/plugin/js/parsers/DummynovelsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("dummynovels.com", () => new DummynovelsParser());
 
-class DummynovelsParser extends Parser{
+class DummynovelsParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/EdanglarstranslationsParser.js
+++ b/plugin/js/parsers/EdanglarstranslationsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("edanglarstranslations.com", () => new EdanglarstranslationsParser());
 
-class EdanglarstranslationsParser extends Parser{
+class EdanglarstranslationsParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/EightMusesParser.js
+++ b/plugin/js/parsers/EightMusesParser.js
@@ -1,7 +1,7 @@
 "use strict";
 
-parserFactory.register("www.8muses.com", function() { return new EightMusesParser() });
-parserFactory.register("comics.8muses.com", function() { return new EightMusesParser() });
+parserFactory.register("www.8muses.com", function() { return new EightMusesParser(); });
+parserFactory.register("comics.8muses.com", function() { return new EightMusesParser(); });
 
 class EightMusesParserImageCollector extends ImageCollector {
     constructor() {
@@ -13,7 +13,7 @@ class EightMusesParserImageCollector extends ImageCollector {
     }
 }
 
-class EightMusesParser extends Parser{
+class EightMusesParser extends Parser {
     constructor() {
         super(new EightMusesParserImageCollector());
     }
@@ -22,21 +22,21 @@ class EightMusesParser extends Parser{
         return [...dom.querySelectorAll("div.gallery a")]
             .map(link => util.hyperLinkToChapter(link))
             .filter(c => !util.isNullOrEmpty(c.title));
-    };
+    }
 
     findContent(dom) {
         let content = dom.querySelector("div#content");
         // this.removeOldPages(content);
-        for(let i of content.querySelectorAll("img")) {
+        for (let i of content.querySelectorAll("img")) {
             if (i.src === "") {
                 i.src = i.getAttribute("data-src");
             }
         }
         return content;
-    };
+    }
 
     removeOldPages(content) {
-        for(let a of [...content.querySelectorAll("a")]) {
+        for (let a of [...content.querySelectorAll("a")]) {
             let path = a.href.split("/");
             let file = parseInt(path[path.length - 1]);
             if (file < 63) {

--- a/plugin/js/parsers/EngnovelParser.js
+++ b/plugin/js/parsers/EngnovelParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("engnovel.com", () => new EngnovelParser());
 
-class EngnovelParser extends Parser{
+class EngnovelParser extends Parser {
     constructor() {
         super();
     }
@@ -12,7 +12,7 @@ class EngnovelParser extends Parser{
         let chapters = EngnovelParser.extractPartialChapterList(dom);
         let formData = EngnovelParser.getTocFetchInfo(dom);
         chapterUrlsUI.showTocProgress(chapters);
-        for(let i = 2; i <= formData.maxPage; ++i) {
+        for (let i = 2; i <= formData.maxPage; ++i) {
             let partialList = await EngnovelParser.fetchPartialChapterList(formData.id, i);
             chapterUrlsUI.showTocProgress(partialList);
             chapters = chapters.concat(partialList);

--- a/plugin/js/parsers/ErofusParser.js
+++ b/plugin/js/parsers/ErofusParser.js
@@ -1,6 +1,6 @@
 "use strict";
 
-parserFactory.register("erofus.com", function() { return new ErofusParser() });
+parserFactory.register("erofus.com", function() { return new ErofusParser(); });
 
 class ErofusParserImageCollector extends ImageCollector {
     constructor() {
@@ -16,7 +16,7 @@ class ErofusParserImageCollector extends ImageCollector {
     }
 }
 
-class ErofusParser extends Parser{
+class ErofusParser extends Parser {
     constructor() {
         super(new ErofusParserImageCollector());
     }
@@ -25,11 +25,11 @@ class ErofusParser extends Parser{
         return [...dom.querySelectorAll("div a div.thumbnail")]
             .map(div => util.hyperLinkToChapter(div.parentElement))
             .filter(c => !util.isNullOrEmpty(c.title));
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div.content");
-    };
+    }
 
     findCoverImageUrl() {
         return null;

--- a/plugin/js/parsers/EstarParser.js
+++ b/plugin/js/parsers/EstarParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("estar.jp", () => new EstarParser());
 
-class EstarParser extends Parser{
+class EstarParser extends Parser {
     constructor() {
         super();
     }
@@ -17,14 +17,14 @@ class EstarParser extends Parser{
                 "requestHeaders": [{ "header": "origin", "operation": "remove" }]
             },
             "condition": { "urlFilter" : "estar.jp"}
-        }]
+        }];
         await HttpClient.setDeclarativeNetRequestRules(rule);
 
         let leaves = dom.baseURI.split("/");
         let id = leaves[leaves.length - 1];
         let fetchUrl = "https://estar.jp/api/graphql";
         let formData = {"query":"pages/novels/workId/episodes","data":{"workId":id,"first":30,"page":1}};
-        let header = {"Content-Type": "application/json;charset=UTF-8", "x-from": "https://estar.jp/"}
+        let header = {"Content-Type": "application/json;charset=UTF-8", "x-from": "https://estar.jp/"};
         let options = {
             method: "POST",
             credentials: "include",

--- a/plugin/js/parsers/ExiledrebelsscanlationsParser.js
+++ b/plugin/js/parsers/ExiledrebelsscanlationsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("exiledrebelsscanlations.com", () => new ExiledrebelsscanlationsParser());
 
-class ExiledrebelsscanlationsParser extends Parser{
+class ExiledrebelsscanlationsParser extends Parser {
     constructor() {
         super();
     }
@@ -38,7 +38,7 @@ class ExiledrebelsscanlationsParser extends Parser{
             let notes = [...webPageDom.querySelectorAll("div.easy-footnote-title, ol.easy-footnotes-wrapper")];
             let content = this.findContent(webPageDom);
             this.tagAuthorNotes(notes);
-            for(let e of notes) {
+            for (let e of notes) {
                 content.appendChild(e);
             }
         }

--- a/plugin/js/parsers/FanFicParadiseParser.js
+++ b/plugin/js/parsers/FanFicParadiseParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("fanficparadise.com", () => new FanFicParadiseParser());
 
-class FanFicParadiseParser extends Parser{
+class FanFicParadiseParser extends Parser {
     constructor() {
         super();
         this.cache = new FetchCache();
@@ -13,7 +13,7 @@ class FanFicParadiseParser extends Parser{
         let chapters = [...dom.querySelectorAll("li.threadmarkListItem a")]
             .filter(this.isLinkToChapter);
         return chapters.map(a => util.hyperLinkToChapter(a));
-    };
+    }
 
     isLinkToChapter(link) {
         return !link.querySelector("date")
@@ -22,16 +22,16 @@ class FanFicParadiseParser extends Parser{
 
     findContent(dom) {
         return Parser.findConstrutedContent(dom);
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("h1.p-title-value");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("a.username");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 
     async fetchChapter(url) {
         let fetchedDom = await this.cache.fetch(url);

--- a/plugin/js/parsers/FanFictionParser.js
+++ b/plugin/js/parsers/FanFictionParser.js
@@ -3,10 +3,10 @@
 */
 "use strict";
 
-parserFactory.register("www.fanfiction.net", function() { return new FanFictionParser() });
+parserFactory.register("www.fanfiction.net", function() { return new FanFictionParser(); });
 
 // fictionpress.com has same format as fanfiction.net
-parserFactory.register("www.fictionpress.com", function() { return new FanFictionParser() });
+parserFactory.register("www.fictionpress.com", function() { return new FanFictionParser(); });
 
 class FanFictionParser extends Parser {
     constructor() {
@@ -24,7 +24,7 @@ class FanFictionParser extends Parser {
     }
 
     getOptions(dom) {
-        return [...dom.querySelectorAll("select#chap_select option")]
+        return [...dom.querySelectorAll("select#chap_select option")];
     }
 
     optionToChapterInfo(baseUrl, optionElement) {
@@ -58,7 +58,7 @@ class FanFictionParser extends Parser {
 
     async fetchChapter(url) {
         let dom = await super.fetchChapter(url);
-        this.addTitleToChapter(url, dom)
+        this.addTitleToChapter(url, dom);
         return dom;
     }
 
@@ -68,11 +68,11 @@ class FanFictionParser extends Parser {
         {
             return await super.fetchWebPageContent(webPage);
         }
-        catch(ex)
+        catch (ex)
         {
             //Determine if path contains extra parameters. Immediately fail if already shortened.
             //Shortened URI is not always ideal solution; apparently related to caching on server. 
-            let regex = /(https?:\/\/(?:www\.)?\w+\.\w+\/s\/\d+\/\d+\/)[a-z\-0-9]+/i
+            let regex = /(https?:\/\/(?:www\.)?\w+\.\w+\/s\/\d+\/\d+\/)[a-z\-0-9]+/i;
             let shortUri = regex.exec(webPage.sourceUrl);
             if (shortUri)
             {
@@ -103,10 +103,10 @@ class FanFictionParser extends Parser {
     addTitleToChapter(url, dom) {
         let path = url.split("/");
         let chapterId = path[path.length - 2];
-        for(let option of this.getOptions(dom)) {
+        for (let option of this.getOptions(dom)) {
             if (chapterId === option.getAttribute("value")) {
                 let title = dom.createElement("H1");
-                title.appendChild(dom.createTextNode(option.textContent))
+                title.appendChild(dom.createTextNode(option.textContent));
                 let content = this.findContent(dom);
                 content.insertBefore(title, content.firstChild);
                 break;
@@ -115,21 +115,21 @@ class FanFictionParser extends Parser {
     }
 
     populateInfoDiv(infoDiv, dom) {
-        for(let n of this.getInformationEpubItemChildNodes(dom).filter(n => n != null)) {
+        for (let n of this.getInformationEpubItemChildNodes(dom).filter(n => n != null)) {
             let clone = util.sanitizeNode(n);
             this.cleanInformationNode(clone);
             if (clone != null) {
                 // convert dates to avoid '19hours ago'
-                for(let s of clone.querySelectorAll("span[data-xutime]")) {
+                for (let s of clone.querySelectorAll("span[data-xutime]")) {
                     let time = new Date(1000*s.getAttribute("data-xutime"));
                     s.textContent = time.toLocaleString();
                 }
                 // fix relative url links.
-                for(let a of clone.querySelectorAll("a[href]")) {
-                    a.href = new URL(a["href"], dom.baseURI).href
+                for (let a of clone.querySelectorAll("a[href]")) {
+                    a.href = new URL(a["href"], dom.baseURI).href;
                 }
                 // Fix for > from CSS
-                for(let s of clone.querySelectorAll("span.icon-chevron-right")) {
+                for (let s of clone.querySelectorAll("span.icon-chevron-right")) {
                     s.textContent = " > ";
                 }
                 infoDiv.appendChild(clone);

--- a/plugin/js/parsers/FanficusParser.js
+++ b/plugin/js/parsers/FanficusParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("fanficus.com", () => new FanficusParser());
 
-class FanficusParser extends Parser{
+class FanficusParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/FastNovelParser.js
+++ b/plugin/js/parsers/FastNovelParser.js
@@ -5,29 +5,29 @@ parserFactory.register("fastnovel.net", () => new FastNovelParser());
 //dead url
 parserFactory.register("novelgate.net", () => new FastNovelParser());
 
-class FastNovelParser extends Parser{
+class FastNovelParser extends Parser {
     constructor() {
         super();
     }
 
     getChapterUrls(dom) {
         let chapters = [...dom.querySelectorAll("div#list-chapters li a")]
-            .map(a => util.hyperLinkToChapter(a))
+            .map(a => util.hyperLinkToChapter(a));
         return Promise.resolve(chapters);
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div#chapter-body");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.film-info h1");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("div.film-info ul.meta-data a");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 
     findChapterTitle(dom) {
         return dom.querySelector("h1.episode-name");

--- a/plugin/js/parsers/FenrirealmParser.js
+++ b/plugin/js/parsers/FenrirealmParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("fenrirealm.com", () => new FenrirealmParser());
 
-class FenrirealmParser extends Parser{
+class FenrirealmParser extends Parser {
     constructor() {
         super();
     }
@@ -38,7 +38,7 @@ class FenrirealmParser extends Parser{
         let parts = titleText.split(":");
         return (parts.length >= 2) && (parts[0].trim() === parts[1].trim())
             ? parts.slice(1).join(":")
-            : titleText
+            : titleText;
     }
 
     findCoverImageUrl(dom) {

--- a/plugin/js/parsers/Ffxs8Parser.js
+++ b/plugin/js/parsers/Ffxs8Parser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("ffxs8.com", () => new Ffxs8Parser());
 
-class Ffxs8Parser extends Parser{
+class Ffxs8Parser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/FictionManiaParser.js
+++ b/plugin/js/parsers/FictionManiaParser.js
@@ -7,7 +7,7 @@
 */
 "use strict";
 
-parserFactory.register("fictionmania.tv", function() { return new FictionManiaParser() });
+parserFactory.register("fictionmania.tv", function() { return new FictionManiaParser(); });
 
 class FictionManiaParser extends Parser {
     constructor() {
@@ -42,10 +42,10 @@ class FictionManiaParser extends Parser {
     extractTitleImpl(dom) {
         let that = this;
         return util.getElement(dom.body, "a", e => that.isChapterHref(e));
-    };
+    }
 
     extractAuthor(dom) {
         let author = dom.querySelector("a[href*='/searchdisplay/authordisplay.html?word=']");
         return (author === null) ? super.extractAuthor(dom) : author.innerText;
-    };
+    }
 }

--- a/plugin/js/parsers/FictioneerParser.js
+++ b/plugin/js/parsers/FictioneerParser.js
@@ -3,14 +3,14 @@
 // This is for the Fictioneer WordPress theme: https://github.com/Tetrakern/fictioneer
 
 //dead urls
-parserFactory.register("blossomtranslation.com", function() { return new FictioneerParser() });
-parserFactory.register("igniforge.com", function() { return new FictioneerParser() });
-parserFactory.register("razentl.com", function() { return new FictioneerParser() });
+parserFactory.register("blossomtranslation.com", function() { return new FictioneerParser(); });
+parserFactory.register("igniforge.com", function() { return new FictioneerParser(); });
+parserFactory.register("razentl.com", function() { return new FictioneerParser(); });
 //these still exist
-parserFactory.register("emberlib731.xyz", function() { return new FictioneerParser() });
-parserFactory.register("lilyonthevalley.com", function() { return new FictioneerParser() });
-parserFactory.register("novelib.com", function() { return new FictioneerParser() });
-parserFactory.register("springofromance.com", function() { return new FictioneerParser() });
+parserFactory.register("emberlib731.xyz", function() { return new FictioneerParser(); });
+parserFactory.register("lilyonthevalley.com", function() { return new FictioneerParser(); });
+parserFactory.register("novelib.com", function() { return new FictioneerParser(); });
+parserFactory.register("springofromance.com", function() { return new FictioneerParser(); });
 
 parserFactory.registerRule(
     (url, dom) => FictioneerParser.isFictioneerTheme(dom) * 0.7,
@@ -24,7 +24,7 @@ class FictioneerParser extends Parser {
 
     static isFictioneerTheme(dom) {
         // the html tag has the class "fictioneer-theme"
-        return (dom.querySelector("html.fictioneer-theme") !== null)
+        return (dom.querySelector("html.fictioneer-theme") !== null);
     }
 
     async getChapterUrls(dom) {
@@ -114,7 +114,7 @@ class FictioneerParser extends Parser {
     removeUnwantedElementsFromContentElement(element) {
         util.removeElements(element.querySelectorAll("iframe, .eoc-chapter-groups, .chapter-nav"));
         super.removeUnwantedElementsFromContentElement(element);
-    };
+    }
 
     getInformationEpubItemChildNodes(dom) {
         return [...dom.querySelectorAll(".story__header, .story__summary")];

--- a/plugin/js/parsers/FictionhuntParser.js
+++ b/plugin/js/parsers/FictionhuntParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("fictionhunt.com", () => new FictionhuntParser());
 
-class FictionhuntParser extends Parser{
+class FictionhuntParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/FicwadParser.js
+++ b/plugin/js/parsers/FicwadParser.js
@@ -3,7 +3,7 @@
 */
 "use strict";
 
-parserFactory.register("ficwad.com", function() { return new FicwadParser() });
+parserFactory.register("ficwad.com", function() { return new FicwadParser(); });
 
 class FicwadParser extends Parser {
     constructor() {
@@ -69,7 +69,7 @@ class FicwadParser extends Parser {
         let title = dom.querySelector("div.storylist h4");
         if (title !== null) {
             let s = title.textContent;
-            for(let link of title.querySelectorAll("a")) {
+            for (let link of title.querySelectorAll("a")) {
                 link.remove();
             }
             title.textContent = s;

--- a/plugin/js/parsers/FimfictionParser.js
+++ b/plugin/js/parsers/FimfictionParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("fimfiction.net", () => new FimfictionParser());
 
-class FimfictionParser extends Parser{
+class FimfictionParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/FlyingLinesParser.js
+++ b/plugin/js/parsers/FlyingLinesParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("flying-lines.com", () => new FlyingLinesParser());
 
-class FlyingLinesParser extends Parser{
+class FlyingLinesParser extends Parser {
     constructor() {
         super();
     }
@@ -10,24 +10,24 @@ class FlyingLinesParser extends Parser{
     getChapterUrls(dom) {
         let menu = dom.querySelector("div.chapter-container");
         return Promise.resolve(util.hyperlinksToChapterList(menu));
-    };
+    }
 
     findContent(dom) {
         return Parser.findConstrutedContent(dom);
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.title h2");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("ul.profile li");
         if (authorLabel === null) {
-            return super.extractAuthor(dom)
+            return super.extractAuthor(dom);
         }
         util.removeChildElementsMatchingSelector(authorLabel, "span");
         return authorLabel.textContent;
-    };
+    }
 
     findCoverImageUrl(dom) {
         return util.getFirstImgSrc(dom, "div.novel-thumb");
@@ -35,10 +35,10 @@ class FlyingLinesParser extends Parser{
 
     // this is basically identical to NovelSpread
     fetchChapter(url) {
-        return HttpClient.wrapFetch(url).then(function (xhr) {
+        return HttpClient.wrapFetch(url).then(function(xhr) {
             let restUrl = FlyingLinesParser.extractRestUrl(xhr.responseXML);
             return HttpClient.fetchJson(restUrl);
-        }).then(function (handler) {
+        }).then(function(handler) {
             return FlyingLinesParser.buildChapter(handler.json.data);
         });
     }
@@ -56,7 +56,7 @@ class FlyingLinesParser extends Parser{
         title.textContent = `${json.chapter_number}. ${json.chapter_title}`;
         newDoc.content.appendChild(title);
         let content = util.sanitize(json.chapter_content);
-        for(let n of [...content.body.childNodes]) {
+        for (let n of [...content.body.childNodes]) {
             if (n.className !== "siteCopyrightInfo") {
                 newDoc.content.appendChild(n);
             }

--- a/plugin/js/parsers/FoxaholicParser.js
+++ b/plugin/js/parsers/FoxaholicParser.js
@@ -5,7 +5,7 @@ parserFactory.registerUrlRule(
     () => new FoxaholicParser()
 );
 
-class FoxaholicParser extends WordpressBaseParser{
+class FoxaholicParser extends WordpressBaseParser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/FoxtellerParser.js
+++ b/plugin/js/parsers/FoxtellerParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("foxteller.com", () => new FoxtellerParser());
 
-class FoxtellerParser extends Parser{
+class FoxtellerParser extends Parser {
     constructor() {
         super();
     }
@@ -36,8 +36,8 @@ class FoxtellerParser extends Parser{
     }
 
     async fetchContentForChapter(dom) {
-        let novelRegex = /.*?novel_id'\s?:\s?'([\w\s]+)'/i
-        let chapRegex = /.*?chapter_id'\s?:\s?'([\w\s]+)'/i
+        let novelRegex = /.*?novel_id'\s?:\s?'([\w\s]+)'/i;
+        let chapRegex = /.*?chapter_id'\s?:\s?'([\w\s]+)'/i;
 
         let html = dom.head.innerText;
         let storyID = html.match(novelRegex)[1];
@@ -60,7 +60,7 @@ class FoxtellerParser extends Parser{
     decodeFoxteller(json) {
         var n = json.aux.replace(/%Ra&/g, "A").replace(/%Rc&/g, "B").replace(/%Rb&/g, "C").replace(/%Rd&/g, "D").replace(/%Rf&/g, "E").replace(/%Re&/g, "F");
         return decodeURIComponent(Array.prototype.map.call(atob(n), function(e) {
-            return "%" + ("00" + e.charCodeAt(0).toString(16)).slice(-2)
+            return "%" + ("00" + e.charCodeAt(0).toString(16)).slice(-2);
         }).join(""));   
     }    
 

--- a/plugin/js/parsers/FreelightnovelParser.js
+++ b/plugin/js/parsers/FreelightnovelParser.js
@@ -5,7 +5,7 @@ parserFactory.register("freelightnovel.net", () => new FreelightnovelParser());
 //dead url
 parserFactory.register("m.freelightnovel.net", () => new MFreelightnovelParser());
 
-class FreelightnovelParser extends Parser{
+class FreelightnovelParser extends Parser {
     constructor() {
         super();
     }
@@ -37,7 +37,7 @@ class FreelightnovelParser extends Parser{
     }
 }
 
-class MFreelightnovelParser extends Parser{
+class MFreelightnovelParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/FuhuzzParser.js
+++ b/plugin/js/parsers/FuhuzzParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("fuhuzz.pro", () => new FuhuzzParser());
 
-class FuhuzzParser extends Parser{
+class FuhuzzParser extends Parser {
     constructor() {
         super();
     }
@@ -38,19 +38,19 @@ class FuhuzzParser extends Parser{
         return this.buildChapter(chapjson.images[0], url, id.currentTitle);
     }
 
-    flatObjFn2(obj){
-        var finalObj = {} 
-        for(let key in obj){
-            if(typeof obj[key] === "object"){
+    flatObjFn2(obj) {
+        var finalObj = {}; 
+        for (let key in obj) {
+            if (typeof obj[key] === "object") {
                 Object.assign(finalObj, this.flatObjFn2(obj[key], key));
-            }else{
-                finalObj[key] = obj[key]
+            } else {
+                finalObj[key] = obj[key];
             }
         }
         return finalObj;
     }
 
-    parseNextjsHydration(nextjs){
+    parseNextjsHydration(nextjs) {
         let malformedjson = nextjs.match(/{.*}/s);
         let json;
         if (malformedjson == null) {

--- a/plugin/js/parsers/FullnovelParser.js
+++ b/plugin/js/parsers/FullnovelParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("fullnovel.co", () => new FullnovelParser());
 
-class FullnovelParser extends Parser{
+class FullnovelParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/GamefaqsGamespotParser.js
+++ b/plugin/js/parsers/GamefaqsGamespotParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("gamefaqs.gamespot.com", () => new GamefaqsGamespotParser());
 
-class GamefaqsGamespotParser extends Parser{
+class GamefaqsGamespotParser extends Parser {
     constructor() {
         super();
     }
@@ -11,17 +11,17 @@ class GamefaqsGamespotParser extends Parser{
     async getChapterUrls(dom) {
         let toc = dom.querySelector(".ftoc");
         if (toc !== null) {
-            return this.linksToChapters(dom.baseURI, toc)
+            return this.linksToChapters(dom.baseURI, toc);
         }
         toc = dom.querySelector("div.main_content");
         if (toc !== null) {
             util.removeChildElementsMatchingSelector(toc, "nav.content_nav_wrap");
-            return this.linksToChapters(dom.baseURI, toc)
+            return this.linksToChapters(dom.baseURI, toc);
         }
         return [];
     }
 
-    linksToChapters(base, toc){
+    linksToChapters(base, toc) {
         if (!base.endsWith("/")) {
             base += "/";
         }

--- a/plugin/js/parsers/GenesiStudioParser.js
+++ b/plugin/js/parsers/GenesiStudioParser.js
@@ -5,7 +5,7 @@
 
 parserFactory.register("genesistudio.com", () => new GenesiStudioParser());
 
-class GenesiStudioParser extends Parser{
+class GenesiStudioParser extends Parser {
     constructor() {
         super();
         this.minimumThrottle = 2000;
@@ -35,7 +35,7 @@ class GenesiStudioParser extends Parser{
         return chapters.concat(pchapters);
     }
     
-    async loadEpubMetaInfo(dom){
+    async loadEpubMetaInfo(dom) {
         // eslint-disable-next-line
         let data = (await HttpClient.fetchJson(dom.baseURI + "/__data.json")).json;
         let tmpids = data.nodes[2].data[data.nodes[2].data[0].novel];

--- a/plugin/js/parsers/GlobalNovelpiaParser.js
+++ b/plugin/js/parsers/GlobalNovelpiaParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("global.novelpia.com", () => new GlobalNovelpiaParser());
 
-class GlobalNovelpiaParser extends Parser{
+class GlobalNovelpiaParser extends Parser {
     constructor() {
         super();
     }
@@ -54,7 +54,7 @@ class GlobalNovelpiaParser extends Parser{
     }
 
     findChapterTitle(dom) {
-        return dom.querySelector(".in-ch-txt")
+        return dom.querySelector(".in-ch-txt");
     }
 
     findCoverImageUrl(dom) {

--- a/plugin/js/parsers/GoodNovelParser.js
+++ b/plugin/js/parsers/GoodNovelParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("goodnovel.com", () => new GoodNovelParser());
 
-class GoodNovelParser extends Parser{
+class GoodNovelParser extends Parser {
     constructor() {
         super();
     }
@@ -17,7 +17,7 @@ class GoodNovelParser extends Parser{
             this.extractPartialChapterList, urlsOfTocPages, chapterUrlsUI));
     }
 
-    static extractBookID(dom){
+    static extractBookID(dom) {
         let url = dom.baseURI;
         let retid = null;
         retid = url.match(new RegExp("_[0-9]+$"))?.[0].match(new RegExp("[0-9]+$"))?.[0];
@@ -31,7 +31,7 @@ class GoodNovelParser extends Parser{
     static extractTocPageUrls(dom, baseUrl) {
         let max = GoodNovelParser.extractMaxToc(dom);
         let tocUrls = [];
-        for(let i = 1; i <= max; ++i) {
+        for (let i = 1; i <= max; ++i) {
             tocUrls.push(`${baseUrl}${i}`);
         }
         return tocUrls;
@@ -46,7 +46,7 @@ class GoodNovelParser extends Parser{
     extractPartialChapterList(dom) {
         let ChapterlistNodes = dom.querySelectorAll(".catalog>div.catalog-box");
         let Chapterlist = [];
-        for(let element of ChapterlistNodes){
+        for (let element of ChapterlistNodes) {
             Chapterlist.push(GoodNovelParser.hyperLinkToChapter(element));
         }
         return Chapterlist;
@@ -61,7 +61,7 @@ class GoodNovelParser extends Parser{
         };
     }
     
-    static isLinkLocked(link){
+    static isLinkLocked(link) {
         return (link.querySelector(".cat-lock") == null) ? true : false;
     }
 

--- a/plugin/js/parsers/GraverobbertlParser.js
+++ b/plugin/js/parsers/GraverobbertlParser.js
@@ -3,14 +3,14 @@
 //dead url/ parser
 parserFactory.register("graverobbertl.site", () => new TemplateParser());
 
-class TemplateParser extends Parser{
+class TemplateParser extends Parser {
     constructor() {
         super();
     }
 
     async getChapterUrls(dom) {
         let links = [...dom.querySelectorAll("div.post-entry ul a")]
-            .filter(a => a.host !== "graverobbertl.wordpress.com")
+            .filter(a => a.host !== "graverobbertl.wordpress.com");
         return links.map(a => util.hyperLinkToChapter(a));
     }
 
@@ -35,7 +35,7 @@ class TemplateParser extends Parser{
         let paragraphCount = [...content.querySelectorAll("p")].length;
         let links = [...content.querySelectorAll("a")]
             .filter(a => (a.host === "graverobbertl.site") && 
-                a.textContent.toLowerCase().includes("click here"))
+                a.textContent.toLowerCase().includes("click here"));
         if ((paragraphCount < 20) && (0 < links.length)) {
             dom = (await HttpClient.wrapFetch(links[0].href)).responseXML;
         }
@@ -45,10 +45,10 @@ class TemplateParser extends Parser{
     getInformationEpubItemChildNodes(dom) {
         let children = dom.querySelector("div.post-entry").children;
         let filtered = [];
-        for(let i = 0; i < children.length; ++i) {
+        for (let i = 0; i < children.length; ++i) {
             let e = children[i];
             if (e.tagName === "P") {
-                filtered.push(e)
+                filtered.push(e);
             }
             if (e.tagName === "H2" || e.tagName === "UL") {
                 break;

--- a/plugin/js/parsers/GravityTalesParser.js
+++ b/plugin/js/parsers/GravityTalesParser.js
@@ -1,6 +1,6 @@
 "use strict";
 
-parserFactory.register("gravitytales.com", function() { return new GravityTalesParser() });
+parserFactory.register("gravitytales.com", function() { return new GravityTalesParser(); });
 
 class GravityTalesParser extends Parser {
     constructor() {
@@ -87,11 +87,11 @@ class GravityTalesParser extends Parser {
 
     static fetchUrlsOfChapters(novelId, baseUri, fetchJson) {
         let chapterGroupsUrl = `https://gravitytales.com/api/novels/chaptergroups/${novelId}`;
-        return fetchJson(chapterGroupsUrl).then(function (handler) {
+        return fetchJson(chapterGroupsUrl).then(function(handler) {
             return Promise.all(
                 handler.json.map(group => GravityTalesParser.fetchChapterListForGroup(novelId, group, fetchJson))
             );
-        }).then(function (chapterLists) {
+        }).then(function(chapterLists) {
             return GravityTalesParser.mergeChapterLists(chapterLists, baseUri);
         });
     } 
@@ -99,7 +99,7 @@ class GravityTalesParser extends Parser {
     static fetchChapterListForGroup(novelId, chapterGroup, fetchJson) {
         let groupId = chapterGroup.ChapterGroupId;
         let chaptersUrl = `https://gravitytales.com/api/novels/chaptergroup/${groupId}`;
-        return fetchJson(chaptersUrl).then(function (handler) {
+        return fetchJson(chaptersUrl).then(function(handler) {
             return {
                 groupTitle: chapterGroup.Title,
                 chapters: handler.json
@@ -111,7 +111,7 @@ class GravityTalesParser extends Parser {
         let uniqueChapters = new Set();
         return chapterLists.reduce(function(chapters, chapterList) {
             let groupTitle = chapterList.groupTitle;
-            for(let c of chapterList.chapters) {
+            for (let c of chapterList.chapters) {
                 let url = util.removeTrailingSlash(baseUri + "/" + c.Slug);
                 if (!uniqueChapters.has(url)) {
                     uniqueChapters.add(url);
@@ -119,9 +119,9 @@ class GravityTalesParser extends Parser {
                     // only first chapter in each group gets the arc name
                     if (groupTitle != null) {
                         groupTitle = null; 
-                    };
-                };
-            };
+                    }
+                }
+            }
             return chapters;
         }, []);
     }
@@ -135,7 +135,7 @@ class GravityTalesParser extends Parser {
     }
 
     static searchForNovelIdinScriptTags(dom) {
-        for(let e of dom.querySelectorAll("script")) {
+        for (let e of dom.querySelectorAll("script")) {
             let novelId = GravityTalesParser.searchForNovelIdinString(e.innerText);
             if ( novelId !== null) {
                 return novelId;

--- a/plugin/js/parsers/GunnerkriggParser.js
+++ b/plugin/js/parsers/GunnerkriggParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("gunnerkrigg.com", () => new GunnerkriggParser());
 
-class GunnerkriggParser extends Parser{
+class GunnerkriggParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/GutenbergDEParser.js
+++ b/plugin/js/parsers/GutenbergDEParser.js
@@ -11,9 +11,9 @@
 // Use this function if site's host name is sufficient.  
 // i.e. All pages are on same site, and use same format.
 //dead url/ parser
-parserFactory.register("gutenberg.spiegel.de", function() { return new GutenbergDEParser() });
+parserFactory.register("gutenberg.spiegel.de", function() { return new GutenbergDEParser(); });
 
-class GutenbergDEParser extends Parser{
+class GutenbergDEParser extends Parser {
     constructor() {
         super();
     }
@@ -27,7 +27,7 @@ class GutenbergDEParser extends Parser{
         // to convert the links into a list of URLs the parser will collect.
         let menu = dom.querySelector("ul.gbnav");
         return Promise.resolve(util.hyperlinksToChapterList(menu));        
-    };
+    }
     
 
     // returns the element holding the story content in a chapter
@@ -36,7 +36,7 @@ class GutenbergDEParser extends Parser{
         // typical implementation is find node with all wanted content
         // return is the element holding just the wanted content.
         return dom.querySelector("div#gutenb");
-    };
+    }
     
 
     // title of the story  (not to be confused with title of each chapter)
@@ -47,13 +47,13 @@ class GutenbergDEParser extends Parser{
 
         // this works if chapter 1 contains a cover with separate class attributes 
         let titleElem=dom.querySelector("h2.title");
-        if(null != titleElem) return titleElem.textContent.trim();
+        if (null != titleElem) return titleElem.textContent.trim();
 
         // else rely on the div showing a breadcrumb 
         let gbbreadcrumb=dom.querySelector("div.gbbreadcrumb");
         let titleE=gbbreadcrumb.firstElementChild.nextElementSibling.nextElementSibling;
         return titleE;
-    };
+    }
     
 
     // author of the story
@@ -64,12 +64,12 @@ class GutenbergDEParser extends Parser{
         // Major points to note
 
         let authorElem=dom.querySelector("h3.author");
-        if(null != authorElem) return authorElem.textContent.trim();
+        if (null != authorElem) return authorElem.textContent.trim();
 
         let gbbreadcrumb=dom.querySelector("div.gbbreadcrumb");
         let authorA=gbbreadcrumb.firstElementChild.nextElementSibling;
         if (authorA) return authorA.textContent.trim();
 
         return super.extractAuthor(dom);
-    };
+    }
 }

--- a/plugin/js/parsers/GzbpParser.js
+++ b/plugin/js/parsers/GzbpParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("m.gzbpi.com", () => new GzbpParser());
 
-class GzbpParser extends Parser{
+class GzbpParser extends Parser {
     constructor() {
         super();
     }
@@ -15,13 +15,13 @@ class GzbpParser extends Parser{
             this.getChapterUrlsFromTocPage,
             this.nextTocPageUrl,
             chapterUrlsUI
-        ))
+        ));
     }
 
     getChapterUrlsFromTocPage(dom) {
         return [...dom.querySelectorAll("ul.fk li a")]
             .filter(a => a.href.includes("wapbook"))
-            .map(a => util.hyperLinkToChapter(a))
+            .map(a => util.hyperLinkToChapter(a));
     }
 
     nextTocPageUrl(dom) {

--- a/plugin/js/parsers/HelheimscansParser.js
+++ b/plugin/js/parsers/HelheimscansParser.js
@@ -7,7 +7,7 @@ parserFactory.register("helheimscans.org", () => new HelheimscansParser());
 parserFactory.register("helioscans.com", () => new HelheimscansParser());
 
 
-class HelheimscansParser extends Parser{
+class HelheimscansParser extends Parser {
     constructor() {
         super();
     }
@@ -15,7 +15,7 @@ class HelheimscansParser extends Parser{
     async getChapterUrls(dom) {
         return [...dom.querySelectorAll("#chapters_panel a")]
             .map(this.linkToChapter)
-            .reverse()
+            .reverse();
     }
 
     linkToChapter(link) {

--- a/plugin/js/parsers/HellpingParser.js
+++ b/plugin/js/parsers/HellpingParser.js
@@ -4,7 +4,7 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("hellping.org", function() { return new HellpingParser() });
+parserFactory.register("hellping.org", function() { return new HellpingParser(); });
 
 class HellpingParser extends WordpressBaseParser {
     constructor() {

--- a/plugin/js/parsers/HentaiFoundryParser.js
+++ b/plugin/js/parsers/HentaiFoundryParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("hentai-foundry.com", () => new HentaiFoundryParser());
 
-class HentaiFoundryParser extends Parser{
+class HentaiFoundryParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/HiscensionParser.js
+++ b/plugin/js/parsers/HiscensionParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("hiscension.com", () => new HiscensionParser());
 
-class HiscensionParser extends WordpressBaseParser{
+class HiscensionParser extends WordpressBaseParser {
     constructor() {
         super();
     }
@@ -11,13 +11,13 @@ class HiscensionParser extends WordpressBaseParser{
         let chapters = [...dom.querySelectorAll("table.wp-block-table td a")]
             .map(a => util.hyperLinkToChapter(a));
         return Promise.resolve(chapters);
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div.blog-post-single-content");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("article h1");
-    };
+    }
 }

--- a/plugin/js/parsers/HostednovelParser.js
+++ b/plugin/js/parsers/HostednovelParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("hostednovel.com", () => new HostednovelParser());
 
-class HostednovelParser extends Parser{
+class HostednovelParser extends Parser {
     constructor() {
         super();
     }
@@ -25,7 +25,7 @@ class HostednovelParser extends Parser{
         if (lastLink !== null) {
             let url = new URL(lastLink.href);
             let maxPage = parseInt(url.searchParams.get("page"));
-            for(let i = 2; i <= maxPage; ++i) {
+            for (let i = 2; i <= maxPage; ++i) {
                 url.searchParams.set("page", i);
                 urls.push(url.href);
             }
@@ -49,7 +49,7 @@ class HostednovelParser extends Parser{
 
     chapterUrlsOnPage(dom) {
         return [...dom.querySelectorAll(".chaptergroup a:not([rel])")]
-            .map(a => util.hyperLinkToChapter(a))
+            .map(a => util.hyperLinkToChapter(a));
     }
 
     findContent(dom) {

--- a/plugin/js/parsers/Hui3rParser.js
+++ b/plugin/js/parsers/Hui3rParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("hui3r.wordpress.com", () => new Hui3rParser());
 
-class Hui3rParser extends WordpressBaseParser{
+class Hui3rParser extends WordpressBaseParser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/IdleturtletranslationsParser.js
+++ b/plugin/js/parsers/IdleturtletranslationsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("idleturtle-translations.com", () => new IdleturtletranslationsParser());
 
-class IdleturtletranslationsParser extends Parser{
+class IdleturtletranslationsParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/IdnovelmyidParser.js
+++ b/plugin/js/parsers/IdnovelmyidParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("idnovel.my.id", () => new IdnovelmyidParser());
 
-class IdnovelmyidParser extends Parser{
+class IdnovelmyidParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/ImgurParser.js
+++ b/plugin/js/parsers/ImgurParser.js
@@ -3,7 +3,7 @@
 */
 "use strict";
 
-parserFactory.register("imgur.com", function() { return new ImgurParser() });
+parserFactory.register("imgur.com", function() { return new ImgurParser(); });
 
 parserFactory.registerUrlRule(
     url => Imgur.isImgurHostName(util.extractHostName(url).toLowerCase()),

--- a/plugin/js/parsers/IndomtlParser.js
+++ b/plugin/js/parsers/IndomtlParser.js
@@ -3,19 +3,19 @@
 //dead url/ parser
 parserFactory.register("indomtl.com", () => new IndomtlParser());
 
-class IndomtlParser extends Parser{
+class IndomtlParser extends Parser {
     constructor() {
         super();
     }
 
     async getChapterUrls(dom) {
-        let links = [...dom.querySelectorAll("div#panelchapterlist div[role='list'] a")]
+        let links = [...dom.querySelectorAll("div#panelchapterlist div[role='list'] a")];
         return links.map(IndomtlParser.linkToChapter).reverse();
     }
 
     static linkToChapter(link) {
         util.removeChildElementsMatchingSelector(link, "span.time");
-        return util.hyperLinkToChapter(link)
+        return util.hyperLinkToChapter(link);
     }
 
     findContent(dom) {

--- a/plugin/js/parsers/IndowebnovelParser.js
+++ b/plugin/js/parsers/IndowebnovelParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("indowebnovel.id", () => new IndowebnovelParser());
 
-class IndowebnovelParser extends Parser{
+class IndowebnovelParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/InkittParser.js
+++ b/plugin/js/parsers/InkittParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("inkitt.com", () => new InkittParser());
 
-class InkittParser extends Parser{
+class InkittParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/InoveltranslationParser.js
+++ b/plugin/js/parsers/InoveltranslationParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("inoveltranslation.com", () => new InoveltranslationParser());
 
-class InoveltranslationParser extends Parser{
+class InoveltranslationParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/IsekaiScanParser.js
+++ b/plugin/js/parsers/IsekaiScanParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("isekaiscan.com", () => new IsekaiScanParser());
 
-class IsekaiScanParser extends Parser{
+class IsekaiScanParser extends Parser {
     constructor() {
         super();
     }
@@ -15,7 +15,7 @@ class IsekaiScanParser extends Parser{
 
     findContent(dom) {
         let content = dom.querySelector("div.reading-content");
-        for(let i of content.querySelectorAll("img")) {
+        for (let i of content.querySelectorAll("img")) {
             let data_src = i.getAttribute("data-src");
             if (!util.isNullOrEmpty(data_src)) {
                 i.src = data_src;

--- a/plugin/js/parsers/IsotlsParser.js
+++ b/plugin/js/parsers/IsotlsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("isotls.com", () => new IsotlsParser());
 
-class IsotlsParser extends Parser{
+class IsotlsParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/JadeRabbitParser.js
+++ b/plugin/js/parsers/JadeRabbitParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("jade-rabbit.net", () => new JadeRabbitParser());
 
-class JadeRabbitParser extends Parser{
+class JadeRabbitParser extends Parser {
     constructor() {
         super();
     }
@@ -22,7 +22,7 @@ class JadeRabbitParser extends Parser{
     }
 
     static nextTocPageUrl(dom) {
-        let link = dom.querySelector("div.older a")
+        let link = dom.querySelector("div.older a");
         return link === null ? null : link.href;
     }
 

--- a/plugin/js/parsers/JaptemParser.js
+++ b/plugin/js/parsers/JaptemParser.js
@@ -3,7 +3,7 @@
 */
 "use strict";
 
-parserFactory.register("japtem.com", function() { return new JaptemParser() });
+parserFactory.register("japtem.com", function() { return new JaptemParser(); });
 
 class JaptemParser extends Parser {
     constructor() {

--- a/plugin/js/parsers/JjwxcParser.js
+++ b/plugin/js/parsers/JjwxcParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("jjwxc.net", () => new JjwxcParser());
 
-class JjwxcParser extends Parser{
+class JjwxcParser extends Parser {
     constructor() {
         super();
     }
@@ -44,7 +44,7 @@ class JjwxcParser extends Parser{
         element.querySelector("#report_box")?.parentElement?.remove();
         util.removeChildElementsMatchingSelector(element, ".readsmall, div[align='right']");
         this.fixupAuthorNote(element);
-        for(let div of element.querySelectorAll("div")) {
+        for (let div of element.querySelectorAll("div")) {
             div.style = null;
         }
         super.removeUnwantedElementsFromContentElement(element);

--- a/plugin/js/parsers/JonaxxstoriesParser.js
+++ b/plugin/js/parsers/JonaxxstoriesParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("jonaxxstories.com", () => new JonaxxstoriesParser());
 
-class JonaxxstoriesParser extends WordpressBaseParser{
+class JonaxxstoriesParser extends WordpressBaseParser {
     constructor() {
         super();
     }
@@ -13,10 +13,10 @@ class JonaxxstoriesParser extends WordpressBaseParser{
             this.getUrlsOfTocPages,
             chapterUrlsUI
         )).reverse();
-    };
+    }
 
     getUrlsOfTocPages(dom) {
-        let urls = []
+        let urls = [];
         let lastLink = [...dom.querySelectorAll(".nav-links a:not(.next)")]
             .slice(-1);
         if (0 < lastLink.length)
@@ -25,7 +25,7 @@ class JonaxxstoriesParser extends WordpressBaseParser{
             let href = lastLink[0].href;
             let index = href.lastIndexOf("/", href.length - 2);
             href = href.substring(0, index + 1);
-            for(let i = 2; i <= max; ++i) {
+            for (let i = 2; i <= max; ++i) {
                 urls.push(href + i + "/");
             }
         }

--- a/plugin/js/parsers/JpmtlParser.js
+++ b/plugin/js/parsers/JpmtlParser.js
@@ -3,13 +3,13 @@
 //dead url/ parser
 parserFactory.register("jpmtl.com", () => new JpmtlParser());
 
-class JpmtlParser extends Parser{
+class JpmtlParser extends Parser {
     constructor() {
         super();
     }
 
     async getChapterUrls(dom) {
-        let chapters = [...dom.querySelectorAll("a.book-ccontent__content")]
+        let chapters = [...dom.querySelectorAll("a.book-ccontent__content")];
         return chapters.map(this.linkToChapter);
     }
 

--- a/plugin/js/parsers/KakaoParser.js
+++ b/plugin/js/parsers/KakaoParser.js
@@ -11,19 +11,19 @@ class KakaoParser extends Parser {
     }
 
     async setAuthorizationToken() {
-        if(typeof this.token === "undefined") {
+        if (typeof this.token === "undefined") {
             const jsonUrl = "https://page.kakao.com/api/login";
 
             const fetchOptions = {
                 method: "POST",
                 credentials: "include"
-            }
+            };
 
             return HttpClient.fetchJson(jsonUrl, fetchOptions);
         }
     }
 
-    async wrapFetch(jsonUrl){
+    async wrapFetch(jsonUrl) {
         // disable doing authentication, seems to have changed.
         return HttpClient.fetchJson(jsonUrl);        
 
@@ -92,7 +92,7 @@ class KakaoParser extends Parser {
 
             let div = doc.dom.createElement("div");
             div.id = "content";
-            for(let i = 1; i < body.length; ++i){
+            for (let i = 1; i < body.length; ++i) {
                 let p = doc.dom.createElement("p");
                 p.textContent = body[i];
                 div.appendChild(p);
@@ -120,7 +120,7 @@ class KakaoParser extends Parser {
             let json = jsonResponse.json;
 
             let chapterList = [];
-            for(let chapter of json.content) {
+            for (let chapter of json.content) {
                 let url = dom.baseURI.replace("pagestage", "api-pagestage")
                     + "/episodes/" + chapter.id;
                 let chapterInfo = {

--- a/plugin/js/parsers/KakuyomuParser.js
+++ b/plugin/js/parsers/KakuyomuParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("kakuyomu.jp", () => new KakuyomuParser());
 
-class KakuyomuParser extends Parser{
+class KakuyomuParser extends Parser {
     constructor() {
         super();
     }
@@ -16,8 +16,8 @@ class KakuyomuParser extends Parser{
         let script = dom.querySelector("script#__NEXT_DATA__").innerHTML;
         let json = JSON.parse(script).props.pageProps.__APOLLO_STATE__;
         let work = json["Work:" + this.extractWorkId(dom)];
-        let chapters = []
-        for(let tocc of work.tableOfContents) {
+        let chapters = [];
+        for (let tocc of work.tableOfContents) {
             this.buildSubToc(chapters, json[tocc.__ref], json, dom.baseURI);
         }
         return chapters;
@@ -31,7 +31,7 @@ class KakuyomuParser extends Parser{
 
     buildSubToc(chapters, tocc, json, baseURI) {
         let arcStartIndex = chapters.length;
-        for(let episoderef of tocc.episodeUnions) {
+        for (let episoderef of tocc.episodeUnions) {
             let episode = this.buildEpisode(json[episoderef.__ref], baseURI);
             chapters.push(episode);
         }

--- a/plugin/js/parsers/KariStudioParser.js
+++ b/plugin/js/parsers/KariStudioParser.js
@@ -1,6 +1,6 @@
 "use strict";
 
-parserFactory.register("karistudio.com", function () {return new KariStudioParser();});
+parserFactory.register("karistudio.com", function() {return new KariStudioParser();});
 
 class KariStudioParser extends Parser {
     constructor() {

--- a/plugin/js/parsers/KaystlsParser.js
+++ b/plugin/js/parsers/KaystlsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("kaystls.site", () => new KaystlsParser());
 
-class KaystlsParser extends Parser{
+class KaystlsParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/KemonopartyParser.js
+++ b/plugin/js/parsers/KemonopartyParser.js
@@ -5,7 +5,7 @@ parserFactory.registerRule(
     () => new KemonopartyParser()
 );
 
-class KemonopartyParser extends Parser{
+class KemonopartyParser extends Parser {
     constructor() {
         super();
     }
@@ -18,7 +18,7 @@ class KemonopartyParser extends Parser{
     async getChapterUrls(dom, chapterUrlsUI) {
         let chapters = [];
         let urlsOfTocPages = await this.getUrlsOfTocPages(dom);
-        for(let url of urlsOfTocPages) {
+        for (let url of urlsOfTocPages) {
             await this.rateLimitDelay();
             let json = (await HttpClient.fetchJson(url)).json;
             json.url = url;
@@ -27,7 +27,7 @@ class KemonopartyParser extends Parser{
             chapters = chapters.concat(partialList);
         }
         return chapters.reverse();
-    };
+    }
 
     async fetchChapter(url) {
         let json = (await HttpClient.fetchJson(url)).json;
@@ -69,7 +69,7 @@ class KemonopartyParser extends Parser{
         let urlbuilderjson = (await HttpClient.fetchJson(urlbuilder)).json;
         let lastPageOffset = urlbuilderjson.props.count - (urlbuilderjson.props.count%50);
         let urls = [];
-        for(let i = 0; i <= lastPageOffset; i += 50) {
+        for (let i = 0; i <= lastPageOffset; i += 50) {
             urlbuilder.searchParams.set("o", i);
             urls.push(urlbuilder.href);
         }
@@ -100,7 +100,7 @@ class KemonopartyParser extends Parser{
     copyImagesIntoContent(dom) {
         let content = this.findContent(dom);
         let images = [...dom.querySelectorAll("div.post__files div.post__thumbnail figure a img")];
-        for(let img of images) {
+        for (let img of images) {
             content.append(img);
         }
     }
@@ -117,7 +117,7 @@ class KemonopartyParser extends Parser{
         let filesheader = newDoc.dom.createElement("h2");
         newDoc.content.appendChild(filesheader);
         filesheader.textContent = "Files";
-        for(let i of images) {
+        for (let i of images) {
             let img = newDoc.dom.createElement("img");
             img.src = i.server + "/data" + i.path;
             newDoc.content.append(img);

--- a/plugin/js/parsers/KobatochanParser.js
+++ b/plugin/js/parsers/KobatochanParser.js
@@ -1,16 +1,16 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("kobatochan.com", function () { return new KobatochanParser() });
+parserFactory.register("kobatochan.com", function() { return new KobatochanParser(); });
 
-class KobatochanParser extends WordpressBaseParser{
+class KobatochanParser extends WordpressBaseParser {
     constructor() {
         super();
     }
 
     fetchChapter(url) {
         let that = this;
-        return HttpClient.wrapFetch(url).then(function (xhr) {
+        return HttpClient.wrapFetch(url).then(function(xhr) {
             let newDom = xhr.responseXML;
             let extraPageUrls = KobatochanParser.findAdditionalPageUrls(newDom);
             KobatochanParser.removePaginationElements(newDom);
@@ -33,7 +33,7 @@ class KobatochanParser extends WordpressBaseParser{
         if (extraPageUrls.length === 0) {
             return Promise.resolve(dom);
         }
-        return HttpClient.wrapFetch(extraPageUrls.pop()).then(function (xhr) {
+        return HttpClient.wrapFetch(extraPageUrls.pop()).then(function(xhr) {
             let newDom = xhr.responseXML;
             KobatochanParser.removePaginationElements(newDom);
             let dest = that.findContent(dom);

--- a/plugin/js/parsers/KrytykalParser.js
+++ b/plugin/js/parsers/KrytykalParser.js
@@ -3,7 +3,7 @@
 */
 "use strict";
 
-parserFactory.register("krytykal.org", function() { return new KrytykalParser() });
+parserFactory.register("krytykal.org", function() { return new KrytykalParser(); });
 
 class KrytykalParser extends Parser {
     constructor() {

--- a/plugin/js/parsers/LanrySpaceParser.js
+++ b/plugin/js/parsers/LanrySpaceParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("lanry.space", () => new LanrySpaceParser());
 
-class LanrySpaceParser extends Parser{
+class LanrySpaceParser extends Parser {
     constructor() {
         super();
         this.bookid = "";
@@ -12,7 +12,7 @@ class LanrySpaceParser extends Parser{
         let slug = this.getSlug(dom);
         let bookinfo = await this.fetchBookinfo(dom);
         this.bookid = bookinfo.id;
-        let unlocked = new Set()
+        let unlocked = new Set();
         bookinfo.chapter_unlocks.map(a => unlocked.add(a.chapter_number));
         let currenttime = Date.now();
         let chapterlist = [...bookinfo.chapters];
@@ -29,7 +29,7 @@ class LanrySpaceParser extends Parser{
     async fetchBookinfo(dom) {
         let slug = this.getSlug(dom);
         let apikey = "&apikey=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZrZ2toaXBhc3hxeGl0d2xrdHd6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzAyMzE4MzMsImV4cCI6MjA0NTgwNzgzM30.mHBd2yrRm934yPGy4pui3p7cW4FxfIf6yxh7b2TpUA8";
-        let apibasetoc = "https://vkgkhipasxqxitwlktwz.supabase.co/rest/v1/novels?select=*%2Cchapter_unlocks%21left%28chapter_number%2Cprofile_id%29%2Ccategories%3Acategories_on_novels%28category%3Acategory_id%28id%2Cname%2Ccreated_at%2Cupdated_at%29%29%2Ctags%3Atags_on_novels%21left%28novel_id%2Ctag_id%2Ccreated_at%2Ctag%3Atag_id%28id%2Cname%2Cdescription%29%29%2Cchapters%28id%2Ctitle%2Ccreated_at%2Cchapter_number%2Cpart_number%2Cpublish_at%2Ccoins%2Cvolume_id%2Cage_rating%29"
+        let apibasetoc = "https://vkgkhipasxqxitwlktwz.supabase.co/rest/v1/novels?select=*%2Cchapter_unlocks%21left%28chapter_number%2Cprofile_id%29%2Ccategories%3Acategories_on_novels%28category%3Acategory_id%28id%2Cname%2Ccreated_at%2Cupdated_at%29%29%2Ctags%3Atags_on_novels%21left%28novel_id%2Ctag_id%2Ccreated_at%2Ctag%3Atag_id%28id%2Cname%2Cdescription%29%29%2Cchapters%28id%2Ctitle%2Ccreated_at%2Cchapter_number%2Cpart_number%2Cpublish_at%2Ccoins%2Cvolume_id%2Cage_rating%29";
         return (await HttpClient.fetchJson(apibasetoc+slug+apikey)).json[0];
     }
 
@@ -43,7 +43,7 @@ class LanrySpaceParser extends Parser{
             : slug;
     }
 
-    sourceURL(a, slug){
+    sourceURL(a, slug) {
         if (a.part_number == null) {
             return "https://www.lanry.space/novels/"+slug+"/c" + a.chapter_number;
         } else {
@@ -51,7 +51,7 @@ class LanrySpaceParser extends Parser{
         }
     }
 
-    chtitle(a){
+    chtitle(a) {
         let chapNum = (a.part_number == null)
             ? `Ch. ${a.chapter_number}`
             : `Ch. ${a.chapter_number}-${a.part_number}`;
@@ -60,7 +60,7 @@ class LanrySpaceParser extends Parser{
             : chapNum;
     }
     
-    async loadEpubMetaInfo(dom){
+    async loadEpubMetaInfo(dom) {
         let bookinfo = await this.fetchBookinfo(dom);
         this.title = bookinfo.title;
         this.author = bookinfo.author;

--- a/plugin/js/parsers/LibersparkParser.js
+++ b/plugin/js/parsers/LibersparkParser.js
@@ -4,11 +4,11 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("liberspark.com", function() { return new LibersparkParser() });
+parserFactory.register("liberspark.com", function() { return new LibersparkParser(); });
 //dead url
-parserFactory.register("veratales.com", function() { return new LibersparkParser() });
+parserFactory.register("veratales.com", function() { return new LibersparkParser(); });
 
-class LibersparkParser extends Parser{
+class LibersparkParser extends Parser {
     constructor() {
         super();
     }
@@ -16,19 +16,19 @@ class LibersparkParser extends Parser{
     getChapterUrls(dom) {
         // Page in browser has chapter links reduced to 5
         // Fetch page again to get all chapter links.
-        return HttpClient.wrapFetch(dom.baseURI).then(function (xhr) {
+        return HttpClient.wrapFetch(dom.baseURI).then(function(xhr) {
             let table = xhr.responseXML.querySelector("table#novel-chapters-list");
             return util.hyperlinksToChapterList(table).reverse();
         });
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div#chapter_body");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("h1");
-    };
+    }
 
     findCoverImageUrl(dom) {
         return util.getFirstImgSrc(dom, "div.card-header");

--- a/plugin/js/parsers/Libri7Parser.js
+++ b/plugin/js/parsers/Libri7Parser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("libri7.com", () => new Libri7Parser());
 
-class Libri7Parser extends Parser{
+class Libri7Parser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/LightNovelBastionParser.js
+++ b/plugin/js/parsers/LightNovelBastionParser.js
@@ -1,6 +1,6 @@
 "use strict";
 
-parserFactory.register("lightnovelbastion.com", function() { return new LightNovelBastionParser() });
+parserFactory.register("lightnovelbastion.com", function() { return new LightNovelBastionParser(); });
 
 class LightNovelBastionParser extends Parser {
     constructor() {
@@ -27,7 +27,7 @@ class LightNovelBastionParser extends Parser {
             return element.textContent;
         }
         return null;
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("div.author-content");

--- a/plugin/js/parsers/LightNovelWorldParser.js
+++ b/plugin/js/parsers/LightNovelWorldParser.js
@@ -13,7 +13,7 @@ parserFactory.register("webnovelpub.com", () => new LightNovelWorldParser());
 parserFactory.register("webnovelpub.pro", () => new LightNovelWorldParser());
 parserFactory.register("pandanovel.co", () => new LightNovelWorldParser());
 
-class LightNovelWorldParser extends Parser{
+class LightNovelWorldParser extends Parser {
     constructor() {
         super();
     }
@@ -25,7 +25,7 @@ class LightNovelWorldParser extends Parser{
         let chapters = this.extractPartialChapterList(dom);
         let urlsOfTocPages  = this.getUrlsOfTocPages(dom);
 
-        for(let url of urlsOfTocPages) {
+        for (let url of urlsOfTocPages) {
             await this.rateLimitDelay();
             let newDom = (await HttpClient.wrapFetch(url)).responseXML;
             let partialList = this.extractPartialChapterList(newDom);
@@ -59,13 +59,13 @@ class LightNovelWorldParser extends Parser{
     }
 
     getUrlsOfTocPages(dom) {
-        let urls = []
+        let urls = [];
         let paginateUrls = [...dom.querySelectorAll("ul.pagination li a")]
             .map(a => a.href);
         if (0 < paginateUrls.length) {
             let maxPage = this.maxPageId(paginateUrls);
             let url = new URL(paginateUrls[0]);
-            for(let i = 2; i <= maxPage; ++i) {
+            for (let i = 2; i <= maxPage; ++i) {
                 url.searchParams.set("page", i);
                 urls.push(url.href);
             }
@@ -78,7 +78,7 @@ class LightNovelWorldParser extends Parser{
         let pageNum = function(url) {
             let pageNo = new URL(url).searchParams.get("page");
             return parseInt(pageNo);
-        }
+        };
         return urls.reduce((p, c) => Math.max(p, pageNum(c)), 0);
     }
 
@@ -139,19 +139,19 @@ class LightNovelWorldParser extends Parser{
     }
 }
 
-class LightNovelPubParser extends LightNovelWorldParser{
+class LightNovelPubParser extends LightNovelWorldParser {
     constructor() {
         super();
         this.minimumThrottle = 1200;
     }
 }
 
-class NovelfireParser extends LightNovelWorldParser{
+class NovelfireParser extends LightNovelWorldParser {
     constructor() {
         super();
     }
     
-    removeUnwantedElementsFromContentElement(element){
+    removeUnwantedElementsFromContentElement(element) {
         util.removeHTMLUnknownElement(element);
         super.removeUnwantedElementsFromContentElement(element);
     }

--- a/plugin/js/parsers/LightNovelsTranslationsParser.js
+++ b/plugin/js/parsers/LightNovelsTranslationsParser.js
@@ -1,8 +1,8 @@
 "use strict";
 
-parserFactory.register("lightnovelstranslations.com", function() { return new LightNovelsTranslationsParser() });
+parserFactory.register("lightnovelstranslations.com", function() { return new LightNovelsTranslationsParser(); });
 
-class LightNovelsTranslationsParser extends WordpressBaseParser{
+class LightNovelsTranslationsParser extends WordpressBaseParser {
     constructor() {
         super();
     }
@@ -10,7 +10,7 @@ class LightNovelsTranslationsParser extends WordpressBaseParser{
     async getChapterUrls(dom) {
         return [...dom.querySelectorAll("li.chapter-item a")]
             .map(a => util.hyperLinkToChapter(a));
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div.text_story");

--- a/plugin/js/parsers/LightnovelboxParser.js
+++ b/plugin/js/parsers/LightnovelboxParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("lightnovelbox.com", () => new LightnovelboxParser());
 
-class LightnovelboxParser extends Parser{
+class LightnovelboxParser extends Parser {
     constructor() {
         super();
     }
@@ -11,7 +11,7 @@ class LightnovelboxParser extends Parser{
         let links = [...dom.querySelectorAll("ul.chapter-list a")];
         let chapters = LightnovelboxParser.linksToChapters(links);
         let urls = LightnovelboxParser.getUrlsOfTocPages(dom);
-        for(let url of urls) {
+        for (let url of urls) {
             let rawDom = (await HttpClient.fetchJson(url)).json.chapters;
             links = [...util.sanitize(rawDom).querySelectorAll("a")];
             let partialList = LightnovelboxParser.linksToChapters(links);

--- a/plugin/js/parsers/LightnovelfrParser.js
+++ b/plugin/js/parsers/LightnovelfrParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("lightnovelfr.com", () => new LightnovelfrParser());
 
-class LightnovelfrParser extends Parser{
+class LightnovelfrParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/LightnovelreadParser.js
+++ b/plugin/js/parsers/LightnovelreadParser.js
@@ -4,7 +4,7 @@
 parserFactory.register("lightnovelread.com", () => new LightnovelreadParser());
 parserFactory.register("goblinsguide.com", () => new GoblinsguideParser());
 
-class LightnovelreadParser extends WordpressBaseParser{
+class LightnovelreadParser extends WordpressBaseParser {
     constructor() {
         super();
     }
@@ -13,7 +13,7 @@ class LightnovelreadParser extends WordpressBaseParser{
         let cat_id, countPosts, baseUrl;
         [cat_id, countPosts, baseUrl] = this.extractScript(dom);
         let chapters = [];
-        for(let offset = 0; offset < countPosts; offset += 100) {
+        for (let offset = 0; offset < countPosts; offset += 100) {
             let formData = this.createFormData(cat_id, offset);
             let partialList = await (this.fetchToc(formData, baseUrl));
             chapterUrlsUI.showTocProgress(partialList);
@@ -29,7 +29,7 @@ class LightnovelreadParser extends WordpressBaseParser{
         let script = [...dom.querySelectorAll("script")]
             .filter(s => s.innerText.includes(search))
             .map(s => s.innerText);
-        script = script[0].split("\n")
+        script = script[0].split("\n");
         let cat_id = this.extractNumber(script, search);
         let countPosts = this.extractNumber(script, "const countPosts = ");
         return [cat_id, countPosts, baseUrl];
@@ -80,7 +80,7 @@ class LightnovelreadParser extends WordpressBaseParser{
     }
 }
 
-class GoblinsguideParser extends LightnovelreadParser{
+class GoblinsguideParser extends LightnovelreadParser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/LightnovelreaderParser.js
+++ b/plugin/js/parsers/LightnovelreaderParser.js
@@ -7,7 +7,7 @@ parserFactory.register("lnreader.org", () => new LightnovelreaderParser());
 //dead url
 parserFactory.register("readlitenovel.com", () => new LightnovelreaderParser());
 
-class LightnovelreaderParser extends Parser{
+class LightnovelreaderParser extends Parser {
     constructor() {
         super();
     }
@@ -26,7 +26,7 @@ class LightnovelreaderParser extends Parser{
     }
 
     extractAuthor(dom) {
-        let authorLabel = [...dom.querySelectorAll("a[href*='author']")].map(x => x.textContent.trim())
+        let authorLabel = [...dom.querySelectorAll("a[href*='author']")].map(x => x.textContent.trim());
         return (authorLabel.length === 0) ? super.extractAuthor(dom) : authorLabel.join(", ");
     }
 

--- a/plugin/js/parsers/LightnovelsmeParser.js
+++ b/plugin/js/parsers/LightnovelsmeParser.js
@@ -7,7 +7,7 @@ parserFactory.register("pandapama.com", () => new LightnovelsmeParser());
 //dead url
 parserFactory.register("lightnovels.live", () => new LightnovelsmeParser());
 
-class LightnovelsmeParser extends Parser{
+class LightnovelsmeParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/LiteroticaParser.js
+++ b/plugin/js/parsers/LiteroticaParser.js
@@ -3,15 +3,15 @@
 */
 "use strict";
 
-parserFactory.register("literotica.com", function() { return new LiteroticaParser() });
+parserFactory.register("literotica.com", function() { return new LiteroticaParser(); });
 
-class LiteroticaParser extends Parser{
+class LiteroticaParser extends Parser {
     constructor() {
         super();
     }
 
     async getChapterUrls(dom, chapterUrlsUI) {
-        const section = dom.baseURI.split("//")[1].split("/")[1]
+        const section = dom.baseURI.split("//")[1].split("/")[1];
 
         return this.getChapterUrlsFromMultipleTocPages(
             dom,
@@ -20,69 +20,69 @@ class LiteroticaParser extends Parser{
                 ? this.getUrlOfTopTocPages
                 : this.getUrlOfCategoryTocPages,
             chapterUrlsUI
-        )
+        );
     }
 
     getUrlOfTopTocPages(dom) {
-        const link = dom.querySelector("span.pwrpr a:last-child ")
-        let urls = []
+        const link = dom.querySelector("span.pwrpr a:last-child ");
+        let urls = [];
         if (link != null) {
-            const limit = parseInt(link.text)
+            const limit = parseInt(link.text);
             for (let i = 1; i <= limit; i++) {
-                urls.push(LiteroticaParser.buildTopUrl(link, i))
+                urls.push(LiteroticaParser.buildTopUrl(link, i));
             }
         }
-        return urls
+        return urls;
     }
     getUrlOfCategoryTocPages(dom) {
-        const link = dom.querySelector("div.b-alpha-links li:last-child a")
+        const link = dom.querySelector("div.b-alpha-links li:last-child a");
 
-        let urls = []
+        let urls = [];
         if (link != null) {
-            const limit = parseInt(link.href.split("/").pop())
+            const limit = parseInt(link.href.split("/").pop());
 
             for (let i = 1; i <= limit; i++) {
-                urls.push(LiteroticaParser.buildCategoryUrl(link, i))
+                urls.push(LiteroticaParser.buildCategoryUrl(link, i));
             }
         }
 
-        return urls
+        return urls;
     }
 
     static buildTopUrl(link, i) {
-        link.search = `?page=${i}`
-        return link.href
+        link.search = `?page=${i}`;
+        return link.href;
     }
     static buildCategoryUrl(link, i) {
-        const pathname = link.pathname.split("/").slice(0, -1)
-        link.pathname = pathname.join("/") + `/${i}-page`
-        return link.href
+        const pathname = link.pathname.split("/").slice(0, -1);
+        link.pathname = pathname.join("/") + `/${i}-page`;
+        return link.href;
     }
 
     chaptersFromMemberPage(dom) {
-        const section = dom.baseURI.split("//")[1].split("/")[1]
+        const section = dom.baseURI.split("//")[1].split("/")[1];
 
         if (section === "series") {
-            let links = [...dom.querySelectorAll("ul.series__works li a.br_rj")]
-            return links.map((a) => util.hyperLinkToChapter(a))
+            let links = [...dom.querySelectorAll("ul.series__works li a.br_rj")];
+            return links.map((a) => util.hyperLinkToChapter(a));
         } else if (section === "s") {
-            let content = dom.querySelector("div.aa_ht")
-            return content === null ? [] : util.hyperlinksToChapterList(content)
-        } else if (section === "stories"){
+            let content = dom.querySelector("div.aa_ht");
+            return content === null ? [] : util.hyperlinksToChapterList(content);
+        } else if (section === "stories") {
             let links = [...dom.querySelectorAll("td.fc a, div.b-story-list-box h3 a, div.b-story-list h3 a")];
             if (0 < links.length) {
-                return links.map((a) => util.hyperLinkToChapter(a))
+                return links.map((a) => util.hyperLinkToChapter(a));
             }
-            let content = dom.querySelector("div.b-story-list")
-            return content === null ? [] : util.hyperlinksToChapterList(content)
+            let content = dom.querySelector("div.b-story-list");
+            return content === null ? [] : util.hyperlinksToChapterList(content);
         } 
         else {
-            let links = [...dom.querySelectorAll("td.mcol a:first-child")]
+            let links = [...dom.querySelectorAll("td.mcol a:first-child")];
             if (0 < links.length) {
-                return links.map((a) => util.hyperLinkToChapter(a))
+                return links.map((a) => util.hyperLinkToChapter(a));
             }
-            let content = dom.querySelector("div.b-story-list")
-            return content === null ? [] : util.hyperlinksToChapterList(content)
+            let content = dom.querySelector("div.b-story-list");
+            return content === null ? [] : util.hyperlinksToChapterList(content);
         }
     }
 
@@ -102,7 +102,7 @@ class LiteroticaParser extends Parser{
 
     findContent(dom) {
         return LiteroticaParser.contentForPage(dom);
-    };
+    }
 
     static contentForPage(dom) {
         return dom.querySelector("div.aa_ht")
@@ -115,11 +115,11 @@ class LiteroticaParser extends Parser{
 
     fetchChapter(url) {
         let dom = null;
-        return HttpClient.wrapFetch(url).then(function (xhr) {
+        return HttpClient.wrapFetch(url).then(function(xhr) {
             dom = xhr.responseXML;
             let pageUrls = LiteroticaParser.findUrlsOfAdditionalPagesMakingChapter(url, dom);
             return Promise.all(pageUrls.map(LiteroticaParser.fetchAdditionalPageContent));
-        }).then(function (fragments) {
+        }).then(function(fragments) {
             return LiteroticaParser.assembleChapter(dom, fragments);
         });
     }
@@ -130,22 +130,22 @@ class LiteroticaParser extends Parser{
             .filter(t => t !== 1);
         let urls = [];
         const totalPages = (0 < pageIds.length) ? pageIds.pop() : 0;
-        for(let i = 2; i <= totalPages; ++i) {
+        for (let i = 2; i <= totalPages; ++i) {
             urls.push(`${url}?page=${i}`);
         }
         return urls;
     }
 
     static fetchAdditionalPageContent(url) {
-        return HttpClient.wrapFetch(url).then(function (xhr) {
+        return HttpClient.wrapFetch(url).then(function(xhr) {
             return LiteroticaParser.contentForPage(xhr.responseXML);
         });
     }
 
     static assembleChapter(dom, fragments) {
         let content = LiteroticaParser.contentForPage(dom);
-        for(let f of fragments.filter(f => f !== null)) {
-            while(0 < f.children.length) {
+        for (let f of fragments.filter(f => f !== null)) {
+            while (0 < f.children.length) {
                 content.appendChild(f.children[0]);
             }
         }

--- a/plugin/js/parsers/LnmtlParser.js
+++ b/plugin/js/parsers/LnmtlParser.js
@@ -4,7 +4,7 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("lnmtl.com", function() { return new LnmtlParser() });
+parserFactory.register("lnmtl.com", function() { return new LnmtlParser(); });
 
 class LnmtlParser extends Parser {
     constructor() {
@@ -19,10 +19,10 @@ class LnmtlParser extends Parser {
     getChapterUrls(dom) {
         let volumesList = LnmtlParser.findVolumesList(dom);
         if (volumesList.length !== 0) {
-            return LnmtlParser.fetchChapterLists(volumesList, HttpClient.fetchJson).then(function (lists) {
+            return LnmtlParser.fetchChapterLists(volumesList, HttpClient.fetchJson).then(function(lists) {
                 return LnmtlParser.mergeChapterLists(lists); 
             });
-        };
+        }
 
         let table = dom.querySelector("#volumes-container table");
         return Promise.resolve(util.hyperlinksToChapterList(table));
@@ -37,7 +37,7 @@ class LnmtlParser extends Parser {
     }
 
     customRawDomToContentStep(chapter, content) {
-        for(let s of content.querySelectorAll("sentence")) {
+        for (let s of content.querySelectorAll("sentence")) {
             if (this.userPreferences.removeOriginal.value && s.className === "original") {
                 s.remove();
             } else if (this.userPreferences.removeTranslated.value && s.className === "translated") {
@@ -75,15 +75,15 @@ class LnmtlParser extends Parser {
 
     static fetchChapterListsForVolume(volumeInfo, fetchJson) {
         let restUrl = LnmtlParser.makeChapterListUrl(volumeInfo.id, 1);
-        return fetchJson(restUrl).then(function (handler) {
+        return fetchJson(restUrl).then(function(handler) {
             let firstPage = handler.json;
             let pagesForVolume = [Promise.resolve(handler)];
-            for( let i = 2; i <= firstPage.last_page; ++i) {
+            for ( let i = 2; i <= firstPage.last_page; ++i) {
                 let url = LnmtlParser.makeChapterListUrl(volumeInfo.id, i);
                 pagesForVolume.push(fetchJson(url));
-            };
+            }
             return Promise.all(pagesForVolume);
-        })
+        });
     }
 
     static makeChapterListUrl(volumeId, page) {
@@ -92,17 +92,17 @@ class LnmtlParser extends Parser {
 
     static mergeChapterLists(lists) {
         let chapters = [];
-        for(let list of lists) {
+        for (let list of lists) {
             for (let page of list) {
-                for(let chapter of page.json.data) {
+                for (let chapter of page.json.data) {
                     chapters.push({
                         sourceUrl: chapter.site_url,
                         title: "#" + chapter.number + ": " + chapter.title,
                         newArc: null                    
                     });
-                };
-            };
-        };
+                }
+            }
+        }
         return chapters;
     }
 }

--- a/plugin/js/parsers/MMyWwuxiaWorldParser.js
+++ b/plugin/js/parsers/MMyWwuxiaWorldParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("m.mywuxiaworld.com", () => new MMyWwuxiaWorldParser());
 
-class MMyWwuxiaWorldParser extends Parser{
+class MMyWwuxiaWorldParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/MachineTranslationParser.js
+++ b/plugin/js/parsers/MachineTranslationParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("machine-translation.org", () => new MachineTranslationParser());
 
-class MachineTranslationParser extends Parser{
+class MachineTranslationParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/MadaraParser.js
+++ b/plugin/js/parsers/MadaraParser.js
@@ -7,24 +7,24 @@ parserFactory.register("wuxiaworld.site", () => new MadaraParser());
 //dead url
 parserFactory.register("pery.info", () => new MadaraParser());
 parserFactory.register("morenovel.net", () => new MadaraParser());
-parserFactory.register("nightcomic.com", function() { return new MadaraParser() });
+parserFactory.register("nightcomic.com", function() { return new MadaraParser(); });
 //dead url
-parserFactory.register("webnovel.live", function() { return new MadaraParser() });
+parserFactory.register("webnovel.live", function() { return new MadaraParser(); });
 //dead url
-parserFactory.register("noveltrench.com", function() { return new MadaraParser() });
-parserFactory.register("mangasushi.net", function() { return new MadaraParser() });
+parserFactory.register("noveltrench.com", function() { return new MadaraParser(); });
+parserFactory.register("mangasushi.net", function() { return new MadaraParser(); });
 //dead url
-parserFactory.register("mangabob.com", function() { return new MadaraParser() });
-parserFactory.register("greenztl2.com", function() { return new MadaraVariantParser() });
+parserFactory.register("mangabob.com", function() { return new MadaraParser(); });
+parserFactory.register("greenztl2.com", function() { return new MadaraVariantParser(); });
 
-parserFactory.register("kdtnovels.com", function() { return new KdtnovelsParser() });
+parserFactory.register("kdtnovels.com", function() { return new KdtnovelsParser(); });
 
 parserFactory.registerRule(
     (url, dom) => MadaraParser.isMadaraTheme(dom) * 0.6,
     () => new MadaraParser()
 );
 
-class MadaraParser extends WordpressBaseParser{
+class MadaraParser extends WordpressBaseParser {
     constructor() {
         super();
     }
@@ -51,7 +51,7 @@ class MadaraParser extends WordpressBaseParser{
             }
         }
         return content;
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("div.author-content a");
@@ -64,7 +64,7 @@ class MadaraParser extends WordpressBaseParser{
     }
 
     extractDescription(dom) {
-        let descriptionElement = dom.querySelector(".summary__content")
+        let descriptionElement = dom.querySelector(".summary__content");
         return descriptionElement === null ? "" : descriptionElement.textContent.trim();
     }
     
@@ -85,7 +85,7 @@ class MadaraParser extends WordpressBaseParser{
     getInformationEpubItemChildNodes(dom) {
         let nodes = [...dom.querySelectorAll("div.summary__content")];
         if (nodes.length === 0) {
-            nodes = [...dom.querySelectorAll("div.manga-summary p")]
+            nodes = [...dom.querySelectorAll("div.manga-summary p")];
         }
         return nodes;
     }
@@ -101,7 +101,7 @@ class MadaraVariantParser extends MadaraParser {
             .map(a => this.hyperLinkToChapter(a)).reverse();
     }
 
-    hyperLinkToChapter (link, newArc) {
+    hyperLinkToChapter(link, newArc) {
         let retVal = util.hyperLinkToChapter(link, newArc);
         let uri = retVal.sourceUrl;
         if (!uri || link.attributes.href.value == "#") //search for alternate URLs if typical link fails

--- a/plugin/js/parsers/MadnovelParser.js
+++ b/plugin/js/parsers/MadnovelParser.js
@@ -44,12 +44,12 @@ class MadnovelParser extends Parser {
     }
 
     extractAuthor(dom) {
-        let authorLabel = [...dom.querySelectorAll("a[href*='authors'] span")].map(x => x.textContent.trim())
+        let authorLabel = [...dom.querySelectorAll("a[href*='authors'] span")].map(x => x.textContent.trim());
         return (authorLabel.length === 0) ? super.extractAuthor(dom) : authorLabel.join(", ");
     }
 
     extractSubject(dom) {
-        let tags = [...dom.querySelectorAll("a[href*='genres']")]
+        let tags = [...dom.querySelectorAll("a[href*='genres']")];
         return tags.map(e => e.textContent.trim()).join("");
     }
 

--- a/plugin/js/parsers/MandarinducktalesParser.js
+++ b/plugin/js/parsers/MandarinducktalesParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("mandarinducktales.com", () => new MandarinducktalesParser());
 
-class MandarinducktalesParser extends Parser{
+class MandarinducktalesParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/MangaHereParser.js
+++ b/plugin/js/parsers/MangaHereParser.js
@@ -3,7 +3,7 @@
 */
 "use strict";
 
-parserFactory.register("www.mangahere.cc", function() { return new MangaHereParser() });
+parserFactory.register("www.mangahere.cc", function() { return new MangaHereParser(); });
 
 class MangaHereParser extends Parser {
     constructor() {
@@ -22,11 +22,11 @@ class MangaHereParser extends Parser {
 
     convertSelectToImgTagsToFollow(dom, content, select) {
         let options = Array.from(select.querySelectorAll("option"));
-        for(let option of options.filter(o => !o.value.includes("featured"))) {
+        for (let option of options.filter(o => !o.value.includes("featured"))) {
             let img = dom.createElement("img");
             img.src = option.value;
             content.appendChild(img);
-        };
+        }
         
         // first image in list is current page, so replace with image URL 
         // to skip fetching this page again
@@ -97,7 +97,7 @@ class MangaHereParser extends Parser {
         let index = url.lastIndexOf("/");
         let root = url.substring(0, index + 1);
         let urls = [];
-        for(let i = 1; i <= imageCount; ++i) {
+        for (let i = 1; i <= imageCount; ++i) {
             urls.push(`${root}chapterfun.ashx?cid=${chapterId}&page=${i}`);
         }
         return urls;
@@ -119,7 +119,7 @@ class MangaHereParser extends Parser {
     }
 
     static addImgsToNewDoc(newDoc, urls, imgUrls) {
-        for(let u of urls) {
+        for (let u of urls) {
             if (!imgUrls.has(u)) {
                 imgUrls.add(u);
                 let img = newDoc.dom.createElement("img");
@@ -154,8 +154,8 @@ class MangaHereParser extends Parser {
 
     // extracted from MangaHere (and deobfuscated)
     static decrypt(p, max, len, fragments) {
-        let makeKey = function (index) {
-            return (index < max ? "" : makeKey(parseInt(index / max))) + ((index = index % max) > 35 ? String.fromCharCode(index + 29) : index.toString(36))
+        let makeKey = function(index) {
+            return (index < max ? "" : makeKey(parseInt(index / max))) + ((index = index % max) > 35 ? String.fromCharCode(index + 29) : index.toString(36));
         };
         let replacements = {};
         while (len--)

--- a/plugin/js/parsers/MangaReadParser.js
+++ b/plugin/js/parsers/MangaReadParser.js
@@ -1,8 +1,8 @@
 "use strict";
 
-parserFactory.register("mangaread.co", function() { return new MangaReadParser() });
+parserFactory.register("mangaread.co", function() { return new MangaReadParser(); });
 
-class MangaReadParser extends Parser{
+class MangaReadParser extends Parser {
     constructor() {
         super();
     }
@@ -10,20 +10,20 @@ class MangaReadParser extends Parser{
     async getChapterUrls(dom) {
         return [...dom.querySelectorAll("li.wp-manga-chapter a")]
             .map(a => util.hyperLinkToChapter(a)).reverse();
-    };
+    }
 
     findContent(dom) {
         return Parser.findConstrutedContent(dom);
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.post-title h1");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("div.author-content a");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 
     findChapterTitle(dom) {
         return dom.querySelector("h1");
@@ -45,8 +45,8 @@ class MangaReadParser extends Parser{
         let base = img.getAttribute("data-lazy-src");
         let index = base.lastIndexOf("/");
         base = base.substring(0, index + 1);
-        let imgUrls = []
-        for(let i = 1; i <= options.length; ++i) {
+        let imgUrls = [];
+        for (let i = 1; i <= options.length; ++i) {
             let name = ("00" + i);
             name = name.substring(name.length - 3);
             imgUrls.push(base + name + ".jpg");
@@ -55,7 +55,7 @@ class MangaReadParser extends Parser{
     }
 
     async buildPageWithImageTags(imgUrls, newDoc) {
-        for(let u of imgUrls) {
+        for (let u of imgUrls) {
             let img = newDoc.dom.createElement("img");
             img.src = u;
             newDoc.content.appendChild(img);

--- a/plugin/js/parsers/MangadexParser.js
+++ b/plugin/js/parsers/MangadexParser.js
@@ -1,8 +1,8 @@
 "use strict";
 
-parserFactory.register("mangadex.org", function() { return new MangadexParser() });
+parserFactory.register("mangadex.org", function() { return new MangadexParser(); });
 
-class MangadexParser extends Parser{
+class MangadexParser extends Parser {
     constructor() {
         super();
     }
@@ -12,11 +12,11 @@ class MangadexParser extends Parser{
             .filter(row => (row.querySelector("img[alt='English']") != null))
             .map(row => util.hyperLinkToChapter(row.querySelector("a")));
         return Promise.resolve(chapters.reverse());
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("h3.panel-title");
-    };
+    }
 
     findContent(dom) {
         return Parser.findConstrutedContent(dom);
@@ -28,7 +28,7 @@ class MangadexParser extends Parser{
     
     fetchChapter(url) {
         let restUrl = MangadexParser.chapterImagesRestUrl(url);
-        return HttpClient.fetchJson(restUrl).then(function (xhr) {
+        return HttpClient.fetchJson(restUrl).then(function(xhr) {
             return MangadexParser.jsonToHtmlWithImgTags(url, xhr.json);
         });
     }
@@ -40,11 +40,11 @@ class MangadexParser extends Parser{
             let hostName = util.extractHostName(pageUrl);
             server = `https://${hostName}/data/`;
         }
-        for(let page of json.page_array) {
+        for (let page of json.page_array) {
             let img = newDoc.dom.createElement("img");
             img.src = `${server}${json.hash}/${page}`;
             newDoc.content.appendChild(img);
-        };
+        }
         return newDoc.dom;
     }
 
@@ -56,6 +56,6 @@ class MangadexParser extends Parser{
 
     getInformationEpubItemChildNodes(dom) {
         return [...dom.querySelectorAll("div.card-body div.row")]
-            .filter(row => (row.querySelector("img, button") === null))
+            .filter(row => (row.querySelector("img, button") === null));
     }
 }

--- a/plugin/js/parsers/MangakakalotParser.js
+++ b/plugin/js/parsers/MangakakalotParser.js
@@ -1,8 +1,8 @@
 "use strict";
 
-parserFactory.register("mangakakalot.com", function() { return new MangakakalotParser() });
+parserFactory.register("mangakakalot.com", function() { return new MangakakalotParser(); });
 
-class MangakakalotParser extends Parser{
+class MangakakalotParser extends Parser {
     constructor() {
         super();
     }
@@ -10,20 +10,20 @@ class MangakakalotParser extends Parser{
     getChapterUrls(dom) {
         let chaptersElement = dom.querySelector("div#chapter");
         return Promise.resolve(util.hyperlinksToChapterList(chaptersElement).reverse());
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div#vungdoc");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.manga-info-top h1");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("ul.manga-info-text a[href*='search_author']");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 
     findChapterTitle(dom) {
         return dom.querySelector("h1");

--- a/plugin/js/parsers/MangallamaParser.js
+++ b/plugin/js/parsers/MangallamaParser.js
@@ -1,9 +1,9 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("mangallama.com", function() { return new MangalamaParser() });
+parserFactory.register("mangallama.com", function() { return new MangalamaParser(); });
 
-class MangalamaParser extends Parser{
+class MangalamaParser extends Parser {
     constructor() {
         super();
     }
@@ -11,15 +11,15 @@ class MangalamaParser extends Parser{
     getChapterUrls(dom) {
         let chaptersElement = dom.querySelector("table.table-striped");
         return Promise.resolve(util.hyperlinksToChapterList(chaptersElement).reverse());
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div#chapcontainer");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("h1");
-    };
+    }
 
     findChapterTitle(dom) {
         return dom.querySelector("div#titlecontainer").textContent;

--- a/plugin/js/parsers/ManganeloParser.js
+++ b/plugin/js/parsers/ManganeloParser.js
@@ -1,8 +1,8 @@
 "use strict";
 
-parserFactory.register("manganelo.com", function() { return new ManganeloParser() });
+parserFactory.register("manganelo.com", function() { return new ManganeloParser(); });
 
-class ManganeloParser extends Parser{
+class ManganeloParser extends Parser {
     constructor() {
         super();
     }
@@ -11,15 +11,15 @@ class ManganeloParser extends Parser{
         return [...dom.querySelectorAll("div.panel-story-chapter-list a")]
             .map(a => util.hyperLinkToChapter(a))
             .reverse();
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div.container-chapter-reader");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.story-info-right h1");
-    };
+    }
 
     findChapterTitle(dom) {
         return dom.querySelector("h1");

--- a/plugin/js/parsers/ManganovParser.js
+++ b/plugin/js/parsers/ManganovParser.js
@@ -3,13 +3,13 @@
 //dead url/ parser
 parserFactory.register("manganov.com", () => new ManganovParser());
 
-class ManganovParser extends Parser{
+class ManganovParser extends Parser {
     constructor() {
         super();
     }
 
     async getChapterUrls(dom) {
-        let menu = [...dom.querySelectorAll("ul.chapter-list-wrapper")].pop()
+        let menu = [...dom.querySelectorAll("ul.chapter-list-wrapper")].pop();
         return util.hyperlinksToChapterList(menu);
     }
 

--- a/plugin/js/parsers/ManhwadenParser.js
+++ b/plugin/js/parsers/ManhwadenParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("manhwaden.com", () => new ManhwadenParser());
 
-class ManhwadenParser extends MadaraParser{
+class ManhwadenParser extends MadaraParser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/ManhwatopParser.js
+++ b/plugin/js/parsers/ManhwatopParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("manhwatop.com", () => new ManhwatopParser());
 
-class ManhwatopParser extends MadaraParser{
+class ManhwatopParser extends MadaraParser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/Marx2maoParser.js
+++ b/plugin/js/parsers/Marx2maoParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("marx2mao.com", () => new Marx2maoParser());
 
-class Marx2maoParser extends Parser{
+class Marx2maoParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/MayanovelParser.js
+++ b/plugin/js/parsers/MayanovelParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("mayanovel.com", () => new MayanovelParser());
 
-class MayanovelParser extends Parser{
+class MayanovelParser extends Parser {
     constructor() {
         super();
     }
@@ -33,7 +33,7 @@ class MayanovelParser extends Parser{
         let dom = (await HttpClient.wrapFetch(url)).responseXML;
         let nextUrl = this.nextPageOfChapterUrl(dom);
         let oldContent = this.findContent(dom);
-        while(nextUrl != null) {
+        while (nextUrl != null) {
             let nextDom = (await HttpClient.wrapFetch(nextUrl)).responseXML;
             let newContent = this.findContent(nextDom);
             util.moveChildElements(newContent, oldContent);

--- a/plugin/js/parsers/McStoriesParser.js
+++ b/plugin/js/parsers/McStoriesParser.js
@@ -5,7 +5,7 @@
 */
 "use strict";
 
-parserFactory.register("mcstories.com", function() { return new McStoriesParser() });
+parserFactory.register("mcstories.com", function() { return new McStoriesParser(); });
 
 class McStoriesParser extends Parser {
     constructor() {
@@ -24,7 +24,7 @@ class McStoriesParser extends Parser {
     extractAuthor(dom) {
         let author = dom.querySelector("article a[href*='/Authors/']");
         return (author === null) ? super.extractAuthor(dom) : author.textContent;
-    };
+    }
 
     getInformationEpubItemChildNodes(dom) {
         return [ util.dctermsToTable(dom) ];

--- a/plugin/js/parsers/MeionovelParser.js
+++ b/plugin/js/parsers/MeionovelParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("meionovel.id", () => new MeionovelParser());
 
-class MeionovelParser extends Parser{
+class MeionovelParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/MetanovelParser.js
+++ b/plugin/js/parsers/MetanovelParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("m.metanovel.org", () => new MetanovelParser());
 
-class MetanovelParser extends Parser{
+class MetanovelParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/MidnightramblesParser.js
+++ b/plugin/js/parsers/MidnightramblesParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("midnightrambles.in", () => new MidnightramblesParser());
 
-class MidnightramblesParser extends WordpressBaseParser{
+class MidnightramblesParser extends WordpressBaseParser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/MoonDaisyParser.js
+++ b/plugin/js/parsers/MoonDaisyParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("moondaisyscans.biz", () => new MoonDaisyParser());
 
-class MoonDaisyParser extends Parser{
+class MoonDaisyParser extends Parser {
     constructor() {
         super();
     }
@@ -10,11 +10,11 @@ class MoonDaisyParser extends Parser{
     async getChapterUrls(dom) {
         return [...dom.querySelectorAll("div.eplister a")]
             .map(this.linkToChapter)
-            .reverse()
+            .reverse();
     }
 
     linkToChapter(link) {
-        let title = MoonDaisyParser.extractChapterNum(link).trim()
+        let title = MoonDaisyParser.extractChapterNum(link).trim();
         return ({
             sourceUrl:  link.href,
             title: title

--- a/plugin/js/parsers/MoonQuillParser.js
+++ b/plugin/js/parsers/MoonQuillParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("moonquill.com", () => new MoonqQillParser());
 
-class MoonqQillParser extends Parser{
+class MoonqQillParser extends Parser {
     constructor() {
         super();
     }
@@ -31,12 +31,12 @@ class MoonqQillParser extends Parser{
     }
 
     customRawDomToContentStep(chapter, content) {
-        this.uncommentStoryText(content)
+        this.uncommentStoryText(content);
     }
 
     uncommentStoryText(content) {
         let comments = [...content.childNodes].filter(n => n.nodeType === Node.COMMENT_NODE);
-        for(let comment of comments) {
+        for (let comment of comments) {
             let newDom = util.sanitize("<article>" + comment.data + "</article>");
             let newHtml = newDom.querySelector("article");
             content.appendChild(newHtml);

--- a/plugin/js/parsers/MottruyenParser.js
+++ b/plugin/js/parsers/MottruyenParser.js
@@ -3,7 +3,7 @@
 parserFactory.register("mottruyen.com.vn", () => new MottruyenParser());
 parserFactory.register("mottruyen.vn", () => new MottruyenParser());
 
-class MottruyenParser extends Parser{
+class MottruyenParser extends Parser {
     constructor() {
         super();
     }
@@ -22,7 +22,7 @@ class MottruyenParser extends Parser{
         }));
     }
     
-    async loadEpubMetaInfo(dom){
+    async loadEpubMetaInfo(dom) {
         let leaves = dom.baseURI.split("/").filter(a => a != "");
         let id = leaves[leaves.length - 1];
         let bookinfo = (await HttpClient.fetchJson("https://api.mottruyen.vn/api/v1/story/"+id)).json;
@@ -71,7 +71,7 @@ class MottruyenParser extends Parser{
         return "https://api.mottruyen.vn/api/v1/story/"+id+"/chapter/"+chapternumber+"?password="+this.password;
     }
     
-    isCustomError(response){
+    isCustomError(response) {
         if (response?.json?.lock) {
             return true;
         }
@@ -81,7 +81,7 @@ class MottruyenParser extends Parser{
         return false;
     }
 
-    setCustomErrorResponse(url, wrapOptions, checkedresponse){
+    setCustomErrorResponse(url, wrapOptions, checkedresponse) {
         if (checkedresponse?.json?.lock) {
             //Is only viewable in the app
             let newresp = {};
@@ -107,7 +107,7 @@ class MottruyenParser extends Parser{
         }
     }
 
-    PostToUrl(url, checkedresponse){
+    PostToUrl(url, checkedresponse) {
         let leaves = url.split("/").filter(a => a != "");
         let id = leaves[leaves.length - 3];
         let chapternumber = leaves[leaves.length - 1];

--- a/plugin/js/parsers/MtlarchiveParser.js
+++ b/plugin/js/parsers/MtlarchiveParser.js
@@ -4,7 +4,7 @@ parserFactory.register("fictionzone.net", () => new MtlarchiveParser());
 
 // mtlarchive.com and reader-hub.com were previous names of site
 
-class MtlarchiveParser extends Parser{
+class MtlarchiveParser extends Parser {
     constructor() {
         super();
         this.minimumThrottle = 3000;
@@ -16,7 +16,7 @@ class MtlarchiveParser extends Parser{
         chapterUrlsUI.showTocProgress(chapters);
         let info = await this.findStoryInfo(dom.baseURI);
         if (0 < info.storyId) {
-            for(let page = 1; page <= info.numTocPages; ++page) {
+            for (let page = 1; page <= info.numTocPages; ++page) {
                 await this.rateLimitDelay();
                 try {
                     let partialList = await this.fetchTocData(info.storyId, page, dom.baseURI);

--- a/plugin/js/parsers/MtledNovelsParser.js
+++ b/plugin/js/parsers/MtledNovelsParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("mtled-novels.com", () => new MtledNovelsParser());
 
-class MtledNovelsParser extends Parser{
+class MtledNovelsParser extends Parser {
     constructor() {
         super();
     }
@@ -16,15 +16,15 @@ class MtledNovelsParser extends Parser{
         let chapters = [...dom.querySelectorAll("div.card__body a:not(.list-group-item)")]
             .map(a => util.hyperLinkToChapter(a));
         return Promise.resolve(chapters);
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div.text_content");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("h1");
-    };
+    }
 
     customRawDomToContentStep(chapter, content) {
         if (this.userPreferences.removeOriginal.value) {

--- a/plugin/js/parsers/MtlnationParser.js
+++ b/plugin/js/parsers/MtlnationParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("mtlnation.com", () => new MtlnationParser());
 
-class MtlnationParser extends MadaraParser{
+class MtlnationParser extends MadaraParser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/MtlnovelsParser.js
+++ b/plugin/js/parsers/MtlnovelsParser.js
@@ -10,7 +10,7 @@ parserFactory.registerUrlRule(
     () => new MtlnovelsParser()
 );
 
-class MtlnovelsParser extends Parser{
+class MtlnovelsParser extends Parser {
     constructor() {
         super();
     }
@@ -20,7 +20,7 @@ class MtlnovelsParser extends Parser{
     }
 
     async getChapterUrls(dom) {
-        const tocUrl = dom.querySelector("#panelchapterlist > a").href
+        const tocUrl = dom.querySelector("#panelchapterlist > a").href;
 
         const chapterDom = (await HttpClient.fetchHtml(tocUrl)).responseXML;
 
@@ -30,15 +30,15 @@ class MtlnovelsParser extends Parser{
                 sourceUrl: a.href
             }))
             .reverse();
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div.single-page");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector(".entry-title");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("#author");
@@ -52,7 +52,7 @@ class MtlnovelsParser extends Parser{
         }
         util.removeChildElementsMatchingSelector(element, ".crumbs, .chapter-nav, .lang-btn, .sharer," +
             " amp-embed, .link-title, ol.link-box, a.view-more, button, span[hidden]" + original);
-        for(let e of [...element.querySelectorAll("div")]) {
+        for (let e of [...element.querySelectorAll("div")]) {
             e.removeAttribute("[class]");
         }
         super.removeUnwantedElementsFromContentElement(element);

--- a/plugin/js/parsers/MtlreaderParser.js
+++ b/plugin/js/parsers/MtlreaderParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("mtlreader.com", () => new MtlreaderParser());
 
-class MtlreaderParser extends Parser{
+class MtlreaderParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/MtnovelParser.js
+++ b/plugin/js/parsers/MtnovelParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("mtnovel.net", () => new MtnovelParser());
 
-class MtnovelParser extends Parser{
+class MtnovelParser extends Parser {
     constructor() {
         super();
     }
@@ -13,7 +13,7 @@ class MtnovelParser extends Parser{
             MtnovelParser.getUrlsOfTocPages,
             chapterUrlsUI
         )).reverse();
-    };
+    }
 
     static getUrlsOfTocPages(dom) {
         let lastUrl = dom.querySelector("#pagelink a.last").href;
@@ -43,7 +43,7 @@ class MtnovelParser extends Parser{
     removeUnwantedElementsFromContentElement(element) {
         let links = [...element.querySelectorAll("a")]
             .filter(link => link.textContent.includes("Back to top"));
-        for(let link of links) {
+        for (let link of links) {
             link.replaceWith(link.ownerDocument.createElement("br"));
         }
         super.removeUnwantedElementsFromContentElement(element);

--- a/plugin/js/parsers/MuggleNetParser.js
+++ b/plugin/js/parsers/MuggleNetParser.js
@@ -4,9 +4,9 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("fanfiction.mugglenet.com", function() { return new MuggleNetParser() });
+parserFactory.register("fanfiction.mugglenet.com", function() { return new MuggleNetParser(); });
 
-class MuggleNetParser extends Parser{
+class MuggleNetParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/MvlempyrParser.js
+++ b/plugin/js/parsers/MvlempyrParser.js
@@ -30,7 +30,7 @@ class MvlempyrParser extends Parser {
                     title: "[placeholder]",
                 });
             }
-            else{
+            else {
                 chapterList.push({
                     sourceUrl: link,
                     title: chapterTitles[i-1],

--- a/plugin/js/parsers/MyxlsParser.js
+++ b/plugin/js/parsers/MyxlsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("myxls.net", () => new MyxlsParser());
 
-class MyxlsParser extends Parser{
+class MyxlsParser extends Parser {
     constructor() {
         super();
     }
@@ -11,7 +11,7 @@ class MyxlsParser extends Parser{
         let rows = dom.querySelector("div#list dl").children;
         let links = [];
         let count = 0;
-        for(let row of rows) {
+        for (let row of rows) {
             let tag = row.tagName.toLowerCase();
             if (tag === "dt") {
                 ++count;

--- a/plugin/js/parsers/NanomashinonlineParser.js
+++ b/plugin/js/parsers/NanomashinonlineParser.js
@@ -1,7 +1,7 @@
 "use strict";
 parserFactory.register("nanomashin.online", () => new NanomashinonlineParser());
 
-class NanomashinonlineParser extends Parser{
+class NanomashinonlineParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/NepustationParser.js
+++ b/plugin/js/parsers/NepustationParser.js
@@ -3,7 +3,7 @@
 */
 "use strict";
 
-parserFactory.register("nepustation.com", function() { return new NepustationParser() });
+parserFactory.register("nepustation.com", function() { return new NepustationParser(); });
 
 class CryptEngine {
     constructor() {
@@ -11,7 +11,7 @@ class CryptEngine {
     }
 
     buildLookup(cypherText, clearText) {
-        for(let i = 0; i < clearText.length; ++i) {
+        for (let i = 0; i < clearText.length; ++i) {
             let cy = cypherText.charAt(i);
             let cl = clearText.charAt(i);
             if (this.decryptTable.get(cy) === undefined) {
@@ -27,7 +27,7 @@ class CryptEngine {
         let decryptChar = function(c) {
             let t = that.decryptTable.get(c);
             return (t === undefined) ? c : t;
-        }
+        };
         return cypherText.split("").map(c => decryptChar(c)).join("");
     }
 
@@ -50,6 +50,6 @@ class NepustationParser extends WordpressBaseParser {
         let node = null;
         while ((node = walker.nextNode())) {
             node.textContent = engine.decryptString(node.textContent);
-        };
+        }
     }
 }

--- a/plugin/js/parsers/NineHeavensParser.js
+++ b/plugin/js/parsers/NineHeavensParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("nineheavens.org", () => new NineHeavensParser());
 
-class NineHeavensParser extends Parser{ 
+class NineHeavensParser extends Parser { 
     constructor() {
         super();
     }

--- a/plugin/js/parsers/NobadnovelParser.js
+++ b/plugin/js/parsers/NobadnovelParser.js
@@ -3,9 +3,9 @@
 */
 "use strict";
 
-parserFactory.register("nobadnovel.com", function() { return new NobadnovelParser() });
+parserFactory.register("nobadnovel.com", function() { return new NobadnovelParser(); });
 
-class NobadnovelParser extends Parser{
+class NobadnovelParser extends Parser {
     constructor() {
         super();
         this.minimumThrottle = 500;

--- a/plugin/js/parsers/NoblemtlParser.js
+++ b/plugin/js/parsers/NoblemtlParser.js
@@ -41,7 +41,7 @@ parserFactory.registerRule(
     () => new NoblemtlParser()
 );
 
-class NoblemtlParser extends Parser{
+class NoblemtlParser extends Parser {
     constructor() {
         super();
     }
@@ -54,7 +54,7 @@ class NoblemtlParser extends Parser{
     async getChapterUrls(dom) {
         return [...dom.querySelectorAll("div.eplister a")]
             .map(this.linkToChapter)
-            .reverse()
+            .reverse();
     }
 
     linkToChapter(link) {
@@ -110,7 +110,7 @@ class NoblemtlParser extends Parser{
             if (element != null) {
                 title += " " +  element.textContent;
             }
-        }
+        };
         addText("h1.entry-title");
         addText(".cat-series");
         return title;
@@ -132,7 +132,7 @@ class NoblemtlParser extends Parser{
     }
 }
 
-class KnoxtspaceParser extends NoblemtlParser{
+class KnoxtspaceParser extends NoblemtlParser {
     constructor() {
         super();
     }
@@ -142,14 +142,14 @@ class KnoxtspaceParser extends NoblemtlParser{
     }
 }
 
-class WhitemoonlightnovelsParser extends NoblemtlParser{
+class WhitemoonlightnovelsParser extends NoblemtlParser {
     constructor() {
         super();
     }
 
     async getChapterUrls(dom) {
         return [...dom.querySelectorAll("div.eplister a")]
-            .map(this.linkToChapter)
+            .map(this.linkToChapter);
     }
 
     findChapterTitle(dom) {
@@ -161,7 +161,7 @@ class WhitemoonlightnovelsParser extends NoblemtlParser{
     }
 }
 
-class LazygirltranslationsParser extends KnoxtspaceParser{
+class LazygirltranslationsParser extends KnoxtspaceParser {
     constructor() {
         super();
     }
@@ -176,7 +176,7 @@ class LazygirltranslationsParser extends KnoxtspaceParser{
     }
 }
 
-class MyNovelOnlineParser extends NoblemtlParser{
+class MyNovelOnlineParser extends NoblemtlParser {
     constructor() {
         super();
         this.minimumThrottle = 3000;
@@ -189,7 +189,7 @@ class MyNovelOnlineParser extends NoblemtlParser{
     findContent(dom) {
         let content = dom.querySelector(".epwrapper .epcontent");
         //there are random links embeded everywhere i think it is to boost other sites on google as the other site is "relevant"
-        for(let e of content.querySelectorAll("p.chapter a.num-link")) {
+        for (let e of content.querySelectorAll("p.chapter a.num-link")) {
             let pnode = dom.createElement("span");
             pnode.textContent = e.innerText;
             e.replaceWith(pnode);
@@ -203,7 +203,7 @@ class MyNovelOnlineParser extends NoblemtlParser{
     }
 }
 
-class NovelsknightlParser extends NoblemtlParser{
+class NovelsknightlParser extends NoblemtlParser {
     constructor() {
         super();
         this.minimumThrottle = 3000;

--- a/plugin/js/parsers/Novel543Parser.js
+++ b/plugin/js/parsers/Novel543Parser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("novel543.com", () => new Novel543Parser());
 
-class Novel543Parser extends Parser{
+class Novel543Parser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/NovelAllParser.js
+++ b/plugin/js/parsers/NovelAllParser.js
@@ -3,9 +3,9 @@
 */
 "use strict";
 
-parserFactory.register("novelall.com", function() { return new NovelAllParser() });
+parserFactory.register("novelall.com", function() { return new NovelAllParser(); });
 
-class NovelAllParser extends Parser{
+class NovelAllParser extends Parser {
     constructor() {
         super();
     }
@@ -13,27 +13,27 @@ class NovelAllParser extends Parser{
     getChapterUrls(dom) {
         let menuItems = [...dom.querySelectorAll("ul.detail-chlist a")];
         return Promise.resolve(this.buildChapterList(menuItems));
-    };
+    }
 
     buildChapterList(menuItems) {
         return menuItems.reverse().map(
             a => ({sourceUrl: a.href, title: a.getAttribute("title")})
         );
-    };
+    }
     
     findContent(dom) {
         return dom.querySelector("div.reading-box");
-    };
+    }
 
     extractAuthor(dom) {
         let link = dom.querySelector("a[href*='author']");
         return (link == null) ? super.extractAuthor(dom) : link.textContent;
-    };
+    }
 
     // title of the story
     extractTitleImpl(dom) {
         return dom.querySelector("h1");
-    };
+    }
 
     // individual chapter titles are not inside the content element
     findChapterTitle(dom) {

--- a/plugin/js/parsers/NovelCrushParser.js
+++ b/plugin/js/parsers/NovelCrushParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("novelcrush.com", () => new NovelCrushParser());
 
-class NovelCrushParser extends Parser{
+class NovelCrushParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/NovelFeverParser.js
+++ b/plugin/js/parsers/NovelFeverParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("novelfever.com", () => new NovelFeverParser());
 
-class NovelFeverParser extends Parser{
+class NovelFeverParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/NovelNaverParser.js
+++ b/plugin/js/parsers/NovelNaverParser.js
@@ -13,12 +13,12 @@ class NovelNaverImageCollector extends ImageCollector {
         let tagName = element.tagName.toLowerCase();
         let img = (tagName === "img")
             ? element
-            : element.querySelector("img")
+            : element.querySelector("img");
         return img.src;
     }
 }
 
-class NovelNaverParser extends Parser{
+class NovelNaverParser extends Parser {
     constructor() {
         super(new NovelNaverImageCollector());
     }
@@ -45,7 +45,7 @@ class NovelNaverParser extends Parser{
         let urls = [...dom.querySelectorAll("div.default_paging a")]
             .map(l => l.href)
             .filter(u => !found.has(u));
-        for(let u of urls) {
+        for (let u of urls) {
             found.add(u);
         }
         return urls;

--- a/plugin/js/parsers/NovelOnlineFreeParser.js
+++ b/plugin/js/parsers/NovelOnlineFreeParser.js
@@ -3,19 +3,19 @@
 */
 "use strict";
 
-parserFactory.register("novelonlinefree.com", function() { return new NovelOnlineFreeParser() });
+parserFactory.register("novelonlinefree.com", function() { return new NovelOnlineFreeParser(); });
 //dead url
-parserFactory.register("novelonlinefree.info", function() { return new NovelOnlineFreeParser() });
-parserFactory.register("novelonlinefull.com", function() { return new NovelOnlineFreeParser() });
-parserFactory.register("wuxiaworld.online", function() { return new NovelOnlineFreeParser() });
+parserFactory.register("novelonlinefree.info", function() { return new NovelOnlineFreeParser(); });
+parserFactory.register("novelonlinefull.com", function() { return new NovelOnlineFreeParser(); });
+parserFactory.register("wuxiaworld.online", function() { return new NovelOnlineFreeParser(); });
 //dead url
-parserFactory.register("chinesewuxia.world", function() { return new NovelOnlineFreeParser() });
-parserFactory.register("bestlightnovel.com", function() { return new NovelOnlineFreeParser() });
+parserFactory.register("chinesewuxia.world", function() { return new NovelOnlineFreeParser(); });
+parserFactory.register("bestlightnovel.com", function() { return new NovelOnlineFreeParser(); });
 //dead url
-parserFactory.register("wuxia-world.online", function() { return new NovelOnlineFreeParser() });
-parserFactory.register("wuxiaworld.live", function() { return new NovelOnlineFreeParser() });
+parserFactory.register("wuxia-world.online", function() { return new NovelOnlineFreeParser(); });
+parserFactory.register("wuxiaworld.live", function() { return new NovelOnlineFreeParser(); });
 
-class NovelOnlineFreeParser extends Parser{
+class NovelOnlineFreeParser extends Parser {
     constructor() {
         super();
     }
@@ -23,29 +23,29 @@ class NovelOnlineFreeParser extends Parser{
     getChapterUrls(dom) {
         let menuItems = [...dom.querySelectorAll("div.chapter-list a")];
         return Promise.resolve(this.buildChapterList(menuItems));
-    };
+    }
 
     buildChapterList(menuItems) {
         return menuItems.reverse().map(
             a => ({sourceUrl: a.href, title: a.getAttribute("title")})
         );
-    };
+    }
     
     findContent(dom) {
         let content = dom.querySelector("div.vung_doc")
-          || dom.querySelector("div.content-area")
+          || dom.querySelector("div.content-area");
         return content;
-    };
+    }
 
     // title of the story
     extractTitleImpl(dom) {
         return dom.querySelector("h1");
-    };
+    }
 
     extractAuthor(dom) {
         let link = dom.querySelector("a[href*='search_author']");
         return (link == null) ? super.extractAuthor(dom) : link.textContent;
-    };
+    }
 
     // individual chapter titles are not inside the content element
     findChapterTitle(dom) {

--- a/plugin/js/parsers/NovelSpreadParser.js
+++ b/plugin/js/parsers/NovelSpreadParser.js
@@ -1,11 +1,11 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("novelspread.com", function() { return new NovelSpreadParser() });
+parserFactory.register("novelspread.com", function() { return new NovelSpreadParser(); });
 //dead url
-parserFactory.register("m.novelspread.com", function() { return new MNovelSpreadParser() });
+parserFactory.register("m.novelspread.com", function() { return new MNovelSpreadParser(); });
 
-class NovelSpreadParser extends Parser{
+class NovelSpreadParser extends Parser {
     constructor() {
         super();
     }
@@ -18,20 +18,20 @@ class NovelSpreadParser extends Parser{
             chapter.title = `${i + 1}. ${chapter.title}`;
         }
         return chapters;
-    };
+    }
 
     findContent(dom) {
         return Parser.findConstrutedContent(dom);
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.title.split("-")[0];
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("div.main-left div.person h4");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 
     findCoverImageUrl(dom) {
         return util.getFirstImgSrc(dom, "div.novelimg");
@@ -67,7 +67,7 @@ class NovelSpreadParser extends Parser{
     }
 }
 
-class MNovelSpreadParser extends NovelSpreadParser{
+class MNovelSpreadParser extends NovelSpreadParser {
     constructor() {
         super();
     }
@@ -77,7 +77,7 @@ class MNovelSpreadParser extends NovelSpreadParser{
             .filter(a => a.href.includes("/chapter/"))
             .map(a => util.hyperLinkToChapter(a));
         return chapters;
-    };
+    }
 
     findCoverImageUrl(dom) {
         return util.getFirstImgSrc(dom, "div.book");

--- a/plugin/js/parsers/NovelUniverseParser.js
+++ b/plugin/js/parsers/NovelUniverseParser.js
@@ -4,16 +4,16 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("noveluniverse.com", function() { return new NovelUniverseParser() });
+parserFactory.register("noveluniverse.com", function() { return new NovelUniverseParser(); });
 
-class NovelUniverseParser extends Parser{
+class NovelUniverseParser extends Parser {
     constructor() {
         super();
     }
 
     getChapterUrls(dom) {
         return NovelUniverseParser.fetchRestOfToc(dom, []);
-    };
+    }
 
     static fetchRestOfToc(dom, chapterList) {
         let nextPage = NovelUniverseParser.urlOfNextToC(dom);
@@ -22,7 +22,7 @@ class NovelUniverseParser extends Parser{
         if (nextPage.length == 0) {
             return Promise.resolve(chapterList);
         }
-        return HttpClient.wrapFetch(nextPage[0].href).then(function (xhr) {
+        return HttpClient.wrapFetch(nextPage[0].href).then(function(xhr) {
             return NovelUniverseParser.fetchRestOfToc(xhr.responseXML, chapterList);
         });
     }
@@ -39,11 +39,11 @@ class NovelUniverseParser extends Parser{
 
     findContent(dom) {
         return dom.querySelector("div.top_loc");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.info h1");
-    };
+    }
 
     removeUnwantedElementsFromContentElement(element) {
         let review = element.querySelector("div.star-review");

--- a/plugin/js/parsers/NovelUpdatesOnlineParser.js
+++ b/plugin/js/parsers/NovelUpdatesOnlineParser.js
@@ -4,7 +4,7 @@
 parserFactory.register("novelupdates.online", () => new NovelUpdatesOnlineParser());
 parserFactory.register("boxnovel.net", () => new NovelUpdatesOnlineParser());
 
-class NovelUpdatesOnlineParser extends Parser{
+class NovelUpdatesOnlineParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/NovelUpdatesParser.js
+++ b/plugin/js/parsers/NovelUpdatesParser.js
@@ -3,9 +3,9 @@
 */
 "use strict";
 
-parserFactory.register("novelupdates.com", function() { return new NovelUpdatesParser() });
+parserFactory.register("novelupdates.com", function() { return new NovelUpdatesParser(); });
 
-class NovelUpdatesParser extends Parser{
+class NovelUpdatesParser extends Parser {
     constructor() {
         super();
     }
@@ -13,26 +13,26 @@ class NovelUpdatesParser extends Parser{
     // returns promise with the URLs of the chapters to fetch
     // promise is used because may need to fetch the list of URLs from internet
     getChapterUrls(dom) {
-        return NovelUpdatesParser.fetchChapterUrls(dom).then(function (links) {
+        return NovelUpdatesParser.fetchChapterUrls(dom).then(function(links) {
             let chapters = links.map(l => util.hyperLinkToChapter(l));
             return Promise.resolve(chapters.reverse());
-        })
-    };
+        });
+    }
 
     static fetchChapterUrls(dom) {
         let extraPagesWithToc = NovelUpdatesParser.findPagesWithToC(dom);
         return Promise.all(
             extraPagesWithToc.map(url => NovelUpdatesParser.fetchChapterListFromPage(url))
-        ).then(function (chapterLists) {
-            return chapterLists.reduce(function (prev, current) {
+        ).then(function(chapterLists) {
+            return chapterLists.reduce(function(prev, current) {
                 return prev.concat(current);
-            }, NovelUpdatesParser.chapterLinksFromDom(dom))
+            }, NovelUpdatesParser.chapterLinksFromDom(dom));
         });
     }
 
     static fetchChapterListFromPage(url) {
-        return HttpClient.wrapFetch(url).then(function (xhr) {
-            return Promise.resolve(NovelUpdatesParser.chapterLinksFromDom(xhr.responseXML))
+        return HttpClient.wrapFetch(url).then(function(xhr) {
+            return Promise.resolve(NovelUpdatesParser.chapterLinksFromDom(xhr.responseXML));
         });
     }
 
@@ -52,7 +52,7 @@ class NovelUpdatesParser extends Parser{
         let div = dom.querySelector("div.digg_pagination");
         if (div !== null) {
             let maxPage = NovelUpdatesParser.getPageValueOfLastTocPage(div);
-            for(let i = 2; i <= maxPage; ++i) {
+            for (let i = 2; i <= maxPage; ++i) {
                 urls.push(dom.baseURI + "?pg=" + i);
             }
         }
@@ -76,16 +76,16 @@ class NovelUpdatesParser extends Parser{
     // returns the element holding the story content in a chapter
     findContent(dom) {
         return dom.body;
-    };
+    }
 
     // title of the story
     extractTitleImpl(dom) {
         return dom.querySelector("div.seriestitlenu");
-    };
+    }
 
     // author of the story
     extractAuthor(dom) {
         let author = dom.querySelector("div#showauthors a");
         return (author !== null) ? author.textContent : super.extractAuthor(dom);
-    };
+    }
 }

--- a/plugin/js/parsers/NovelcoolParser.js
+++ b/plugin/js/parsers/NovelcoolParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("novelcool.com", () => new NovelcoolParser());
 
-class NovelcoolParser extends Parser{
+class NovelcoolParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/NovelfullParser.js
+++ b/plugin/js/parsers/NovelfullParser.js
@@ -50,7 +50,7 @@ parserFactory.register("zinnovel.net", () => new NovelfullParser());
 
 parserFactory.registerManualSelect("NovelNext", () => new NovelfullParser());
 
-class NovelfullParser extends Parser{
+class NovelfullParser extends Parser {
     constructor() {
         super();
         this.minimumThrottle = 1000;
@@ -61,7 +61,7 @@ class NovelfullParser extends Parser{
     // correct parser for the chapters
     // See: https://github.com/dteviot/WebToEpub/issues/1345
     async addParsersToPages(pagesToFetch) {
-        for(let page of pagesToFetch) {
+        for (let page of pagesToFetch) {
             page.parser = this;
         }
     }
@@ -72,7 +72,7 @@ class NovelfullParser extends Parser{
             this.getUrlsOfTocPages,
             chapterUrlsUI
         );
-    };
+    }
 
     getUrlsOfTocPages(dom) {
         let link = dom.querySelector("li.last a");
@@ -114,17 +114,17 @@ class NovelfullParser extends Parser{
     findContent(dom) {
         return dom.querySelector("#chr-content")
             || dom.querySelector("#chapter-content");
-    };
+    }
 
     // title of the story  (not to be confused with title of each chapter)
     extractTitleImpl(dom) {
         return dom.querySelector("h3.title");
-    };
+    }
 
     extractAuthor(dom) {
         let items = [...dom.querySelectorAll("ul.info-meta li")]
             .filter(u => u.querySelector("h3")?.textContent === "Author:")
-            .map(u => u.querySelector("a")?.textContent)
+            .map(u => u.querySelector("a")?.textContent);
         return 0 < items.length 
             ? items[0]
             : super.extractAuthor(dom);
@@ -151,7 +151,7 @@ class NovelfullParser extends Parser{
         if (watermark) {
             let paragraphs = [...dom.querySelectorAll("p")]
                 .filter(p => p.textContent.includes(watermark));
-            for(let p of paragraphs) {
+            for (let p of paragraphs) {
                 p.textContent = p.textContent.replace(watermark, "");
                 p.appendChild(this.makeSpanWithWatermark(dom, watermark));
             }
@@ -179,18 +179,18 @@ class NovelfullParser extends Parser{
     }
 }
 
-class Novel35Parser extends NovelfullParser{
+class Novel35Parser extends NovelfullParser {
     constructor() {
         super();
     }
 
     getUrlsOfTocPages(dom) {
-        let urls = []
+        let urls = [];
         let paginateUrls = [...dom.querySelectorAll("ul.pagination li a:not([rel])")];
         if (0 < paginateUrls.length) {
             let url = new URL(paginateUrls.pop().href);
             let maxPage = url.searchParams.get("page");
-            for(let i = 2; i <= maxPage; ++i) {
+            for (let i = 2; i <= maxPage; ++i) {
                 url.searchParams.set("page", i);
                 urls.push(url.href);
             }
@@ -200,21 +200,21 @@ class Novel35Parser extends NovelfullParser{
 
     findContent(dom) {
         return dom.querySelector("div.chapter-content");
-    };
+    }
 
     findChapterTitle(dom) {
         return dom.querySelector("div.chapter-title").textContent;
     }    
 }
 
-class NovelHyphenBinParser extends NovelfullParser{
+class NovelHyphenBinParser extends NovelfullParser {
     constructor() {
         super();
     }
 
     removeUnwantedElementsFromContentElement(element) {
         let marks = [...element.querySelectorAll(".novel_online, .unlock-buttons")];
-        for(let mark of marks) {
+        for (let mark of marks) {
             mark.nextSibling.nextSibling.remove();
             mark.remove();
         }
@@ -222,7 +222,7 @@ class NovelHyphenBinParser extends NovelfullParser{
     }
 }
 
-class NovelbinParser extends NovelfullParser{
+class NovelbinParser extends NovelfullParser {
     constructor() {
         super();
     }
@@ -234,7 +234,7 @@ class NovelbinParser extends NovelfullParser{
         let tocHtml = (await HttpClient.wrapFetch("https://novelbin.com/ajax/chapter-archive?novelId="+slug)).responseXML;
         let chapters = this.extractPartialChapterList(tocHtml);
         return chapters;
-    };
+    }
 
     removeUnwantedElementsFromContentElement(element) {
         util.removeChildElementsMatchingSelector(element, ".unlock-buttons");

--- a/plugin/js/parsers/NovelgoParser.js
+++ b/plugin/js/parsers/NovelgoParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("novelgo.id", () => new NovelgoParser());
 
-class NovelgoParser extends Parser{
+class NovelgoParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/NovelgreatParser.js
+++ b/plugin/js/parsers/NovelgreatParser.js
@@ -1,9 +1,9 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("novelgreat.net", function () { return new NovelgreatParser() });
+parserFactory.register("novelgreat.net", function() { return new NovelgreatParser(); });
 
-class NovelgreatParser extends NovelfullParser{
+class NovelgreatParser extends NovelfullParser {
     constructor() {
         super();
     }
@@ -23,5 +23,5 @@ class NovelgreatParser extends NovelfullParser{
 
     findContent(dom) {
         return dom.querySelector("div#chapter-c");
-    };
+    }
 }

--- a/plugin/js/parsers/NovelhallParser.js
+++ b/plugin/js/parsers/NovelhallParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("novelhall.com", () => new NovelhallParser());
 
-class NovelhallParser extends Parser{
+class NovelhallParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/NovelhiParser.js
+++ b/plugin/js/parsers/NovelhiParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("novelhi.com", () => new NovelhiParser());
 
-class NovelhiParser extends Parser{
+class NovelhiParser extends Parser {
     constructor() {
         super();
     }
@@ -19,7 +19,7 @@ class NovelhiParser extends Parser{
         return {
             sourceUrl: baseURI + "/" + onclick[1],
             title: link.querySelector("span").textContent            
-        }
+        };
     }
 
     findContent(dom) {

--- a/plugin/js/parsers/NovelholdParser.js
+++ b/plugin/js/parsers/NovelholdParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("novelhold.com", () => new NovelholdParser());
 
-class NovelholdParser extends Parser{
+class NovelholdParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/NovelightParser.js
+++ b/plugin/js/parsers/NovelightParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("novelight.net", () => new NovelightParser());
 
-class NovelightParser extends Parser{
+class NovelightParser extends Parser {
     constructor() {
         super();
         this.ChacheChapterTitle = new Map();
@@ -49,7 +49,7 @@ class NovelightParser extends Parser{
     }
     
 
-    chaptersFromJson(json, url){
+    chaptersFromJson(json, url) {
         //without this the href links have as baseurl the extension
         let newDoc = Parser.makeEmptyDocForContent(url);
         let content = util.sanitize(json.html);
@@ -110,7 +110,7 @@ class NovelightParser extends Parser{
         title.textContent = this.ChacheChapterTitle.get(url);
         newDoc.content.appendChild(title);
         let content = util.sanitize(json.content);
-        for(let n of [...content.body.querySelectorAll("."+json.class+" div")]) {
+        for (let n of [...content.body.querySelectorAll("."+json.class+" div")]) {
             let br = newDoc.dom.createElement("br");
             newDoc.content.appendChild(n);
             newDoc.content.appendChild(br);

--- a/plugin/js/parsers/NovelinguaParser.js
+++ b/plugin/js/parsers/NovelinguaParser.js
@@ -1,6 +1,6 @@
 "use strict";
 
-parserFactory.register("novelingua.com", function() { return new NovelinguaParser() });
+parserFactory.register("novelingua.com", function() { return new NovelinguaParser(); });
 
 class NovelinguaParser extends Parser {
     constructor() {
@@ -52,7 +52,7 @@ class NovelinguaParser extends Parser {
         util.removeElements(element.querySelectorAll(
             "style, .pagelayer-btn-holder, .pagelayer-share, .pagelayer-image_slider, .pagelayer-embed"));
         super.removeUnwantedElementsFromContentElement(element);
-    };
+    }
 
     getInformationEpubItemChildNodes(dom) {
         return [...dom.querySelectorAll(".entry-content .pagelayer-text-holder")];

--- a/plugin/js/parsers/NovelmaniaParser.js
+++ b/plugin/js/parsers/NovelmaniaParser.js
@@ -2,14 +2,14 @@
 
 parserFactory.register("novelmania.com.br", () => new NovelmaniaParser());
 
-class NovelmaniaParser extends Parser{
+class NovelmaniaParser extends Parser {
     constructor() {
         super();
     }
 
     async getChapterUrls(dom) {
         let links = [...dom.querySelectorAll("ol.list-inline a")];
-        for(let link of links) {
+        for (let link of links) {
             link.querySelector("small")?.remove();
         }
         return links.map(a => util.hyperLinkToChapter(a));

--- a/plugin/js/parsers/NovelmaoParser.js
+++ b/plugin/js/parsers/NovelmaoParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("novelmao.com", () => new NovelmaoParser());
 
-class NovelmaoParser extends Parser{
+class NovelmaoParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/NovelmediumParser.js
+++ b/plugin/js/parsers/NovelmediumParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("novelmedium.com", () => new NovelmediumParser());
 
-class NovelmediumParser extends Parser{
+class NovelmediumParser extends Parser {
     constructor() {
         super();
     }
@@ -18,7 +18,7 @@ class NovelmediumParser extends Parser{
 
     getStoryId(dom, url)  {
         let script = [...dom.querySelectorAll("script")]
-            .filter(s => s.innerText.includes("__NUXT__"))[0]
+            .filter(s => s.innerText.includes("__NUXT__"))[0];
         let blobs = script.innerText.split("{id:");
         let leaf = url.substring(url.lastIndexOf("/") + 1);
         let blob = blobs.filter(b => b.includes(leaf))[0];

--- a/plugin/js/parsers/NovelonomiconParser.js
+++ b/plugin/js/parsers/NovelonomiconParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("novelonomicon.com", () => new NovelonomiconParser());
 
-class NovelonomiconParser extends Parser{
+class NovelonomiconParser extends Parser {
     constructor() {
         super();
     }
@@ -16,7 +16,7 @@ class NovelonomiconParser extends Parser{
     }
 
     getUrlsOfTocPages(dom) {
-        let urls = []
+        let urls = [];
         let lastLink = dom.querySelector(".page-nav a.last")
             || [...dom.querySelectorAll(".page-nav a.page")].slice(-1)[0];
         if (lastLink !== null)
@@ -25,7 +25,7 @@ class NovelonomiconParser extends Parser{
             let href = lastLink.href;
             let index = href.lastIndexOf("/", href.length - 2);
             href = href.substring(0, index + 1);
-            for(let i = 2; i <= max; ++i) {
+            for (let i = 2; i <= max; ++i) {
                 urls.push(href + i + "/");
             }
         }

--- a/plugin/js/parsers/NovelpassionParser.js
+++ b/plugin/js/parsers/NovelpassionParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("novelpassion.com", () => new NovelpassionParser());
 
-class NovelpassionParser extends Parser{
+class NovelpassionParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/NovelplexParser.js
+++ b/plugin/js/parsers/NovelplexParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("novelplex.org", () => new NovelplexParser());
 
-class NovelplexParser extends Parser{
+class NovelplexParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/NovelsRockParser.js
+++ b/plugin/js/parsers/NovelsRockParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("novelsrock.com", () => new NovelsRockParser());
 
-class NovelsRockParser extends Parser{
+class NovelsRockParser extends Parser {
     constructor() {
         super();
     }
@@ -11,25 +11,25 @@ class NovelsRockParser extends Parser{
     getChapterUrls(dom) {
         let chapters = [...dom.querySelectorAll("li.wp-manga-chapter a")]
             .filter(a => (a.querySelector("img") === null))
-            .map(a => util.hyperLinkToChapter(a))
+            .map(a => util.hyperLinkToChapter(a));
         return Promise.resolve(chapters.reverse());
-    };
+    }
 
     findContent(dom) {
         let content = dom.querySelector("div.read-container");
         return (content === null)
             ? dom.querySelector("div.reading-content") 
             : content;
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.post-title h1");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("div.author-content");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 
     findChapterTitle(dom) {
         return dom.querySelector("h1#chapter-heading");

--- a/plugin/js/parsers/NovelsectParser.js
+++ b/plugin/js/parsers/NovelsectParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("novelsect.com", () => new NovelsectParser());
 
-class NovelsectParser extends Parser{
+class NovelsectParser extends Parser {
     constructor() {
         super();
     }
@@ -14,7 +14,7 @@ class NovelsectParser extends Parser{
 
         let novelSlug = this.getNovelSlug(dom.baseURI);
         let urlsOfTocPages  = await this.getUrlsOfTocPages(novelSlug);
-        for(let url of urlsOfTocPages) {
+        for (let url of urlsOfTocPages) {
             await this.rateLimitDelay();
             let json = (await HttpClient.fetchJson(url)).json;
             let partialList = this.extractPartialChapterList(novelSlug, json.chapters);
@@ -28,7 +28,7 @@ class NovelsectParser extends Parser{
         let info = await this.getNovelIdAndChapterCount(novelSlug);
         let tocUrls = [];
         let maxPage = Math.ceil(info.chapter_count / 100);
-        for(let i = 2; i <= maxPage; ++i) {
+        for (let i = 2; i <= maxPage; ++i) {
             tocUrls.push(`https://novelsect.com/api/fetchchapterlistbyindex?novelId=${info.id}&page=${i}`);
         }
         return tocUrls;

--- a/plugin/js/parsers/NovelsemperorParser.js
+++ b/plugin/js/parsers/NovelsemperorParser.js
@@ -3,7 +3,7 @@
 parserFactory.register("novelsemperor.com", () => new NovelsemperorParser());
 parserFactory.register("novelsemperor.net", () => new NovelsemperorParser());
 
-class NovelsemperorParser extends Parser{
+class NovelsemperorParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/NovelsfullParser.js
+++ b/plugin/js/parsers/NovelsfullParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("novelsfull.com", () => new NovelsfullParser());
 
-class NovelsfullParser extends Parser{
+class NovelsfullParser extends Parser {
     constructor() {
         super();
     }
@@ -34,7 +34,7 @@ class NovelsfullParser extends Parser{
             64 != n[3] && (d += String.fromCharCode((3 & n[2]) << 6 | n[3]));
         }
         return d;
-    };
+    }
 
     _utf8_decode(text) {
         for (var t = "", a = 0, r = 0; a < text.length; ) {

--- a/plugin/js/parsers/NovelsplParser.js
+++ b/plugin/js/parsers/NovelsplParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("novels.pl", () => new NovelsplParser());
 
-class NovelsplParser extends Parser{
+class NovelsplParser extends Parser {
     constructor() {
         super();
     }
@@ -37,7 +37,7 @@ class NovelsplParser extends Parser{
 
     static async fetchMultipleToc(chapters, tocInfo, chapterUrlsUI) {
         let maxPage = Math.ceil(tocInfo.max / 50);
-        for(let i = 2; i <= maxPage; ++i) {
+        for (let i = 2; i <= maxPage; ++i) {
             let partialList = await NovelsplParser.fetchTocData(i, tocInfo);
             chapterUrlsUI.showTocProgress(partialList);
             chapters = chapters.concat(partialList);
@@ -71,7 +71,7 @@ class NovelsplParser extends Parser{
     }
 
     removeUnwantedElementsFromContentElement(element) {
-        for(let p of [...element.querySelectorAll("p")]) {
+        for (let p of [...element.querySelectorAll("p")]) {
             let c = p.textContent;
             if ((c === "This chapter is updated by Novels.pl") || 
                 (c === "Liked it? Take a second to support Novels on Patreon!")) {

--- a/plugin/js/parsers/NovelsquareParser.js
+++ b/plugin/js/parsers/NovelsquareParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("novelsquare.blog", () => new NovelsquareParser());
 
-class NovelsquareParser extends Parser{
+class NovelsquareParser extends Parser {
     constructor() {
         super();
     }
@@ -17,7 +17,7 @@ class NovelsquareParser extends Parser{
         maxToCnumber = maxToCnumber.concat(1);
         let getMax = (a, b) => Math.max(parseInt(a)?parseInt(a):0, parseInt(b)?parseInt(b):0);
         maxToCnumber = maxToCnumber.map(a => a.textContent).reduce(getMax);
-        let nextTocPageUrl = function (_dom, chapters, lastFetch) {
+        let nextTocPageUrl = function(_dom, chapters, lastFetch) {
             return ((nextTocIndex <= maxToCnumber) && (0 < lastFetch.length))
                 ? `${baseUrl}?page=${++nextTocIndex}`
                 : null;
@@ -28,7 +28,7 @@ class NovelsquareParser extends Parser{
             nextTocPageUrl,
             chapterUrlsUI
         ));
-    };
+    }
 
     static getChapterUrlsFromTocPage(dom) {
         let menu = dom.querySelector("div#chpagedlist .chapter-list");
@@ -37,7 +37,7 @@ class NovelsquareParser extends Parser{
             :  util.hyperlinksToChapterList(menu);
     }
     
-    async loadEpubMetaInfo(dom){
+    async loadEpubMetaInfo(dom) {
         if (dom.baseURI.match(new RegExp("/chapters$"))) {
             dom = (await HttpClient.wrapFetch(dom.baseURI.slice(0, dom.baseURI.length - 9))).responseXML;
         }

--- a/plugin/js/parsers/NoveltoonParser.js
+++ b/plugin/js/parsers/NoveltoonParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("noveltoon.mobi", () => new NoveltoonParser());
 
-class NoveltoonParser extends Parser{
+class NoveltoonParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/NoveltranslatedbycParser.js
+++ b/plugin/js/parsers/NoveltranslatedbycParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("noveltranslatedbyc.blogspot.com", () => new NoveltranslatedbycParser());
 
-class NoveltranslatedbycParser extends BlogspotParser{
+class NoveltranslatedbycParser extends BlogspotParser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/NovelversetranslationsParser.js
+++ b/plugin/js/parsers/NovelversetranslationsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("novelversetranslations.com", () => new NovelversetranslationsParser());
 
-class NovelversetranslationsParser extends WordpressBaseParser{
+class NovelversetranslationsParser extends WordpressBaseParser {
     constructor() {
         super();
     }
@@ -23,13 +23,13 @@ class NovelversetranslationsParser extends WordpressBaseParser{
     }
 
     getUrlsOfTocPages(dom) {
-        let urls = []
+        let urls = [];
         let paginateUrls = [...dom.querySelectorAll("ul.lcp_paginator a:not(.lcp_nextlink)")]
             .map(a => a.href);
         if (0 < paginateUrls.length) {
             let url = new URL(paginateUrls.pop());
             let maxPage = this.maxPageId(url);
-            for(let i = 2; i <= maxPage; ++i) {
+            for (let i = 2; i <= maxPage; ++i) {
                 url.searchParams.set("lcp_page0", i);
                 urls.push(url.href);
             }

--- a/plugin/js/parsers/NovicetranslationsParser.js
+++ b/plugin/js/parsers/NovicetranslationsParser.js
@@ -1,6 +1,6 @@
 "use strict";
 parserFactory.register("novicetranslations.com", () => new NovicetranslationsParser());
-class NovicetranslationsParser extends WordpressBaseParser{
+class NovicetranslationsParser extends WordpressBaseParser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/NrvnqsrParser.js
+++ b/plugin/js/parsers/NrvnqsrParser.js
@@ -1,9 +1,9 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("forums.nrvnqsr.com", function() { return new NrvnqsrParser() });
+parserFactory.register("forums.nrvnqsr.com", function() { return new NrvnqsrParser(); });
 
-class NrvnqsrParser extends Parser{
+class NrvnqsrParser extends Parser {
     constructor() {
         super();
     }
@@ -11,20 +11,20 @@ class NrvnqsrParser extends Parser{
     getChapterUrls(dom) {
         let menu = dom.querySelector("div.postlist");
         return Promise.resolve(util.hyperlinksToChapterList(menu));        
-    };
+    }
 
     findContent(dom) {
         let postId = util.getParamFromUrl(dom.baseURI, "p");
         let selector = (postId === null) ? "div.postbody div.content" : "div#post_message_" + postId;
         return dom.querySelector(selector);
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("span.threadtitle");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("div.userinfo a.username");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 }

--- a/plugin/js/parsers/NtruyenParser.js
+++ b/plugin/js/parsers/NtruyenParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("ntruyen.vn", () => new NtruyenParser());
 
-class NtruyenParser extends Parser{
+class NtruyenParser extends Parser {
     constructor() {
         super();
     }
@@ -13,7 +13,7 @@ class NtruyenParser extends Parser{
 
         let numPages = this.getNumOfTocPages(dom);
         let storyId = this.getStoryId(dom);
-        for(let i = 2; i <= numPages; ++i) {
+        for (let i = 2; i <= numPages; ++i) {
             let formData = this.createFormData(storyId, i);
             let tocPage = await (this.fetchToc(formData));
             let partialList = this.extractPartialChapterList(tocPage);
@@ -46,7 +46,7 @@ class NtruyenParser extends Parser{
             body: formData
         };
         let json = (await HttpClient.fetchJson("https://ntruyen.vn//ajax/load_chapter", options)).json;
-        return util.sanitize(json.chapters);;
+        return util.sanitize(json.chapters);
     }
 
     createFormData(storyId, page) {

--- a/plugin/js/parsers/NyantlParser.js
+++ b/plugin/js/parsers/NyantlParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("nyantl.wordpress.com", () => new NyantlParser());
 
-class NyantlParser extends WordpressBaseParser{
+class NyantlParser extends WordpressBaseParser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/OctopiiParser.js
+++ b/plugin/js/parsers/OctopiiParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("octopii.co", () => new OctopiiParser());
 
-class OctopiiParser extends Parser{
+class OctopiiParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/OldranobelibParser.js
+++ b/plugin/js/parsers/OldranobelibParser.js
@@ -3,7 +3,7 @@
 parserFactory.register("old.ranobelib.me", () => new OldranobelibParser());
 parserFactory.register("ranobelib.me", () => new OldranobelibParser());
 
-class OldranobelibParser extends Parser{
+class OldranobelibParser extends Parser {
     constructor() {
         super();
         this.homedom = "";
@@ -18,7 +18,7 @@ class OldranobelibParser extends Parser{
         return json.map(j => this.jsonToChapters(j, base));
     }
     
-    async loadEpubMetaInfo(dom){
+    async loadEpubMetaInfo(dom) {
         if (dom.baseURI.includes("https://ranobelib.me/ru/book/")) {
             dom = (await HttpClient.wrapFetch(dom.baseURI.replace("https://ranobelib.me/ru/book/", "https://old.ranobelib.me/old/manga/"))).responseXML;
         }
@@ -30,13 +30,13 @@ class OldranobelibParser extends Parser{
         let startString = "window.__CONTENT__ = ";
         let scriptElement = [...dom.querySelectorAll("script")]
             .filter(s => s.textContent.includes(startString))[0];
-        return util.locateAndExtractJson(scriptElement.textContent, startString)
+        return util.locateAndExtractJson(scriptElement.textContent, startString);
     }
 
     makeChapterBaseUrl(dom) {
         let base = new URL(dom.baseURI);
         let tip = base.pathname.split("/").pop();
-        return `https://old.ranobelib.me/old/${tip}/read/`
+        return `https://old.ranobelib.me/old/${tip}/read/`;
     }
 
     jsonToChapters(json, base) {

--- a/plugin/js/parsers/OnlinenovelbookParser.js
+++ b/plugin/js/parsers/OnlinenovelbookParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("onlinenovelbook.com", () => new OnlinenovelbookParser());
 
-class OnlinenovelbookParser extends WordpressBaseParser{
+class OnlinenovelbookParser extends WordpressBaseParser {
     constructor() {
         super();
     }
@@ -18,7 +18,7 @@ class OnlinenovelbookParser extends WordpressBaseParser{
             OnlinenovelbookParser.getUrlsOfTocPages,
             chapterUrlsUI
         ).then(c => c.reverse());
-    };
+    }
 
     static getUrlsOfTocPages(dom) {
         let urls = [];
@@ -26,7 +26,7 @@ class OnlinenovelbookParser extends WordpressBaseParser{
         let maxPage = parseInt(util.extractSubstring(paginationUrl, "/page/", "/"));
         let index = paginationUrl.indexOf("/page/") + 6;
         let prefix = paginationUrl.substring(0, index);
-        for(let i = 2; i <= maxPage; ++i) {
+        for (let i = 2; i <= maxPage; ++i) {
             urls.push(prefix + i +"/");
         }
         return urls;

--- a/plugin/js/parsers/OntimestoryParser.js
+++ b/plugin/js/parsers/OntimestoryParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("ontimestory.eu", () => new OntimestoryParser());
 
-class OntimestoryParser extends Parser{
+class OntimestoryParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/OssantlParser.js
+++ b/plugin/js/parsers/OssantlParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("ossantl.com", () => new OssantlParser());
 
-class OssantlParser extends Parser{
+class OssantlParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/PandaNovelParser.js
+++ b/plugin/js/parsers/PandaNovelParser.js
@@ -10,7 +10,7 @@ class PandaNovelParser extends Parser {
     }
 
     async getChapterUrls(dom, chapterUrlsUI) {
-        let chapters = []
+        let chapters = [];
         let urlsOfTocPages = PandaNovelParser.getUrlsOfTocPages(dom);
         let baseUrl = new URL(dom.baseURI).origin;
         for (let url of urlsOfTocPages) {
@@ -27,10 +27,10 @@ class PandaNovelParser extends Parser {
         let pageIds = [...dom.querySelectorAll("ul.pagination li a")]
             .filter(a => a.text)
             .map(a => parseInt(a.text.trim()));
-        pageIds.concat(1)
+        pageIds.concat(1);
         let maxPage = Math.max(...pageIds);
         let baseUrl = new URL(dom.baseURI).origin;
-        let bookId = parseInt(dom.baseURI.split("-").pop())
+        let bookId = parseInt(dom.baseURI.split("-").pop());
         let urls = [];
         for (let i = 1; i <= maxPage; ++i) {
             urls.push(baseUrl + "/api/book/chapters/" + bookId + "/" + i);
@@ -92,7 +92,7 @@ class PandaNovelParser extends Parser {
 
     extractAuthor(dom) {
         //Note: In "a[href*='/author']" forward slash is required
-        let authorLabel = [...dom.querySelectorAll(".novel-desc a[href*='/author']")].map(x => x.textContent.trim())
+        let authorLabel = [...dom.querySelectorAll(".novel-desc a[href*='/author']")].map(x => x.textContent.trim());
         return (authorLabel.length === 0) ? super.extractAuthor(dom) : authorLabel.join(", ");
     }
 

--- a/plugin/js/parsers/PatreonParser.js
+++ b/plugin/js/parsers/PatreonParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("patreon.com", () => new PatreonParser());
 
-class PatreonParser extends Parser{
+class PatreonParser extends Parser {
     constructor() {
         super();
     }
@@ -11,7 +11,7 @@ class PatreonParser extends Parser{
         if (this.isCollectionList()) {
             return this.getCollectionLinks(dom);
         }
-        let cards = [...dom.querySelectorAll("div[data-tag='post-card']")]
+        let cards = [...dom.querySelectorAll("div[data-tag='post-card']")];
         return cards
             .filter(c => this.hasAccessableContent(c))
             .map(s => this.cardToChapter(s)).reverse();
@@ -65,7 +65,7 @@ class PatreonParser extends Parser{
             img.src = json.image.url;
             newDoc.content.append(img);
         }
-        let content =  "<div>" + json.content + "</div>"
+        let content =  "<div>" + json.content + "</div>";
         content = util.sanitize(content)
             .querySelector("div");
         newDoc.content.append(content);
@@ -102,7 +102,7 @@ class PatreonParser extends Parser{
 
 
     extractCollectionCover(dom) {
-        let divsWithPicutres = dom.querySelectorAll("div[src]")
+        let divsWithPicutres = dom.querySelectorAll("div[src]");
         if (divsWithPicutres.length == 0) {
             return null;
         }

--- a/plugin/js/parsers/PawreadParser.js
+++ b/plugin/js/parsers/PawreadParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("pawread.com", () => new PawreadParser());
 
-class PawreadParser extends Parser{
+class PawreadParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/PeachblossomcodexParser.js
+++ b/plugin/js/parsers/PeachblossomcodexParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("peachblossomcodex.com", () => new PeachblossomcodexParser());
 
-class PeachblossomcodexParser extends Parser{
+class PeachblossomcodexParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/PeachpittingParser.js
+++ b/plugin/js/parsers/PeachpittingParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("peachpitting.com", () => new PeachpittingParser());
 
-class PeachpittingParser extends Parser{
+class PeachpittingParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/PeachpuffParser.js
+++ b/plugin/js/parsers/PeachpuffParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("peachpuff.in", () => new PeachpuffParser());
 
-class PeachpuffParser extends Parser{
+class PeachpuffParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/PeachygardensBlogspotParser.js
+++ b/plugin/js/parsers/PeachygardensBlogspotParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("peachygardens.blogspot.com", () => new PeachygardensBlogspotParser());
 
-class PeachygardensBlogspotParser extends Parser{
+class PeachygardensBlogspotParser extends Parser {
     constructor() {
         super();
         this.ChacheChapterContent = new Map();
@@ -36,14 +36,14 @@ class PeachygardensBlogspotParser extends Parser{
         return chapters.reverse();
     }
 
-    chaptersFromJson(json){
+    chaptersFromJson(json) {
         return json.feed.entry.map(a => ({
             sourceUrl: a.link[2].href, 
             title: a.link[2].title
         }));
     }
 
-    chacheChapter(json){
+    chacheChapter(json) {
         json.feed.entry.map(a => (this.ChacheChapterContent.set(a.link[2].href, [a.link[2].title, a.content.$t])));
     }
 

--- a/plugin/js/parsers/PowanjuanParser.js
+++ b/plugin/js/parsers/PowanjuanParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("powanjuan.cc", () => new PowanjuanParser());
 
-class PowanjuanParser extends Parser{
+class PowanjuanParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/PtwxzParser.js
+++ b/plugin/js/parsers/PtwxzParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("piaotia.com", () => new PtwxzParser());
 
-class PtwxzParser extends Parser{
+class PtwxzParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/PuretlParser.js
+++ b/plugin/js/parsers/PuretlParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("puretl.com", () => new PuretlParser());
 
-class PuretlParser extends Parser{
+class PuretlParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/QidianParser.js
+++ b/plugin/js/parsers/QidianParser.js
@@ -5,7 +5,7 @@
 
 parserFactory.register("webnovel.com", () => new QidianParser());
 
-class QidianParser extends Parser{
+class QidianParser extends Parser {
     constructor() {
         super();
         this.minimumThrottle = 50; //Minimal delay to reduce frequency of 445 errors.
@@ -26,7 +26,7 @@ class QidianParser extends Parser{
             links = Array.from(dom.querySelectorAll("div.volume-item ol a"));
         }
         return links.map(QidianParser.linkToChapter);
-    };
+    }
 
     static isLinkLocked(link) {
         let img = link.querySelector("svg > use");
@@ -53,7 +53,7 @@ class QidianParser extends Parser{
 
     findContent(dom) {
         return dom.querySelector("div.chapter_content");
-    };
+    }
 
     preprocessRawDom(webPage) {
         if (this.ChacheChapterTitle.size == 0) {
@@ -72,11 +72,11 @@ class QidianParser extends Parser{
         content = webPage.createElement("div");
         content.className = "chapter_content";
         webPage.body.appendChild(content);
-        this.addHeader(webPage, content, json.chapterInfo.chapterName)
-        for(let c of json.chapterInfo?.contents?json.chapterInfo.contents:[]) {
+        this.addHeader(webPage, content, json.chapterInfo.chapterName);
+        for (let c of json.chapterInfo?.contents?json.chapterInfo.contents:[]) {
             this.addParagraph(webPage, content, c.content);
         }
-        for(let c of json.chapterInfo?.chapterPage?json.chapterInfo.chapterPage:[]) {
+        for (let c of json.chapterInfo?.chapterPage?json.chapterInfo.chapterPage:[]) {
             this.addComicPage(webPage, content, c.url);
         }
         if (!this.userPreferences.removeAuthorNotes.value) {
@@ -87,8 +87,8 @@ class QidianParser extends Parser{
                 this.addParagraph(webPage, container, notes);
             }
         }
-        for(let e of [...webPage.querySelectorAll("div.j_bottom_comment_area, div.user-links-wrap, div.g_ad_ph")]) {
-            e.remove()
+        for (let e of [...webPage.querySelectorAll("div.j_bottom_comment_area, div.user-links-wrap, div.g_ad_ph")]) {
+            e.remove();
         }
     }
 
@@ -102,7 +102,7 @@ class QidianParser extends Parser{
         if (tmptitle == undefined || tmptitle == "[placeholder]") {
             let titleEl = content.querySelector("div.chapter_content h1");
             let titleDupChapRegex = new RegExp("(\\w+[\\s\\-]+\\d+):\\s*\\1:?(.*)", "i").exec(titleEl.textContent);
-            if (titleDupChapRegex && titleDupChapRegex.length > 2){
+            if (titleDupChapRegex && titleDupChapRegex.length > 2) {
                 let newtitleText = document.createTextNode(titleDupChapRegex[1] + titleDupChapRegex[2]);
                 newtitlenode.appendChild(newtitleText);
                 titleEl.replaceWith(newtitlenode);
@@ -191,7 +191,7 @@ class QidianParser extends Parser{
     extractTitleImpl(dom) {
         let title = dom.querySelector("div.chapter_content h1");
         return title;
-    };
+    }
 
     extractAuthor(dom) {
         return dom.querySelector("a.c_primary")?.textContent ?? super.extractAuthor(dom);

--- a/plugin/js/parsers/QinxiaoshuoParser.js
+++ b/plugin/js/parsers/QinxiaoshuoParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("qinxiaoshuo.com", () => new QinxiaoshuoParser());
 
-class QinxiaoshuoParser extends Parser{
+class QinxiaoshuoParser extends Parser {
     constructor() {
         super();
     }
@@ -36,7 +36,7 @@ class QinxiaoshuoParser extends Parser{
     }
 
     fetchChapter(url) {
-        return HttpClient.wrapFetch(url).then(function (xhr) {
+        return HttpClient.wrapFetch(url).then(function(xhr) {
             let finalDom = xhr.responseXML;
             let fetchedUrls = new Set();
             fetchedUrls.add(url);
@@ -50,7 +50,7 @@ class QinxiaoshuoParser extends Parser{
         if (url === null) {
             return Promise.resolve(finalDom);
         } else {
-            return HttpClient.wrapFetch(url).then(function (xhr) {
+            return HttpClient.wrapFetch(url).then(function(xhr) {
                 fetchedUrls.add(url);
                 QinxiaoshuoParser.copyContentNodes(finalDom, xhr.responseXML);
                 let nextUrl = QinxiaoshuoParser.urlOfNextPageOfChapter(xhr.responseXML, fetchedUrls);

--- a/plugin/js/parsers/QqxsParser.js
+++ b/plugin/js/parsers/QqxsParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("m.qqxs.vip", () => new QqxsParser());
 
-class QqxsParser extends Parser{
+class QqxsParser extends Parser {
     constructor() {
         super();
     }
@@ -30,7 +30,7 @@ class QqxsParser extends Parser{
 
     getUrlsOfTocPages(dom) {
         return [...dom.querySelectorAll("option")]
-            .map(o => "https://m.qqxs.vip/" + o.value)
+            .map(o => "https://m.qqxs.vip/" + o.value);
     }
 
     findContent(dom) {
@@ -66,7 +66,7 @@ class QqxsParser extends Parser{
 
     fixImages(element) {
         let images = [...element.querySelectorAll("img")];
-        for(let i of images) {
+        for (let i of images) {
             if (i.src.includes("juhao.png")) {
                 i.remove();
             }

--- a/plugin/js/parsers/Quanben5Parser.js
+++ b/plugin/js/parsers/Quanben5Parser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("quanben5.io", () => new Quanben5Parser());
 
-class Quanben5Parser extends Parser{
+class Quanben5Parser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/QuanbenParser.js
+++ b/plugin/js/parsers/QuanbenParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("quanben.io", () => new QuanbenParser());
 
-class QuanbenParser extends Parser{
+class QuanbenParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/QueenrosenovelblogspotParser.js
+++ b/plugin/js/parsers/QueenrosenovelblogspotParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("queenrosenovel.blogspot.com", () => new QueenrosenovelblogspotParser());
 
-class QueenrosenovelblogspotParser extends Parser{
+class QueenrosenovelblogspotParser extends Parser {
     constructor() {
         super();
     }
@@ -10,7 +10,7 @@ class QueenrosenovelblogspotParser extends Parser{
     async getChapterUrls(dom) {
         return [...dom.querySelectorAll("div.epcheck li a")]
             .map(this.linkToChapter)
-            .reverse()
+            .reverse();
     }
 
     linkToChapter(link) {

--- a/plugin/js/parsers/QuotevParser.js
+++ b/plugin/js/parsers/QuotevParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("quotev.com", () => new QuotevParser());
 
-class QuotevParser extends Parser{
+class QuotevParser extends Parser {
     constructor() {
         super();
     }
@@ -25,7 +25,7 @@ class QuotevParser extends Parser{
         return {
             sourceUrl:  baseUrl + option.getAttribute("value"),
             title: option.textContent,
-        }
+        };
     }
 
     makeUrlListForSingleChapterStory(dom) {

--- a/plugin/js/parsers/RaeitranslationsParser.js
+++ b/plugin/js/parsers/RaeitranslationsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("raeitranslations.com", () => new RaeitranslationsParser());
 
-class RaeitranslationsParser extends Parser{
+class RaeitranslationsParser extends Parser {
     constructor() {
         super();
     }
@@ -52,7 +52,7 @@ class RaeitranslationsParser extends Parser{
     buildHtml(json) {
         let paragraphs = json.body.replace(/\n/g, "</p><p>");
         let html = `<div><h1>${json.chapTitle}</h1><p>${paragraphs}</p></div>`;
-        let doc = util.sanitize(html, "text/html")
+        let doc = util.sanitize(html, "text/html");
         return doc.querySelector("div");
     }
 

--- a/plugin/js/parsers/RainOfSnowParser.js
+++ b/plugin/js/parsers/RainOfSnowParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("rainofsnow.com", () => new RainOfSnowParser());
 
-class RainOfSnowParser extends Parser{
+class RainOfSnowParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/RandomtranslatorParser.js
+++ b/plugin/js/parsers/RandomtranslatorParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("randomtranslator.com", () => new RandomtranslatorParser());
 
-class RandomtranslatorParser extends Parser{
+class RandomtranslatorParser extends Parser {
     constructor() {
         super();
     }
@@ -21,7 +21,7 @@ class RandomtranslatorParser extends Parser{
         return chapters;
     }
     
-    async loadEpubMetaInfo(dom){
+    async loadEpubMetaInfo(dom) {
         // eslint-disable-next-line
         let regex = new RegExp("\/novel\/.+");
         let bookhash = dom.baseURI.match(regex)?.[0].slice(7);

--- a/plugin/js/parsers/RanobesParser.js
+++ b/plugin/js/parsers/RanobesParser.js
@@ -4,7 +4,7 @@ parserFactory.register("ranobes.net", () => new RanobesNetParser());
 parserFactory.register("ranobes.top", () => new RanobesParser());
 parserFactory.register("ranobes.com", () => new RanobesParser());
 
-class RanobesParser extends Parser{
+class RanobesParser extends Parser {
     constructor() {
         super();
         this.minimumThrottle = 2000;
@@ -25,7 +25,7 @@ class RanobesParser extends Parser{
         }
         let options = {
             parser: this
-        }
+        };
         let tocDom = (await HttpClient.wrapFetch(tocUrl, options)).responseXML;
         let urlsOfTocPages = RanobesParser.extractTocPageUrls(tocDom, tocUrl);
         return (await this.getChaptersFromAllTocPages(chapters, 
@@ -35,7 +35,7 @@ class RanobesParser extends Parser{
     static extractTocPageUrls(dom, baseUrl) {
         let max = RanobesParser.extractTocJson(dom)?.pages_count ?? 0;
         let tocUrls = [];
-        for(let i = 1; i <= max; ++i) {
+        for (let i = 1; i <= max; ++i) {
             tocUrls.push(`${baseUrl}page/${i}/`);
         }
         return tocUrls;
@@ -54,7 +54,7 @@ class RanobesParser extends Parser{
             let linkElement = Math.max(...[...dom.querySelectorAll(".pages a")].map(a => parseInt(a.textContent)));
             return (Infinity == linkElement || -Infinity == linkElement)?
                 {chapters: [], pages_count: 0} 
-                : {chapters: [], pages_count: linkElement}
+                : {chapters: [], pages_count: linkElement};
         }   
     }
 
@@ -108,7 +108,7 @@ class RanobesParser extends Parser{
     }    
 }
 
-class RanobesNetParser extends RanobesParser{
+class RanobesNetParser extends RanobesParser {
     constructor() {
         super();
         this.minimumThrottle = 8000;
@@ -117,18 +117,18 @@ class RanobesNetParser extends RanobesParser{
     async fetchChapter(url) {
         let options = {
             parser: this
-        }
+        };
         return (await HttpClient.wrapFetch(url, options)).responseXML;
     }
     
-    isCustomError(response){
+    isCustomError(response) {
         if (response.responseXML.title == "Just a moment...") {
             return true;
         }
         return false;
     }
 
-    setCustomErrorResponse(url, wrapOptions){
+    setCustomErrorResponse(url, wrapOptions) {
         let newresp = {};
         newresp.url = url;
         newresp.wrapOptions = wrapOptions;

--- a/plugin/js/parsers/ReLibraryParser.js
+++ b/plugin/js/parsers/ReLibraryParser.js
@@ -1,15 +1,15 @@
 "use strict";
 
-parserFactory.register("re-library.com", function() { return new ReLibraryParser() });
+parserFactory.register("re-library.com", function() { return new ReLibraryParser(); });
 
-class ReLibraryParser extends WordpressBaseParser{
+class ReLibraryParser extends WordpressBaseParser {
     constructor() {
         super();
     }
 
     async getChapterUrls(dom) {
         return [...dom.querySelectorAll("li.page_item a")]
-            .map(a => util.hyperLinkToChapter(a))
+            .map(a => util.hyperLinkToChapter(a));
     }
 
     getInformationEpubItemChildNodes(dom) {

--- a/plugin/js/parsers/ReadComicOnlineParser.js
+++ b/plugin/js/parsers/ReadComicOnlineParser.js
@@ -8,7 +8,7 @@ parserFactory.register("readcomiconline.li", () => new ReadComicOnlineParser());
  * Usually need to open a first page of chapter before rest will work.
  * Also, sometimes pages return a CAPTCHA
  */
-class ReadComicOnlineParser extends Parser{
+class ReadComicOnlineParser extends Parser {
     constructor() {
         super();
     }
@@ -20,7 +20,7 @@ class ReadComicOnlineParser extends Parser{
             .filter(s => s.includes(prefix))[0];
         let urls = [];
         let index = script.indexOf(prefix);
-        while(0 < index) {
+        while (0 < index) {
             index += prefix.length;
             let suffix = script.indexOf("\"", index);
             urls.push(script.substring(index, suffix));
@@ -62,7 +62,7 @@ class ReadComicOnlineParser extends Parser{
         let chapters = [];
         let toclinks = [...dom.querySelectorAll("table.listing a")]
             .filter(l => new URL(l.href).search === "");
-        for(let link of toclinks) {
+        for (let link of toclinks) {
             let html = await this.fetchChapter(link.href);
             let subList = this.getChapterListFromComicTocPage(html);
             subList[0].newArc = link.textContent.trim();
@@ -78,7 +78,7 @@ class ReadComicOnlineParser extends Parser{
             content.className = Parser.WEB_TO_EPUB_CLASS_NAME;
             dom.body.appendChild(content);
             let imgUrls = ReadComicOnlineParser.extractImageUrls(dom);
-            for(let u of imgUrls) {
+            for (let u of imgUrls) {
                 let img = dom.createElement("img");
                 img.src = u;
                 content.appendChild(img);

--- a/plugin/js/parsers/ReadLightNovelCcParser.js
+++ b/plugin/js/parsers/ReadLightNovelCcParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("readlightnovel.cc", () => new ReadLightNovelCcParser());
 
-class ReadLightNovelCcParser extends Parser{
+class ReadLightNovelCcParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/ReadLightNovelParser.js
+++ b/plugin/js/parsers/ReadLightNovelParser.js
@@ -3,12 +3,12 @@
 */
 "use strict";
 
-parserFactory.register("readlightnovel.me", function() { return new ReadLightNovelParser() });
-parserFactory.register("readlightnovel.meme", function() { return new ReadLightNovelParser() });
+parserFactory.register("readlightnovel.me", function() { return new ReadLightNovelParser(); });
+parserFactory.register("readlightnovel.meme", function() { return new ReadLightNovelParser(); });
 //dead url
-parserFactory.register("readlightnovel.org", function() { return new ReadLightNovelParser() });
+parserFactory.register("readlightnovel.org", function() { return new ReadLightNovelParser(); });
 //dead url
-parserFactory.register("readlightnovel.today", function() { return new ReadLightNovelParser() });
+parserFactory.register("readlightnovel.today", function() { return new ReadLightNovelParser(); });
 
 class ReadLightNovelParser extends Parser {
     constructor() {
@@ -41,8 +41,8 @@ class ReadLightNovelParser extends Parser {
                 panelDiv = parent;
             } else {
                 parent = parent.parentNode;
-            };
-        };
+            }
+        }
 
         // get the title
         if (panelDiv !== null) {
@@ -66,8 +66,8 @@ class ReadLightNovelParser extends Parser {
             let li = div.querySelector("li");
             if (li != null) {
                 return li.innerText;
-            };
-        };
+            }
+        }
         return super.extractAuthor(dom);
     }
 
@@ -95,14 +95,14 @@ class ReadLightNovelParser extends Parser {
     removeUnwantedElementsFromContentElement(element) {
         let firstBr = element.querySelector("br:first-of-type");
         let ch = firstBr.nextSibling;
-        if(ch && ch.data.includes("Chapter")) {
+        if (ch && ch.data.includes("Chapter")) {
             let secondBr = ch.nextSibling;
-            if(secondBr && secondBr.tagName == "BR") {
+            if (secondBr && secondBr.tagName == "BR") {
                 util.removeElements([firstBr, ch, secondBr]);
             }
         }
 
-        for(let a of element.querySelectorAll(".adsbyvli")) {
+        for (let a of element.querySelectorAll(".adsbyvli")) {
             let toDelete = [];
             let center = a.parentNode;
             let temp =  this.addPreviousSiblingIfMatches(center, "BR", toDelete);
@@ -111,13 +111,13 @@ class ReadLightNovelParser extends Parser {
             temp = this.addNextSiblingIfMatches(temp, "BR", toDelete);
             this.addNextSiblingIfMatches(temp, "HR", toDelete);
 
-            if(center.tagName == "CENTER") {
+            if (center.tagName == "CENTER") {
                 center.remove();
             }
             util.removeElements(toDelete);
         }
 
-        for(let small of element.querySelectorAll(".ads-title")) {
+        for (let small of element.querySelectorAll(".ads-title")) {
             let toDelete = [];
             this.addPreviousSiblingIfMatches(small, "BR", toDelete);
             let temp = this.addNextSiblingIfMatches(small, "BR", toDelete);
@@ -128,7 +128,7 @@ class ReadLightNovelParser extends Parser {
             util.removeElements(toDelete);
         }
 
-        for(let s of element.querySelectorAll("center > script")) {
+        for (let s of element.querySelectorAll("center > script")) {
             let toDelete = [];
             let center = s.parentNode;
             this.addNextSiblingIfMatches(center, "HR", toDelete);
@@ -157,7 +157,7 @@ class ReadLightNovelParser extends Parser {
         }
         let sibling = op(element);
 
-        if(!sibling && (element.parentNode !== null)) {
+        if (!sibling && (element.parentNode !== null)) {
             sibling = op(element.parentNode);
         }
 
@@ -174,7 +174,7 @@ class ReadLightNovelParser extends Parser {
     removeShareThisLinks(element) {
         let shareLinks = element.querySelectorAll("span.st_facebook, " +
             "span.st_twitter, span.st_googleplus");
-        for(let share of shareLinks) {
+        for (let share of shareLinks) {
             let parent = share.parentNode;
             if (parent.tagName.toLowerCase() === "p") {
                 parent.remove();

--- a/plugin/js/parsers/ReadNovelFullParser.js
+++ b/plugin/js/parsers/ReadNovelFullParser.js
@@ -2,23 +2,23 @@
 
 parserFactory.register("readnovelfull.com", () => new ReadNovelFullParser());
 
-class ReadNovelFullParser extends Parser{
+class ReadNovelFullParser extends Parser {
     constructor() {
         super();
     }
 
     getChapterUrls(dom) {
-        let chapters = ReadNovelFullParser.extractChapterList(dom)
+        let chapters = ReadNovelFullParser.extractChapterList(dom);
         if (0 < chapters.length) {
             return Promise.resolve(chapters);
         }
         return ReadNovelFullParser.fetchChapterList(dom);
-    };
+    }
 
     static fetchChapterList(dom) {
         let novelId = dom.querySelector("div#rating").getAttribute("data-novel-id");
         let url = `https://readnovelfull.com/ajax/chapter-archive?novelId=${novelId}`;
-        return HttpClient.wrapFetch(url).then(function (xhr) {
+        return HttpClient.wrapFetch(url).then(function(xhr) {
             return ReadNovelFullParser.extractChapterList(xhr.responseXML);
         });
     }
@@ -30,16 +30,16 @@ class ReadNovelFullParser extends Parser{
 
     findContent(dom) {
         return dom.querySelector("div#chr-content");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("h3.title");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("ul.info li:nth-of-type(2) a");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 
     findChapterTitle(dom) {
         return dom.querySelector("a.chr-title").textContent;

--- a/plugin/js/parsers/ReadhiveParser.js
+++ b/plugin/js/parsers/ReadhiveParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("readhive.org", () => new ReadhiveParser());
 
-class ReadhiveParser extends Parser{
+class ReadhiveParser extends Parser {
     constructor() {
         super();
     }
@@ -40,14 +40,14 @@ class ReadhiveParser extends Parser{
     }
 
     customRawDomToContentStep(chapter, content) {
-        for(let e of content.querySelectorAll("div")) {
+        for (let e of content.querySelectorAll("div")) {
             let toRemove = [];
-            for(let attr of e.attributes) {
+            for (let attr of e.attributes) {
                 if (attr.name.startsWith("@")) {
                     toRemove.push(attr.name);
                 }
             }
-            for(let attr of toRemove) {
+            for (let attr of toRemove) {
                 e.removeAttribute(attr);
             }
         }

--- a/plugin/js/parsers/ReadnoveldailyParser.js
+++ b/plugin/js/parsers/ReadnoveldailyParser.js
@@ -4,7 +4,7 @@
 parserFactory.register("readnoveldaily.com", () => new ReadnoveldailyParser());
 parserFactory.register("allnovelbook.com", () => new ReadnoveldailyParser());
 
-class ReadnoveldailyParser extends Parser{
+class ReadnoveldailyParser extends Parser {
     constructor() {
         super();
     }
@@ -15,15 +15,15 @@ class ReadnoveldailyParser extends Parser{
             this.getUrlsOfTocPages,
             chapterUrlsUI
         );
-    };
+    }
 
     getUrlsOfTocPages(dom) {
-        let urls = []
+        let urls = [];
         let paginateUrls = [...dom.querySelectorAll("ul.pagination li a:not([rel])")];
         if (0 < paginateUrls.length) {
             let url = new URL(paginateUrls.pop().href);
             let maxPage = url.searchParams.get("page");
-            for(let i = 2; i <= maxPage; ++i) {
+            for (let i = 2; i <= maxPage; ++i) {
                 url.searchParams.set("page", i);
                 urls.push(url.href);
             }
@@ -40,11 +40,11 @@ class ReadnoveldailyParser extends Parser{
         return dom.querySelector("#content");
     }
 
-    isHTMLUnknownElement(element){
+    isHTMLUnknownElement(element) {
         return (element instanceof HTMLUnknownElement);
     }
     //removes the watermark that is wraped in custom xml tag -> no valid HTML tag
-    removeUnknownElement(element){
+    removeUnknownElement(element) {
         for (let node of element.childNodes) {
             if (this.isHTMLUnknownElement(node)) {
                 node.remove();

--- a/plugin/js/parsers/ReadnovelfullorgParser.js
+++ b/plugin/js/parsers/ReadnovelfullorgParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("readnovelfull.org", () => new ReadnovelfullorgParser());
 
-class ReadnovelfullorgParser extends Parser{
+class ReadnovelfullorgParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/ReadnovelmtlParser.js
+++ b/plugin/js/parsers/ReadnovelmtlParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("readnovelmtl.com", () => new ReadnovelmtlParser());
 
-class ReadnovelmtlParser extends Parser{
+class ReadnovelmtlParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/ReadwnParser.js
+++ b/plugin/js/parsers/ReadwnParser.js
@@ -29,7 +29,7 @@ parserFactory.registerRule(
     () => new ReadwnParser()
 );
 
-class ReadwnParser extends Parser{
+class ReadwnParser extends Parser {
     constructor() {
         super();
         this.minimumThrottle = 3000;
@@ -37,7 +37,7 @@ class ReadwnParser extends Parser{
 
     static isReadwn(dom) {
         return (dom.querySelector(ReadwnParser.CoverSelector) !== null)
-            && (dom.querySelector(ReadwnParser.AuthorSelector) !== null)
+            && (dom.querySelector(ReadwnParser.AuthorSelector) !== null);
     }
 
     async getChapterUrls(dom, chapterUrlsUI) {

--- a/plugin/js/parsers/RebirthOnline.js
+++ b/plugin/js/parsers/RebirthOnline.js
@@ -1,8 +1,8 @@
 "use strict";
 
-parserFactory.register("www.rebirth.online", function() { return new RebirthOnlineParser() });
+parserFactory.register("www.rebirth.online", function() { return new RebirthOnlineParser(); });
 
-class RebirthOnlineParser extends Parser{
+class RebirthOnlineParser extends Parser {
     constructor() {
         super();
     }
@@ -10,7 +10,7 @@ class RebirthOnlineParser extends Parser{
     getChapterUrls(dom) {
         let menu = dom.querySelector("div.table_of_content");
         return Promise.resolve(util.hyperlinksToChapterList(menu));
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector(".entry-content");
@@ -18,7 +18,7 @@ class RebirthOnlineParser extends Parser{
 
     extractTitleImpl(dom) {
         return dom.querySelector(".entry-title a");
-    };
+    }
 
     findChapterTitle(dom) {
         return dom.querySelector(".chapter-title");

--- a/plugin/js/parsers/RedditParser.js
+++ b/plugin/js/parsers/RedditParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("reddit.com", () => new RedditParser());
 
-class RedditParser extends Parser{
+class RedditParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/RequiemtlsParser.js
+++ b/plugin/js/parsers/RequiemtlsParser.js
@@ -1,8 +1,8 @@
 "use strict";
 
-parserFactory.register("requiemtls.com", function() { return new RequiemtlsParser() });
+parserFactory.register("requiemtls.com", function() { return new RequiemtlsParser(); });
 
-class RequiemtlsParser extends Parser{
+class RequiemtlsParser extends Parser {
     constructor() {
         super();
     }
@@ -31,7 +31,7 @@ class RequiemtlsParser extends Parser{
 
     extractTitleImpl(dom) {
         return dom.querySelector(".entry-title");
-    };
+    }
 
     findCoverImageUrl(dom) {
         return dom.querySelector("div.thumbook img.ts-post-image")?.src ?? null;
@@ -49,7 +49,7 @@ class RequiemtlsParser extends Parser{
         newDoc.content.appendChild(title);
         let divret = newDoc.dom.createElement("div");
         let content = dom.querySelector(".entry-content");
-        for(let n of [...content.childNodes]) {
+        for (let n of [...content.childNodes]) {
             divret.appendChild(n);
         }
         let regex = new RegExp(/requiem_tnr_.*?(,|")/, "s");

--- a/plugin/js/parsers/RoyalRoadParser.js
+++ b/plugin/js/parsers/RoyalRoadParser.js
@@ -3,10 +3,10 @@
 */
 "use strict";
 
-parserFactory.register("royalroadl.com", function() { return new RoyalRoadParser() });
-parserFactory.register("royalroad.com", function() { return new RoyalRoadParser() });
+parserFactory.register("royalroadl.com", function() { return new RoyalRoadParser(); });
+parserFactory.register("royalroad.com", function() { return new RoyalRoadParser(); });
 
-class RoyalRoadParser extends Parser{
+class RoyalRoadParser extends Parser {
     constructor() {
         super();
     }
@@ -54,19 +54,19 @@ class RoyalRoadParser extends Parser{
         let internalStyles = [...webPageDom.querySelectorAll("style")]
             .map(style => style.sheet?.rules);
         let allCssRules = [];
-        for(let ruleList of internalStyles) {
-            for(let rule of ruleList) {
+        for (let ruleList of internalStyles) {
+            for (let rule of ruleList) {
                 allCssRules.push(rule);
             }
         }
-        for(let rule of allCssRules.filter(s => s.style?.display == "none")) {
+        for (let rule of allCssRules.filter(s => s.style?.display == "none")) {
             webPageDom.querySelector(rule.selectorText)?.remove();
         }        
     }
 
     removeUnwantedElementsFromContentElement(content) {
         // only keep the <div class="chapter-inner" elements of content
-        for(let i = content.childElementCount - 1; 0 <= i; --i) {
+        for (let i = content.childElementCount - 1; 0 <= i; --i) {
             let child = content.children[i];
             if (!this.isWantedElement(child)) {
                 child.remove();
@@ -124,11 +124,11 @@ class RoyalRoadParser extends Parser{
 
     static removeOlderChapterNavJunk(content) {
         // some older chapters have next chapter & previous chapter links seperated by string "<-->"
-        for(let node of util.iterateElements(content, 
+        for (let node of util.iterateElements(content, 
             n => (n.textContent.trim() === "<-->"),
             NodeFilter.SHOW_TEXT)) {
             node.remove();
-        };
+        }
     }
 
     findCoverImageUrl(dom) {

--- a/plugin/js/parsers/RtdMoeParser.js
+++ b/plugin/js/parsers/RtdMoeParser.js
@@ -1,8 +1,8 @@
 "use strict";
 
-parserFactory.register("rtd.moe", function() { return new RtdMoeParser() });
+parserFactory.register("rtd.moe", function() { return new RtdMoeParser(); });
 
-class RtdMoeParser extends Parser{
+class RtdMoeParser extends Parser {
     constructor() {
         super();
     }
@@ -10,15 +10,15 @@ class RtdMoeParser extends Parser{
     getChapterUrls(dom) {
         let menu = this.findContent(dom);
         return Promise.resolve(util.hyperlinksToChapterList(menu));
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div#content");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("h1");
-    };
+    }
 
     removeUnwantedElementsFromContentElement(element) {
         util.removeChildElementsMatchingSelector(element, "div.wp-post-navigation, div.tags, table#amazon-polly-audio-table");

--- a/plugin/js/parsers/RtenzoParser.js
+++ b/plugin/js/parsers/RtenzoParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("rtenzo.net", () => new RtenzoParser());
 
-class RtenzoParser extends Parser{
+class RtenzoParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/RubymaybetranslationsParser.js
+++ b/plugin/js/parsers/RubymaybetranslationsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("rubymaybetranslations.com", () => new RubymaybetranslationsParser());
 
-class RubymaybetranslationsParser extends Parser{
+class RubymaybetranslationsParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/RuversParser.js
+++ b/plugin/js/parsers/RuversParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("ruvers.ru", () => new RuversParser());
 
-class RuversParser extends Parser{
+class RuversParser extends Parser {
     constructor() {
         super();
         this.ChacheChapterTitle = new Map();

--- a/plugin/js/parsers/SangtacvietParser.js
+++ b/plugin/js/parsers/SangtacvietParser.js
@@ -3,7 +3,7 @@
 parserFactory.register("sangtacviet.com", () => new SangtacvietParser());
 parserFactory.register("sangtacviet.vip", () => new SangtacvietParser());
 
-class SangtacvietParser extends Parser{
+class SangtacvietParser extends Parser {
     constructor() {
         super();
         this.minimumThrottle = 9000;
@@ -20,7 +20,7 @@ class SangtacvietParser extends Parser{
                 "requestHeaders": [{ "header": "referer", "operation": "set", "value": "https://"+hostname}]
             },
             "condition": { "urlFilter" : hostname}
-        }]
+        }];
         await HttpClient.setDeclarativeNetRequestRules(rule);
         let leaves = dom.baseURI.split("/").filter(a => a != "");
         let id = leaves[leaves.length - 1];
@@ -71,14 +71,14 @@ class SangtacvietParser extends Parser{
         return this.buildChapter(json, url);
     }
     
-    isCustomError(response){
+    isCustomError(response) {
         if (response.json.code != "0") {
             return true;
         }
         return false;
     }
 
-    setCustomErrorResponse(url, wrapOptions, checkedresponse){
+    setCustomErrorResponse(url, wrapOptions, checkedresponse) {
         let newresp = {};
         newresp.url = url;
         newresp.wrapOptions = wrapOptions;
@@ -88,7 +88,7 @@ class SangtacvietParser extends Parser{
         return newresp;
     }
 
-    RestToUrl(url){
+    RestToUrl(url) {
         let params = new URL(url).searchParams;
         let chapter = params.get("c");
         let id = params.get("bookid");

--- a/plugin/js/parsers/ScribblehubParser.js
+++ b/plugin/js/parsers/ScribblehubParser.js
@@ -12,7 +12,7 @@ class ScribblehubParser extends Parser {
         let baseUrl = dom.baseURI;
         let nextTocIndex = 1;
         let numChapters = parseInt(dom.querySelector("span.cnt_toc").textContent);
-        let nextTocPageUrl = function (_dom, chapters, lastFetch) {
+        let nextTocPageUrl = function(_dom, chapters, lastFetch) {
             // site has bug, sometimes, won't return chapters, so 
             // don't loop forever when this happens
             return ((chapters.length < numChapters) && (0 < lastFetch.length))
@@ -28,16 +28,16 @@ class ScribblehubParser extends Parser {
         )).reverse();
         this.minimumThrottle = saveThrottle;
         return chapters;
-    };
+    }
 
     static getChapterUrlsFromTocPage(dom) {
         return [...dom.querySelectorAll("a.toc_a")]
-            .map(a => util.hyperLinkToChapter(a))
+            .map(a => util.hyperLinkToChapter(a));
     }
 
     findContent(dom) {
         return dom.querySelector("div.fic_row, div#chp_raw");
-    };
+    }
 
     populateUIImpl() {
         document.getElementById("removeAuthorNotesRow").hidden = false;
@@ -45,12 +45,12 @@ class ScribblehubParser extends Parser {
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.fic_title");
-    };
+    }
 
     extractAuthor(dom) {
         let author = dom.querySelector("span.auth_name_fic");
         return (author === null) ? super.extractAuthor(dom) : author.textContent;
-    };
+    }
     
     extractSubject(dom) {
         let selector = "[property='genre']";

--- a/plugin/js/parsers/SecondlifetranslationsParser.js
+++ b/plugin/js/parsers/SecondlifetranslationsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("secondlifetranslations.com", () => new SecondlifetranslationsParser());
 
-class SecondlifetranslationsParser extends Parser{
+class SecondlifetranslationsParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/SemprotParser.js
+++ b/plugin/js/parsers/SemprotParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("semprot.com", () => new SemprotParser());
 
-class SemprotParser extends Parser{
+class SemprotParser extends Parser {
     constructor() {
         super();
     }
@@ -14,7 +14,7 @@ class SemprotParser extends Parser{
         let baseUri = dom.baseURI;
         let chapters = [this.makeChapter(baseUri, "1")];
         let max = this.lastThreadPageNum(dom);
-        for(let i = 2; i <= max; ++i) {
+        for (let i = 2; i <= max; ++i) {
             chapters.push(this.makeChapter(baseUri, i));
         }
         return chapters;
@@ -31,7 +31,7 @@ class SemprotParser extends Parser{
         return {
             sourceUrl:  `${baseUrl}page-${pageNum}`,
             title: `${pageNum}`
-        }
+        };
     }
 
     findContent(dom) {
@@ -51,7 +51,7 @@ class SemprotParser extends Parser{
 
     preprocessRawDom(webPageDom) {
         let articles = [...webPageDom.querySelectorAll("article.message")];
-        for(let article of articles) {
+        for (let article of articles) {
             if (article.getAttribute("data-author") !== SemprotParser.author) {
                 article.remove();
             } else {

--- a/plugin/js/parsers/SexStoriesParser.js
+++ b/plugin/js/parsers/SexStoriesParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("sexstories.com", () => new SexStoriesParser());
 
-class SexStoriesParser extends Parser{
+class SexStoriesParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/ShanghaifantasyParser.js
+++ b/plugin/js/parsers/ShanghaifantasyParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("shanghaifantasy.com", () => new ShanghaifantasyParser());
 
-class ShanghaifantasyParser extends Parser{
+class ShanghaifantasyParser extends Parser {
     constructor() {
         super();
     }
@@ -34,13 +34,13 @@ class ShanghaifantasyParser extends Parser{
     }
 
     extractTitleImpl(dom) {
-        return dom.querySelector("title")?.textContent ?? null;;
+        return dom.querySelector("title")?.textContent ?? null;
     }
 
     removeUnwantedElementsFromContentElement(element) {
         util.removeChildElementsMatchingSelector(element, ".patreon1, section, nav, button, template, #comments, footer, .hideme");
 
-        for(let e of [...element.querySelectorAll("div")]) {
+        for (let e of [...element.querySelectorAll("div")]) {
             e.removeAttribute(":style");
             e.removeAttribute(":class");
             e.removeAttribute("@click.outside");

--- a/plugin/js/parsers/ShikkakutranslationsParser.js
+++ b/plugin/js/parsers/ShikkakutranslationsParser.js
@@ -3,7 +3,7 @@
 */
 "use strict";
 
-parserFactory.register( "shikkakutranslations.org", function() { return new ShikkakutranslationsParser() });
+parserFactory.register( "shikkakutranslations.org", function() { return new ShikkakutranslationsParser(); });
 
 class ShikkakutranslationsImageCollector extends ImageCollector {
     constructor() {

--- a/plugin/js/parsers/ShinningnoveltranslationsParser.js
+++ b/plugin/js/parsers/ShinningnoveltranslationsParser.js
@@ -1,8 +1,8 @@
 "use strict";
 
-parserFactory.register("shinningnoveltranslations.com", function() { return new ShinningnoveltranslationsParser() });
+parserFactory.register("shinningnoveltranslations.com", function() { return new ShinningnoveltranslationsParser(); });
 
-class ShinningnoveltranslationsParser extends Parser{
+class ShinningnoveltranslationsParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/ShinsoriParser.js
+++ b/plugin/js/parsers/ShinsoriParser.js
@@ -4,9 +4,9 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("shinsori.com", function() { return new ShinsoriParser() });
+parserFactory.register("shinsori.com", function() { return new ShinsoriParser(); });
 
-class ShinsoriParser extends Parser{
+class ShinsoriParser extends Parser {
     constructor() {
         super();
     }
@@ -17,7 +17,7 @@ class ShinsoriParser extends Parser{
             ShinsoriParser.getUrlsOfTocPages,
             chapterUrlsUI
         );
-    };
+    }
 
     static getUrlsOfTocPages(dom) {
         return [...dom.querySelectorAll("ul.lcp_paginator a:not(.lcp_nextlink)")]
@@ -33,16 +33,16 @@ class ShinsoriParser extends Parser{
 
     findContent(dom) {
         return dom.querySelector("div.entry-content");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("h2.section-title");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = util.getElement(dom, "strong", e => e.textContent === "Author:");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.nextSibling.textContent;
-    };
+    }
 
     removeUnwantedElementsFromContentElement(content) {
         util.removeElements(content.querySelectorAll("div.stream-item-below-post-content, div.post-bottom-meta"));

--- a/plugin/js/parsers/ShintranslationsParser.js
+++ b/plugin/js/parsers/ShintranslationsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("shintranslations.com", () => new ShintranslationsParser());
 
-class ShintranslationsParser extends Parser{
+class ShintranslationsParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/ShirokunsParser.js
+++ b/plugin/js/parsers/ShirokunsParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("shirokuns.com", () => new ShirokunsParser());
 
-class ShirokunsParser extends Parser{
+class ShirokunsParser extends Parser {
     constructor() {
         super();
     }
@@ -22,11 +22,11 @@ class ShirokunsParser extends Parser{
     }
 
     preprocessRawDom(chapterDom) {
-        util.removeChildElementsMatchingSelector(chapterDom, "p.author, div.col-md-12 img")
+        util.removeChildElementsMatchingSelector(chapterDom, "p.author, div.col-md-12 img");
     }
 
     findCoverImageUrl(dom) {
-        let img = dom.querySelector("article p img")
+        let img = dom.querySelector("article p img");
         return img === null ? null : img.src;
     }
 

--- a/plugin/js/parsers/ShmtranslationsParser.js
+++ b/plugin/js/parsers/ShmtranslationsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("shmtranslations.com", () => new ShmtranslationsParser());
 
-class ShmtranslationsParser extends WordpressBaseParser{
+class ShmtranslationsParser extends WordpressBaseParser {
     constructor() {
         super();
     }
@@ -16,10 +16,10 @@ class ShmtranslationsParser extends WordpressBaseParser{
         // site changed 2019-10-27.  Look for new content and clean
         content = dom.querySelector("article");
         if (content !== null) {
-            ShmtranslationsParser.cleanLaterContent(content)
+            ShmtranslationsParser.cleanLaterContent(content);
         }
         return content;
-    };
+    }
 
     findChapterTitle(dom) {
         return dom.querySelector(".entry-title");
@@ -29,7 +29,7 @@ class ShmtranslationsParser extends WordpressBaseParser{
         let junk = [...content.querySelectorAll("span[style='color: #ffffff;']")]
             .map(s => s.parentElement)
             .filter(p => p.tagName.toLowerCase() === "p")
-            .concat([...content.querySelectorAll("footer, div.awac-wrapper")])
+            .concat([...content.querySelectorAll("footer, div.awac-wrapper")]);
         util.removeElements(junk);
     }
 }

--- a/plugin/js/parsers/ShubaowParser.js
+++ b/plugin/js/parsers/ShubaowParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("shubaow.net", () => new ShubaowParser());
 
-class ShubaowParser extends Parser{
+class ShubaowParser extends Parser {
     constructor() {
         super();
     }
@@ -16,11 +16,11 @@ class ShubaowParser extends Parser{
     removeDuplicates(links) {
         let unique = new Set();
         let dedup = [];
-        while(0 < links.length) {
+        while (0 < links.length) {
             let link = links.pop();
             if (!unique.has(link.href)) {
-                dedup.push(link)
-                unique.add(link.href)
+                dedup.push(link);
+                unique.add(link.href);
             }
         }
         return dedup.reverse();

--- a/plugin/js/parsers/ShubaowbParser.js
+++ b/plugin/js/parsers/ShubaowbParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("shubaowb.com", () => new ShubaowbParser());
 
-class ShubaowbParser extends Parser{
+class ShubaowbParser extends Parser {
     constructor() {
         super();
     }
@@ -28,7 +28,7 @@ class ShubaowbParser extends Parser{
                 v = "/novel" + v;
             }
             return "https://shubaowb.com" + v; 
-        }
+        };
 
         let listpage = dom.querySelector(".listpage");
         return [...listpage.querySelectorAll("option")]

--- a/plugin/js/parsers/Shw5Parser.js
+++ b/plugin/js/parsers/Shw5Parser.js
@@ -3,7 +3,7 @@
 parserFactory.register("shw5.cc", () => new Shw5Parser());
 parserFactory.register("bqka.cc", () => new Shw5Parser());
 
-class Shw5Parser extends Parser{
+class Shw5Parser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/SitesGoogleParser.js
+++ b/plugin/js/parsers/SitesGoogleParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("sites.google.com", () => new SitesGoogleParser());
 
-class SitesGoogleParser extends Parser{
+class SitesGoogleParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/Sjks88Parser.js
+++ b/plugin/js/parsers/Sjks88Parser.js
@@ -3,7 +3,7 @@
 parserFactory.register("sjks88.com", () => new Sjks88Parser());
 parserFactory.register("m.sjks88.com", () => new Sjks88Parser());
 
-class Sjks88Parser extends Parser{
+class Sjks88Parser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/SjuukanshuParser.js
+++ b/plugin/js/parsers/SjuukanshuParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("sj.uukanshu.com", () => new SjuukanshuParser());
 
-class SjuukanshuParser extends Parser{
+class SjuukanshuParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/SkydemonorderParser.js
+++ b/plugin/js/parsers/SkydemonorderParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("skydemonorder.com", () => new SkydemonorderParser());
 
-class SkydemonorderParser extends Parser{
+class SkydemonorderParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/SnowyCodexParser.js
+++ b/plugin/js/parsers/SnowyCodexParser.js
@@ -1,15 +1,15 @@
 "use strict";
 
-parserFactory.register("snowycodex.com", function() { return new SnowyCodexParser() });
+parserFactory.register("snowycodex.com", function() { return new SnowyCodexParser(); });
 
-class SnowyCodexParser extends WordpressBaseParser{
+class SnowyCodexParser extends WordpressBaseParser {
     constructor() {
         super();
     }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.entry-content h2");
-    };
+    }
 
     getInformationEpubItemChildNodes(dom) {
         return [...dom.querySelectorAll("div.entry-content p")];

--- a/plugin/js/parsers/SonakoParser.js
+++ b/plugin/js/parsers/SonakoParser.js
@@ -3,8 +3,8 @@
 */
 "use strict";
 
-parserFactory.register("sonako.wikia.com", function() { return new SonakoParser() });
-parserFactory.register("sonako.fandom.com", function() { return new SonakoParser() });
+parserFactory.register("sonako.wikia.com", function() { return new SonakoParser(); });
+parserFactory.register("sonako.fandom.com", function() { return new SonakoParser(); });
 
 //-----------------------------------------------------------------------------
 // class SonakoImageCollector  (derives from ImageCollector)
@@ -27,7 +27,7 @@ class SonakoImageCollector extends BakaTsukiImageCollector {
         let link = element.querySelector("a");
         if (link !== null) {
             return link.href;
-        };
+        }
         let img = (tagName === "img") ? element : element.querySelector("img");
         let dataImageName = img.getAttribute("data-image-name");
 

--- a/plugin/js/parsers/SoverseParser.js
+++ b/plugin/js/parsers/SoverseParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("soverse.com", () => new SoverseParser());
 
-class SoverseParser extends Parser{
+class SoverseParser extends Parser {
     constructor() {
         super();
     }
@@ -18,7 +18,7 @@ class SoverseParser extends Parser{
         return {
             sourceUrl:  link.href,
             title: link.textContent.trim()
-        }        
+        };        
     }
 
     findContent(dom) {

--- a/plugin/js/parsers/SpacebattlesParser.js
+++ b/plugin/js/parsers/SpacebattlesParser.js
@@ -8,7 +8,7 @@ parserFactory.register("alternatehistory.com", () => new SpacebattlesParser());
 parserFactory.register("forum.questionablequesting.com", () => new SpacebattlesParser());
 parserFactory.register("questionablequesting.com", () => new SpacebattlesParser());
 
-class SpacebattlesParser extends Parser{
+class SpacebattlesParser extends Parser {
     constructor() {
         super();
         this.cache = new FetchCache();
@@ -20,7 +20,7 @@ class SpacebattlesParser extends Parser{
         let chapters = [...dom.querySelectorAll("div.structItem--threadmark a")]
             .filter(this.isLinkToChapter);
         return chapters.map(a => util.hyperLinkToChapter(a));
-    };
+    }
 
     isLinkToChapter(link) {
         return !link.querySelector("date")
@@ -29,16 +29,16 @@ class SpacebattlesParser extends Parser{
 
     findContent(dom) {
         return Parser.findConstrutedContent(dom);
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("h1.p-title-value");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("a.username");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 
     async fetchChapter(url) {
         let article = await this.fetchArticle(url);

--- a/plugin/js/parsers/SpiritfanfictionParser.js
+++ b/plugin/js/parsers/SpiritfanfictionParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("spiritfanfiction.com", () => new SpiritfanfictionParser());
 
-class SpiritfanfictionParser extends Parser{
+class SpiritfanfictionParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/SspaiParser.js
+++ b/plugin/js/parsers/SspaiParser.js
@@ -3,9 +3,9 @@
 */
 "use strict";
 
-parserFactory.register("sspai.com", function() { return new SspaiParser() });
+parserFactory.register("sspai.com", function() { return new SspaiParser(); });
 
-class SspaiParser extends Parser{
+class SspaiParser extends Parser {
     constructor() {
         super();
     }
@@ -13,9 +13,9 @@ class SspaiParser extends Parser{
     getChapterUrls(dom) {
         let menu = dom.querySelector("body");
         return Promise.resolve(util.hyperlinksToChapterList(menu));        
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div.wangEditor-txt");
-    };
+    }
 }

--- a/plugin/js/parsers/StarlightstreamParser.js
+++ b/plugin/js/parsers/StarlightstreamParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("starlightstream.net", () => new StarlightstreamParser());
 
-class StarlightstreamParser extends Parser{
+class StarlightstreamParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/StellarRealmParser.js
+++ b/plugin/js/parsers/StellarRealmParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("stellarrealm.net", () => new StellarRealmParser());
 
-class StellarRealmParser extends Parser{
+class StellarRealmParser extends Parser {
     constructor() {
         super();
     }
@@ -22,12 +22,12 @@ class StellarRealmParser extends Parser{
         return chapters;
     }
 
-    getJson(dom){
+    getJson(dom) {
         let jsondiv = dom.querySelector("#app");
         return JSON.parse(jsondiv.dataset.page);
     }
 
-    async loadEpubMetaInfo(dom){
+    async loadEpubMetaInfo(dom) {
         let xml = (await HttpClient.wrapFetch(dom.baseURI)).responseXML;
         let bookinfo = this.getJson(xml);
         this.title = bookinfo.props.series?.title;

--- a/plugin/js/parsers/StocxParser.js
+++ b/plugin/js/parsers/StocxParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("sto.cx", () => new StocxParser());
 
-class StocxParser extends Parser{
+class StocxParser extends Parser {
     constructor() {
         super();
     }
@@ -12,15 +12,15 @@ class StocxParser extends Parser{
         let chapters = [];
         if (0 < scripts.length) {
             let chapInfo = StocxParser.extractChapterGenInfo(scripts[0]);
-            for(let i = 1; i <= chapInfo.maxPage; ++i) {
+            for (let i = 1; i <= chapInfo.maxPage; ++i) {
                 chapters.push({
                     sourceUrl: `https://www.sto.cx/book-${chapInfo.bookId}-${i}.html`,
                     title: `${i}`
                 });
             }
-        };
+        }
         return Promise.resolve(chapters);
-    };
+    }
 
     static findScriptElementWithChapterInfo(dom) {
         return [...dom.querySelectorAll("script")]
@@ -39,15 +39,15 @@ class StocxParser extends Parser{
 
     findContent(dom) {
         return dom.querySelector("div#BookContent");
-    };
+    }
 
     extractLanguage() {
         return "cn";
-    };
+    }
 
     customRawDomToContentStep(chapter, content) {
         let fix = StocxParser.getTextNodesToFixUp(content);
-        for(let node of fix) {
+        for (let node of fix) {
             node.nodeValue = StocxParser.fixMangledText(node.nodeValue);
         }
     }
@@ -56,7 +56,7 @@ class StocxParser extends Parser{
         let n = null; 
         let nodes = [];
         let walk = document.createTreeWalker(content,NodeFilter.SHOW_TEXT,null,false);
-        while((n = walk.nextNode()) !== null) {
+        while ((n = walk.nextNode()) !== null) {
             if (n.nodeValue.includes("%")) {
                 nodes.push(n);
             }
@@ -70,10 +70,10 @@ class StocxParser extends Parser{
         while (i < text.length) {
             if (StocxParser.isEncodeddByte(text, i)) {
                 bytes.push(StocxParser.decodeByte(text, i));
-                i += 3
+                i += 3;
             } else {
                 let utf = StocxParser.getUtf8encoder().encode(text[i]);
-                for(let u of utf) {
+                for (let u of utf) {
                     bytes.push(u);
                 }
                 ++i;

--- a/plugin/js/parsers/SweekParser.js
+++ b/plugin/js/parsers/SweekParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("sweek.com", () => new SweekParser());
 
-class SweekParser extends Parser{
+class SweekParser extends Parser {
     constructor() {
         super();
     }
@@ -36,7 +36,7 @@ class SweekParser extends Parser{
         return ({
             sourceUrl:  firstUrl + "/" + json.id + "/" + json.device,
             title: json.title,
-        })
+        });
     }
 
     findReadUrl(dom) {

--- a/plugin/js/parsers/SyosetuParser.js
+++ b/plugin/js/parsers/SyosetuParser.js
@@ -3,7 +3,7 @@
 parserFactory.register("ncode.syosetu.com", () => new SyosetuParser());
 parserFactory.register("novel18.syosetu.com", () => new SyosetuParser());
 
-class SyosetuParser extends Parser{
+class SyosetuParser extends Parser {
     constructor() {
         super();
         this.infoPageDom = null;
@@ -37,11 +37,11 @@ class SyosetuParser extends Parser{
 
     findContent(dom) {
         return dom.querySelector("div.p-novel__body");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector(".p-novel__title");
-    };
+    }
 
     extractAuthor(dom) {
         const authorDiv = dom.querySelector("div.p-novel__author");

--- a/plugin/js/parsers/SystemTranslationParser.js
+++ b/plugin/js/parsers/SystemTranslationParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("systemtranslation.com", () => new SystemTranslationParser());
 
-class SystemTranslationParser extends WordpressBaseParser{
+class SystemTranslationParser extends WordpressBaseParser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/Taffygirl13Parser.js
+++ b/plugin/js/parsers/Taffygirl13Parser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("taffygirl13.wordpress.com", () => new Taffygirl13Parser());
 
-class Taffygirl13Parser extends WordpressBaseParser{
+class Taffygirl13Parser extends WordpressBaseParser {
     constructor() {
         super();
     }
@@ -17,9 +17,9 @@ class Taffygirl13Parser extends WordpressBaseParser{
         }
 
         let chapters = [];
-        for(let table of tables) {
+        for (let table of tables) {
             let rhs = [];
-            for(let row of table) {
+            for (let row of table) {
                 chapters.push(row[0]);
                 if (row.length == 2) {
                     rhs.push(row[1]);

--- a/plugin/js/parsers/TapreadParser.js
+++ b/plugin/js/parsers/TapreadParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("tapread.com", () => new TapreadParser());
 
-class TapreadParser extends Parser{
+class TapreadParser extends Parser {
     constructor() {
         super();
     }
@@ -14,7 +14,7 @@ class TapreadParser extends Parser{
             chapters = this.fetchToc(dom.baseURI);
         }
         return chapters;
-    };
+    }
 
     static linkToChapter(link) {
         let title = link.querySelector("p");
@@ -42,16 +42,16 @@ class TapreadParser extends Parser{
 
     findContent(dom) {
         return Parser.findConstrutedContent(dom);
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.book-name");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("div.author > span.name");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 
     findCoverImageUrl(dom) {
         return util.getFirstImgSrc(dom, "div.book-img");

--- a/plugin/js/parsers/TeanovelParser.js
+++ b/plugin/js/parsers/TeanovelParser.js
@@ -4,7 +4,7 @@ parserFactory.register("teanovel.com", () => new TeanovelParser());
 //dead url
 parserFactory.register("teanovel.net", () => new TeanovelParser());
 
-class TeanovelParser extends Parser{
+class TeanovelParser extends Parser {
     constructor() {
         super();
     }
@@ -30,7 +30,7 @@ class TeanovelParser extends Parser{
     }
 
     extractTitleImpl(dom) {
-        return dom.querySelector("h1");;
+        return dom.querySelector("h1");
     }
 
     removeUnwantedElementsFromContentElement(element) {

--- a/plugin/js/parsers/TeenficParser.js
+++ b/plugin/js/parsers/TeenficParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("teenfic.net", () => new TeenficParser());
 
-class TeenficParser extends Parser{
+class TeenficParser extends Parser {
     constructor() {
         super();
     }
@@ -51,7 +51,7 @@ class TeenficParser extends Parser{
         let urls = [];
         let links = [...dom.querySelectorAll("ul.page li:not(.active) a")]
             .map(link => link.href);
-        for(let link of links) {
+        for (let link of links) {
             if (!seen.has(link)) {
                 urls.push(link);
                 seen.add(link);

--- a/plugin/js/parsers/Template.js
+++ b/plugin/js/parsers/Template.js
@@ -25,7 +25,7 @@ parserFactory.registerRule(
 );
 */
 
-class TemplateParser extends Parser{
+class TemplateParser extends Parser {
     constructor() {
         super();
         //Optional Parameters:

--- a/plugin/js/parsers/TigertranslationsParser.js
+++ b/plugin/js/parsers/TigertranslationsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("tigertranslations.org", () => new TigertranslationsParser());
 
-class TigertranslationsParser extends Parser{
+class TigertranslationsParser extends Parser {
     constructor() {
         super();
     }
@@ -68,7 +68,7 @@ class TigertranslationsParser extends Parser{
     }    
 
     isTigerTranslationsHost(link) {
-        return new URL(link.href).host === "tigertranslations.org"        
+        return new URL(link.href).host === "tigertranslations.org";        
     }
 
     cleanInitialDom(element) {

--- a/plugin/js/parsers/TimotxtParser.js
+++ b/plugin/js/parsers/TimotxtParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("timotxt.com", () => new TimotxtParser());
 
-class TimotxtParser extends Parser{
+class TimotxtParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/TitannovelParser.js
+++ b/plugin/js/parsers/TitannovelParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("titannovel.net", () => new TitannovelParser());
 
-class TitannovelParser extends Parser{
+class TitannovelParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/ToctruyenParser.js
+++ b/plugin/js/parsers/ToctruyenParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("toctruyen.net", () => new ToctruyenParser());
 
-class ToctruyenParser extends Parser{
+class ToctruyenParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/TomotranslationsParser.js
+++ b/plugin/js/parsers/TomotranslationsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("tomotranslations.com", () => new TomotranslationsParser());
 
-class TomotranslationsParser extends Parser{
+class TomotranslationsParser extends Parser {
     constructor() {
         super();
     }
@@ -10,15 +10,15 @@ class TomotranslationsParser extends Parser{
     getChapterUrls(dom) {
         let menu = dom.querySelector("section.entry");
         return Promise.resolve(util.hyperlinksToChapterList(menu));
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("section.entry");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("h1.title");
-    };
+    }
 
     removeUnwantedElementsFromContentElement(element) {
         util.removeChildElementsMatchingSelector(element, "div.taxonomies");

--- a/plugin/js/parsers/TranslationChickenParser.js
+++ b/plugin/js/parsers/TranslationChickenParser.js
@@ -1,8 +1,8 @@
 "use strict";
 
-parserFactory.register("translationchicken.com", function() { return new TranslationChickenParser() });
+parserFactory.register("translationchicken.com", function() { return new TranslationChickenParser(); });
 
-class TranslationChickenParser extends WordpressBaseParser{
+class TranslationChickenParser extends WordpressBaseParser {
     constructor() {
         super();
     }
@@ -16,5 +16,5 @@ class TranslationChickenParser extends WordpressBaseParser{
             content.insertBefore(feature, content.children[0]);
         }
         return content;
-    };
+    }
 }

--- a/plugin/js/parsers/TravistranslationsParser.js
+++ b/plugin/js/parsers/TravistranslationsParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("travistranslations.com", () => new TravistranslationsParser());
 
-class TravistranslationsParser extends Parser{
+class TravistranslationsParser extends Parser {
     constructor() {
         super();
     }
@@ -42,7 +42,7 @@ class TravistranslationsParser extends Parser{
 
     addAuthorNotes(webPageDom) {
         let content = this.findContent(webPageDom); 
-        for(let n of [...content.parentElement.querySelectorAll("div.py-1")]) {
+        for (let n of [...content.parentElement.querySelectorAll("div.py-1")]) {
             content.append(n);
         }
     }

--- a/plugin/js/parsers/TruyenParser.js
+++ b/plugin/js/parsers/TruyenParser.js
@@ -8,8 +8,8 @@ class TruyenParser extends Parser {
     }
 
     async getChapterUrls(dom) {
-        const chapterLinks = [...dom.querySelectorAll("#clwd ul a")]
-        const chapterTitles = [...dom.querySelectorAll("#clwd span.block")]
+        const chapterLinks = [...dom.querySelectorAll("#clwd ul a")];
+        const chapterTitles = [...dom.querySelectorAll("#clwd span.block")];
         const chapterUrls = [];
         for (let i = 0; i < chapterLinks.length; i++) {
             const chapterLink = chapterLinks[i];
@@ -18,7 +18,7 @@ class TruyenParser extends Parser {
                 sourceUrl: chapterLink.href,
                 title: chapterTitle.textContent,
             });
-        };
+        }
         return chapterUrls.reverse();
     }
 

--- a/plugin/js/parsers/TruyenfullParser.js
+++ b/plugin/js/parsers/TruyenfullParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("truyenfull.vn", () => new TruyenfullParser());
 
-class TruyenfullParser extends Parser{
+class TruyenfullParser extends Parser {
     constructor() {
         super();
     }
@@ -13,14 +13,14 @@ class TruyenfullParser extends Parser{
             TruyenfullParser.getUrlsOfTocPages,
             chapterUrlsUI
         );
-    };
+    }
 
     static getUrlsOfTocPages(dom) {
         let urls = [];
         let input = dom.querySelector("input#total-page");
         if (input != null) {
             let totalp = parseInt(input.getAttribute("value"));
-            for(let i = 2; i <= totalp; ++i ) {
+            for (let i = 2; i <= totalp; ++i ) {
                 urls.push(`${dom.baseURI}trang-${i}/`);
             }
         }
@@ -34,19 +34,19 @@ class TruyenfullParser extends Parser{
 
     findContent(dom) {
         return dom.querySelector("div.chapter-c");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("h3.title");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("a[itemprop='author']");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 
     findChapterTitle(dom) {
-        let title = dom.querySelector("a.chapter-title")
+        let title = dom.querySelector("a.chapter-title");
         return (title === null) ? super.findChapterTitle(dom) : title.textContent;
     }
 

--- a/plugin/js/parsers/TruyenyyParser.js
+++ b/plugin/js/parsers/TruyenyyParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("truyenyy.com", () => new TruyenyyParser());
 
-class TruyenyyParser extends Parser{
+class TruyenyyParser extends Parser {
     constructor() {
         super();
     }
@@ -13,12 +13,12 @@ class TruyenyyParser extends Parser{
             TruyenyyParser.getUrlsOfTocPages,
             chapterUrlsUI
         );
-    };
+    }
 
     static extractPartialChapterList(dom) {
         let previousText = "";
         let mergedlinks = [];
-        for(let l of dom.querySelectorAll("table.table a")) {
+        for (let l of dom.querySelectorAll("table.table a")) {
             if (l.className === "table-chap-title") {
                 l.textContent = previousText + ": " + l.textContent.trim();
                 mergedlinks.push(l);
@@ -34,13 +34,13 @@ class TruyenyyParser extends Parser{
         if (pagination != null ) {
             let tocLinks = [...dom.querySelectorAll("a.page-link")]
                 .map(a => a.href)
-                .filter(href => href.includes("?p="))
+                .filter(href => href.includes("?p="));
             let maxPage = tocLinks
                 .map(href => parseInt(href.split("?p=")[1]))
                 .reduce((p, c) => Math.max(p, c), -1);
             if (1 < maxPage) {
                 let base = tocLinks[0].split("?p=")[0];
-                for(let i = 2; i <= maxPage; ++i) {
+                for (let i = 2; i <= maxPage; ++i) {
                     tocUrls.push(`${base}?p=${i}`);
                 }
             }
@@ -50,16 +50,16 @@ class TruyenyyParser extends Parser{
 
     findContent(dom) {
         return dom.querySelector("div#id_chap_content div.inner");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.novel-info .name");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("div.novel-info .author a");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 
     findChapterTitle(dom) {
         return dom.querySelector("div#id_chap_content .chapter-title");

--- a/plugin/js/parsers/TrxsParser.js
+++ b/plugin/js/parsers/TrxsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("trxs.me", () => new TrxsParser());
 
-class TrxsParser extends Parser{
+class TrxsParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/TumblrParser.js
+++ b/plugin/js/parsers/TumblrParser.js
@@ -5,7 +5,7 @@ parserFactory.registerUrlRule(
     () => new TumblrParser()
 );
 
-class TumblrParser extends Parser{
+class TumblrParser extends Parser {
     constructor() {
         super();
     }
@@ -21,7 +21,7 @@ class TumblrParser extends Parser{
             dom.querySelector("main div.post-main") ||
             dom.querySelector("article div.post-content");
         //fix embeded image links
-        for(let e of content.querySelectorAll("a[data-big-photo]")) {
+        for (let e of content.querySelectorAll("a[data-big-photo]")) {
             e.href = e.dataset?.bigPhoto;
         }
         return content;

--- a/plugin/js/parsers/UltimaguilParser.js
+++ b/plugin/js/parsers/UltimaguilParser.js
@@ -4,7 +4,7 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("ultimaguil.org", function() { return new UltimaguilParser(new VariableSizeImageCollector()) });
+parserFactory.register("ultimaguil.org", function() { return new UltimaguilParser(new VariableSizeImageCollector()); });
 
 class UltimaguilParser extends Parser {
     constructor(imageCollector) {
@@ -51,13 +51,13 @@ class UltimaguilParser extends Parser {
 
     convertMidpartToHeaders(content) {
         let doc = content.ownerDocument;
-        for(let midpart of content.querySelectorAll("div.part.midpart.gear")) {
+        for (let midpart of content.querySelectorAll("div.part.midpart.gear")) {
             let parent = midpart.parentElement;
             let h3 = doc.createElement("h2");
             let link = midpart.querySelector("a");
             h3.appendChild(doc.createTextNode(link.getAttribute("title")));
             parent.replaceWith(h3);
-        };
+        }
     }
 
     customRawDomToContentStep(chapter, content) {
@@ -76,21 +76,21 @@ class UltimaguilParser extends Parser {
                 let node = read_content.childNodes[0];
                 if (node.tagName.toLowerCase() === "div") {
                     let div = node;
-                    while(div.hasChildNodes()) {
+                    while (div.hasChildNodes()) {
                         parent.insertBefore(div.childNodes[0], read_content);
-                    };
+                    }
                     div.remove();
                 } else {
                     parent.insertBefore(node, read_content);
-                };
-            };
-        };
+                }
+            }
+        }
     }
 
     removeLinkFromHeaders(content) {
         let document = content.ownerDocument;
-        for(let link of content.querySelectorAll("h2 a")) {
+        for (let link of content.querySelectorAll("h2 a")) {
             link.replaceWith(document.createTextNode(link.textContent));
-        };
+        }
     }
 }

--- a/plugin/js/parsers/UnlimitedNovelFailuresParser.js
+++ b/plugin/js/parsers/UnlimitedNovelFailuresParser.js
@@ -5,7 +5,7 @@
 
 //dead url/ parser
 parserFactory.register("unlimitednovelfailures.mangamatters.com", 
-    function() { return new UnlimitedNovelFailuresParser() }
+    function() { return new UnlimitedNovelFailuresParser(); }
 );
 
 class UnlimitedNovelFailuresParser extends Parser {
@@ -49,7 +49,7 @@ class UnlimitedNovelFailuresParser extends Parser {
 
     convertAnchorsToHeaders(content) {
         let document = content.ownerDocument;
-        for(let link of content.querySelectorAll("a[id]")) {
+        for (let link of content.querySelectorAll("a[id]")) {
             let h2 = document.createElement("h2");
             h2.id = link.id;
             h2.appendChild(document.createTextNode(link.textContent));
@@ -60,6 +60,6 @@ class UnlimitedNovelFailuresParser extends Parser {
             } else {
                 link.replaceWith(h2);
             }
-        };
+        }
     }
 }

--- a/plugin/js/parsers/UntamedAlleyParser.js
+++ b/plugin/js/parsers/UntamedAlleyParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("untamedalley.com", () => new UntamedAlleyParser());
 
-class UntamedAlleyParser extends Parser{
+class UntamedAlleyParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/VelvetReverieParser.js
+++ b/plugin/js/parsers/VelvetReverieParser.js
@@ -1,8 +1,8 @@
 "use strict";
 
-parserFactory.register("velvet-reverie.org", function() { return new VelvetReverieParser() });
+parserFactory.register("velvet-reverie.org", function() { return new VelvetReverieParser(); });
 
-class VelvetReverieParser extends Parser{
+class VelvetReverieParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/VipNovelParser.js
+++ b/plugin/js/parsers/VipNovelParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("vipnovel.com", () => new VipNovelParser());
 
-class VipNovelParser extends Parser{
+class VipNovelParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/VolarenovelsParser.js
+++ b/plugin/js/parsers/VolarenovelsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("volarenovels.com", () => new VolarenovelsParser());
 
-class VolarenovelsParser extends Parser{
+class VolarenovelsParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/VynovelParser.js
+++ b/plugin/js/parsers/VynovelParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("vynovel.com", () => new VynovelParser());
 
-class VynovelParser extends Parser{
+class VynovelParser extends Parser {
     constructor() {
         super();
     }
@@ -13,7 +13,7 @@ class VynovelParser extends Parser{
         return this.chaptersFromList(links).reverse();
     }
 
-    chaptersFromList(list){
+    chaptersFromList(list) {
         return list.map(a => ({
             sourceUrl: a.href, 
             title: a.querySelector("span").innerText.trim()

--- a/plugin/js/parsers/WLPublishingParser.js
+++ b/plugin/js/parsers/WLPublishingParser.js
@@ -10,10 +10,10 @@ parserFactory.register("storiesonline.net", () => new WLPublishingParser());
 
 parserFactory.registerManualSelect(
     "WLPublishing",
-    function() { return new WLPublishingParser() }
+    function() { return new WLPublishingParser(); }
 );
 
-class WLPublishingParser extends Parser{
+class WLPublishingParser extends Parser {
     constructor() {
         super();
     }
@@ -24,21 +24,21 @@ class WLPublishingParser extends Parser{
             let baseUrl = this.getBaseUrl(dom);
             return this.singleChapterStory(baseUrl, dom);
         }
-        for(let link of index.querySelectorAll("a")) {
+        for (let link of index.querySelectorAll("a")) {
             if (link.hasAttribute("title") && (link.getAttribute("title") === "download")) {
                 link.remove();
             }
         }
         return util.hyperlinksToChapterList(index);
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("article");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("h1");
-    };
+    }
 
     extractAuthor(dom) {
         let title = dom.querySelector("title").textContent;
@@ -46,7 +46,7 @@ class WLPublishingParser extends Parser{
             return title.substring(0, title.indexOf(":"));
         }
         return super.extractAuthor(dom);
-    };
+    }
 
     removeUnwantedElementsFromContentElement(element) {
         util.removeChildElementsMatchingSelector(element, "div.date");
@@ -89,7 +89,7 @@ class WLPublishingParser extends Parser{
         let urls = [];
         let pager = dom.querySelector("div.pager");
         if (pager) {
-            for(let link of pager.querySelectorAll("a")) {
+            for (let link of pager.querySelectorAll("a")) {
                 if (link.textContent != "Next") {
                     urls.push(link.href);
                 }
@@ -105,7 +105,7 @@ class WLPublishingParser extends Parser{
             let child = pageContent.childNodes[0];
             // The chapter title appears on each page in the chapter and we only want it from the first.
             if ((child.tagName == "H1") || (child.tagName == "H2")) {
-                child.remove()
+                child.remove();
             } else {
                 chapterContent.appendChild(child);
             }

--- a/plugin/js/parsers/WanderinginnParser.js
+++ b/plugin/js/parsers/WanderinginnParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("wanderinginn.com", () => new WanderinginnParser());
 
-class WanderinginnParser extends WordpressBaseParser{
+class WanderinginnParser extends WordpressBaseParser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/WatashiwasugoidesuParser.js
+++ b/plugin/js/parsers/WatashiwasugoidesuParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("watashiwasugoidesu.com", () => new WatashiwasugoidesuParser());
 
-class WatashiwasugoidesuParser extends Parser{
+class WatashiwasugoidesuParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/WattpadParser.js
+++ b/plugin/js/parsers/WattpadParser.js
@@ -1,6 +1,6 @@
 "use strict";
 
-parserFactory.register("wattpad.com", function() { return new WattpadParser() });
+parserFactory.register("wattpad.com", function() { return new WattpadParser(); });
 
 class WattpadImageCollector extends ImageCollector {
     constructor() {
@@ -22,7 +22,7 @@ class WattpadImageCollector extends ImageCollector {
     }
 }
 
-class WattpadParser extends Parser{
+class WattpadParser extends Parser {
     constructor() {
         super(new WattpadImageCollector());
     }
@@ -33,13 +33,13 @@ class WattpadParser extends Parser{
             return this.fetchChapterList(dom);
         }
         return util.hyperlinksToChapterList(menu);
-    };
+    }
 
     async fetchChapterList(dom) {
         let storyId = WattpadParser.extractIdFromUrl(dom.baseURI);
         let chaptersUrl = `https://www.wattpad.com/api/v3/stories/${storyId}`;
         let json = (await HttpClient.fetchJson(chaptersUrl)).json;
-        return json.parts.map(p => ({sourceUrl: p.url, title: p.title}))
+        return json.parts.map(p => ({sourceUrl: p.url, title: p.title}));
     }
 
     static extractIdFromUrl(url) {
@@ -69,7 +69,7 @@ class WattpadParser extends Parser{
 
     findJsonWithRestOfChapterUriInfo(dom) {
         let searchString = ".metadata\":{\"data\":";
-        for(let s of [...dom.querySelectorAll("script")]) {
+        for (let s of [...dom.querySelectorAll("script")]) {
             let source = s.innerHTML;
             let index = source.indexOf(searchString);
             if (0 <= index) {
@@ -86,7 +86,7 @@ class WattpadParser extends Parser{
 
     async fetchExtraChapterContent(extraUris) {
         let extraContent = [];
-        for(let page = 2; page <= extraUris.pages; ++page) {
+        for (let page = 2; page <= extraUris.pages; ++page) {
             let text = (await this.fetchPage(extraUris, page));
             extraContent.push(text);
         }
@@ -125,7 +125,7 @@ class WattpadParser extends Parser{
 
     static removeDuplicateParagraphs(dom) {
         let s = new Set();
-        for(let p of [...dom.querySelectorAll("p[data-p-id]")]) {
+        for (let p of [...dom.querySelectorAll("p[data-p-id]")]) {
             let id = p.getAttribute("data-p-id");
             if (s.has(id)) {
                 p.remove();
@@ -143,12 +143,12 @@ class WattpadParser extends Parser{
 
     findContent(dom) {
         return dom.querySelector("div[data-page-number]");
-    };
+    }
 
     // title of the story  (not to be confused with title of each chapter)
     extractTitleImpl(dom) {
         return dom.querySelector("div.story-info span.sr-only");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("div.af6dp a");
@@ -168,7 +168,7 @@ class WattpadParser extends Parser{
     removeUnwantedElementsFromContentElement(element) {
         let keep = [...element.querySelectorAll("p")];
         util.removeElements([...element.children]);
-        for(let e of keep) {
+        for (let e of keep) {
             element.appendChild(e);
         }
         super.removeUnwantedElementsFromContentElement(element);

--- a/plugin/js/parsers/WebNovelOnlineParser.js
+++ b/plugin/js/parsers/WebNovelOnlineParser.js
@@ -3,29 +3,29 @@
 //dead url/ parser
 parserFactory.register("webnovelonline.com", () => new WebNovelOnlineParser());
 
-class WebNovelOnlineParser extends Parser{
+class WebNovelOnlineParser extends Parser {
     constructor() {
         super();
     }
 
     getChapterUrls(dom) {
         let chapters = [...dom.querySelectorAll("div.chapter-list a")]
-            .map(a => util.hyperLinkToChapter(a))
+            .map(a => util.hyperLinkToChapter(a));
         return Promise.resolve(chapters.reverse());
-    };
+    }
 
     findContent(dom) {
         return Parser.findConstrutedContent(dom);
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.novel-dexc h1");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("div.novel-desc > div.info > p:nth-child(1) > span:nth-child(2)");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 
     findCoverImageUrl(dom) {
         return util.getFirstImgSrc(dom, "div.book");
@@ -54,7 +54,7 @@ class WebNovelOnlineParser extends Parser{
             .filter(p => (p !== null) && (0 < p.length));
         for (let text of paragraphs) {
             let p = newDoc.dom.createElement("p");
-            p.appendChild(newDoc.dom.createTextNode(text))
+            p.appendChild(newDoc.dom.createTextNode(text));
             newDoc.content.appendChild(p);
         }
     }

--- a/plugin/js/parsers/Wenku8Parser.js
+++ b/plugin/js/parsers/Wenku8Parser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("wenku8.net", () => new Wenku8Parser());
 
-class Wenku8Parser extends Parser{
+class Wenku8Parser extends Parser {
     constructor() {
         super();
     }
@@ -10,7 +10,7 @@ class Wenku8Parser extends Parser{
     getChapterUrls(dom) {
         let id = Wenku8Parser.extractBookId(dom);
         let tocUrl = ` https://www.wenku8.net/modules/article/reader.php?aid=${id}`;
-        return HttpClient.wrapFetch(tocUrl, this.makeOptions()).then(function (xhr) {
+        return HttpClient.wrapFetch(tocUrl, this.makeOptions()).then(function(xhr) {
             let menu = xhr.responseXML.querySelector("table");
             return Promise.resolve(util.hyperlinksToChapterList(menu));
         });
@@ -44,7 +44,7 @@ class Wenku8Parser extends Parser{
 
     fetchChapter(url) {
         // site does not tell us GBK is used to encode text
-        return HttpClient.wrapFetch(url, this.makeOptions()).then(function (xhr) {
+        return HttpClient.wrapFetch(url, this.makeOptions()).then(function(xhr) {
             return Promise.resolve(xhr.responseXML);
         });
     }

--- a/plugin/js/parsers/WetriedTlsParser.js
+++ b/plugin/js/parsers/WetriedTlsParser.js
@@ -91,7 +91,7 @@ class WetriedTlsParser extends Parser {
 
     buildChapter(rawHtml, url) {
         let newDoc = Parser.makeEmptyDocForContent(url);
-        let content = util.sanitize(rawHtml)
+        let content = util.sanitize(rawHtml);
         util.moveChildElements(content.body, newDoc.content);
         return newDoc.dom;
     }

--- a/plugin/js/parsers/WfxsParser.js
+++ b/plugin/js/parsers/WfxsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("wfxs.tw", () => new WfxsParser());
 
-class WfxsParser extends Parser{
+class WfxsParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/WikipediaParser.js
+++ b/plugin/js/parsers/WikipediaParser.js
@@ -10,10 +10,10 @@ parserFactory.registerUrlRule(
 
 parserFactory.registerManualSelect(
     "Wikipedia", 
-    function() { return new WikipediaParser() }
+    function() { return new WikipediaParser(); }
 );
 
-class WikipediaParser extends Parser{
+class WikipediaParser extends Parser {
     constructor() {
         super();
     }
@@ -25,12 +25,12 @@ class WikipediaParser extends Parser{
             title: dom.title
         };
         return Promise.resolve([chapter]);
-    };
+    }
 
     // returns the element holding the story content in a chapter
     findContent(dom) {
         return dom.getElementById("bodyContent");
-    };
+    }
 
     removeUnwantedElementsFromContentElement(element) {
         super.removeUnwantedElementsFromContentElement(element);
@@ -48,14 +48,14 @@ class WikipediaParser extends Parser{
     }
 
     removeExternalHyperlinks(element) {
-        for(let a of util.getElements(element, "a", e => !this.isLinkToKeep(e))) {
+        for (let a of util.getElements(element, "a", e => !this.isLinkToKeep(e))) {
             this.replaceHyperlinkWithTextContent(a);
         }
     }
     
     isLinkToKeep(hyperlink) {
         return !util.isNullOrEmpty(hyperlink.hash) ||
-            (hyperlink.querySelector("img, image") !== null)
+            (hyperlink.querySelector("img, image") !== null);
     }
 
     replaceHyperlinkWithTextContent(hyperlink) {

--- a/plugin/js/parsers/WixParser.js
+++ b/plugin/js/parsers/WixParser.js
@@ -11,7 +11,7 @@ parserFactory.registerUrlRule(
     () => new WixParser()
 );
 
-class WixParser extends Parser{
+class WixParser extends Parser {
     constructor() {
         super();
     }
@@ -21,7 +21,7 @@ class WixParser extends Parser{
         let chapters = util.hyperlinksToChapterList(dom.body);
         this.mapPageUrlToPageTitle = this.buildMapOfPageUrlsToPageTitles(chapters);
         return Promise.resolve(chapters);
-    };
+    }
 
     buildMapOfPageUrltoRestUrlWithContent(dom) {
         let json = this.findJsonWithRestUrls(dom);
@@ -29,13 +29,13 @@ class WixParser extends Parser{
     }
 
     findJsonWithRestUrls(dom) {
-        for(let script of dom.querySelectorAll("script")) {
+        for (let script of dom.querySelectorAll("script")) {
             let text = script.textContent;
             let json = util.locateAndExtractJson(text, "var publicModel =");
             if (json != null) {
                 return json;
             }
-        };
+        }
     }    
 
     extractRestUrlsFromJson(json) {
@@ -58,12 +58,12 @@ class WixParser extends Parser{
 
     findContent(dom) {
         return dom.querySelector("div");
-    };
+    }
 
     fetchChapter(url) {
         let that = this;
         let restUrl = this.mapPageUrltoRestUrl.get(url);
-        return HttpClient.fetchJson(restUrl).then(function (handler) {
+        return HttpClient.fetchJson(restUrl).then(function(handler) {
             let content = that.findContentInJson(handler.json);
             return Promise.resolve(that.constructDoc(content, url));
         });

--- a/plugin/js/parsers/WnmtlOrgParser.js
+++ b/plugin/js/parsers/WnmtlOrgParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("wnmtl.org", () => new WnmtlOrgParser());
 
-class WnmtlOrgParser extends Parser{
+class WnmtlOrgParser extends Parser {
     constructor() {
         super();
     }
@@ -13,7 +13,7 @@ class WnmtlOrgParser extends Parser{
         let tocUrl = this.makeTocUrl(bookId, 1);
         let data = (await HttpClient.fetchJson(tocUrl)).json.data;
         let chapters = this.extractPartialChapterListFromJson(data);
-        for(let url of this.makeUrlsOfTocPages(bookId, data.totalPages)) {
+        for (let url of this.makeUrlsOfTocPages(bookId, data.totalPages)) {
             data = (await HttpClient.fetchJson(url)).json.data;
             let partialList = this.extractPartialChapterListFromJson(data);
             chapterUrlsUI.showTocProgress(partialList);
@@ -33,7 +33,7 @@ class WnmtlOrgParser extends Parser{
 
     makeUrlsOfTocPages(bookId, totalPages) {
         let urls = [];
-        for(let page = 2; page <= totalPages; ++page) {
+        for (let page = 2; page <= totalPages; ++page) {
             urls.push(this.makeTocUrl(bookId, page));
         }
         return urls;
@@ -85,7 +85,7 @@ class WnmtlOrgParser extends Parser{
             .filter(p => !util.isNullOrEmpty(p));
         for (let text of paragraphs) {
             let p = newDoc.dom.createElement("p");
-            p.appendChild(newDoc.dom.createTextNode(text))
+            p.appendChild(newDoc.dom.createTextNode(text));
             newDoc.content.appendChild(p);
         }
         return newDoc.dom;

--- a/plugin/js/parsers/WnmtlParser.js
+++ b/plugin/js/parsers/WnmtlParser.js
@@ -1,8 +1,8 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("wnmtl.com", function() { return new WnmtlParser() });
-class WnmtlParser extends Parser{
+parserFactory.register("wnmtl.com", function() { return new WnmtlParser(); });
+class WnmtlParser extends Parser {
     constructor() {
         super();
     }
@@ -12,17 +12,17 @@ class WnmtlParser extends Parser{
             .filter(link => link.parentElement.parentElement.className !== "text-mutedxxx")
             .map(link => util.hyperLinkToChapter(link));
         return Promise.resolve(items);
-    };
+    }
 
     findContent(dom) {
         util.removeElements(dom.querySelectorAll("div#ct div.article-social"));
         return dom.querySelector("div#ct");
-    };
+    }
 
     // title of the story  (not to be confused with title of each chapter)
     extractTitleImpl(dom) {
         return dom.querySelector("article header h2, article header h1");
-    };
+    }
 
     findChapterTitle(dom) {
         return dom.querySelector("h1.article-title");

--- a/plugin/js/parsers/WoopreadParser.js
+++ b/plugin/js/parsers/WoopreadParser.js
@@ -2,27 +2,27 @@
 
 parserFactory.register("woopread.com", () => new WoopreadParser());
 
-class WoopreadParser extends Parser{
+class WoopreadParser extends Parser {
     constructor() {
         super();
     }
 
     extractTitleImpl(dom) {
         return dom.querySelector("h1.text-3xl");
-    };
+    }
 
     getInformationEpubItemChildNodes(dom) {
         return [...dom.querySelectorAll("div.relative .text-text-secondary")];
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("div.mb-4:nth-of-type(4) a");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 
     findCoverImageUrl(dom) {
         return util.getFirstImgSrc(dom, "div.relative");
-    };
+    }
 
     async getChapterUrls(dom) {
         const chapterLinks = [...dom.querySelectorAll("main.grow .notranslate .mt-8 .grid-cols-1 a")];
@@ -34,16 +34,16 @@ class WoopreadParser extends Parser{
                 sourceUrl: chapterLinks[i].href,
                 title: chapterTitles[i].textContent,
             });
-        };
+        }
 
         return chapterList.reverse();
     }
     
     findChapterTitle(dom) {
         return dom.querySelector("h2.text-2xl");
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div[id^='chapter']");
-    };
+    }
 }

--- a/plugin/js/parsers/WordexcerptParser.js
+++ b/plugin/js/parsers/WordexcerptParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("wordexcerpt.com", () => new WordexcerptParser());
 
-class WordexcerptParser extends Parser{
+class WordexcerptParser extends Parser {
     constructor() {
         super();
     }
@@ -10,27 +10,27 @@ class WordexcerptParser extends Parser{
     getChapterUrls(dom) {
         let menu = dom.querySelector("div.listing-chapters_wrap");
         return Promise.resolve(util.hyperlinksToChapterList(menu).reverse());
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div.reading-content div.text-left");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.post-title h1");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("div.author-content a");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 
     removeUnwantedElementsFromContentElement(element) {
         let ads = [...element.querySelectorAll("div.adsbyvli")]
             .map(e => e.parentElement)
             .filter(p => p.tagName.toUpperCase() === "CENTER");
         util.removeElements(ads);
-        for(let node of util.getElements(element, "B:IF")) {
+        for (let node of util.getElements(element, "B:IF")) {
             util.flattenNode(node);
         }
         super.removeUnwantedElementsFromContentElement(element);

--- a/plugin/js/parsers/WordpressBaseParser.js
+++ b/plugin/js/parsers/WordpressBaseParser.js
@@ -3,22 +3,22 @@
 */
 "use strict";
 
-parserFactory.register("bakapervert.wordpress.com", function() { return new WordpressBaseParser() });
-parserFactory.register("crimsonmagic.me", function() { return new WordpressBaseParser() });
-parserFactory.register("shalvationtranslations.wordpress.com", function() { return new WordpressBaseParser() });
-parserFactory.register("frostfire10.wordpress.com", function() { return new WordpressBaseParser() });
-parserFactory.register("isekaicyborg.wordpress.com", function() { return new WordpressBaseParser() });
-parserFactory.register("moonbunnycafe.com", function() { return new WordpressBaseParser() });
+parserFactory.register("bakapervert.wordpress.com", function() { return new WordpressBaseParser(); });
+parserFactory.register("crimsonmagic.me", function() { return new WordpressBaseParser(); });
+parserFactory.register("shalvationtranslations.wordpress.com", function() { return new WordpressBaseParser(); });
+parserFactory.register("frostfire10.wordpress.com", function() { return new WordpressBaseParser(); });
+parserFactory.register("isekaicyborg.wordpress.com", function() { return new WordpressBaseParser(); });
+parserFactory.register("moonbunnycafe.com", function() { return new WordpressBaseParser(); });
 //dead url
-parserFactory.register("rainingtl.org", function() { return new WordpressBaseParser() });
+parserFactory.register("rainingtl.org", function() { return new WordpressBaseParser(); });
 //dead url
-parserFactory.register("raisingthedead.ninja", function() { return new WordpressBaseParser() });
+parserFactory.register("raisingthedead.ninja", function() { return new WordpressBaseParser(); });
 //dead url
-parserFactory.register("skythewoodtl.com", function() { return new WordpressBaseParser() });
+parserFactory.register("skythewoodtl.com", function() { return new WordpressBaseParser(); });
 //dead url
-parserFactory.register("yoraikun.wordpress.com", function() { return new WordpressBaseParser() });
-parserFactory.register("wanderertl130.id", function() { return new Wanderertl130Parser() });
-parserFactory.register("sasakitomyiano.wordpress.com", function() { return new WordpressBaseParser() });
+parserFactory.register("yoraikun.wordpress.com", function() { return new WordpressBaseParser(); });
+parserFactory.register("wanderertl130.id", function() { return new Wanderertl130Parser(); });
+parserFactory.register("sasakitomyiano.wordpress.com", function() { return new WordpressBaseParser(); });
 
 parserFactory.registerRule(
     // return probability (0.0 to 1.0) web page is a Wordpress page
@@ -31,7 +31,7 @@ parserFactory.registerRule(
 
 parserFactory.registerManualSelect(
     "Wordpress",
-    function() { return new WordpressBaseParser() }
+    function() { return new WordpressBaseParser(); }
 );
 
 class WordpressBaseParser extends Parser {

--- a/plugin/js/parsers/WorldnovelOnlineParser.js
+++ b/plugin/js/parsers/WorldnovelOnlineParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("worldnovel.online", () => new WorldnovelOnlineParser());
 
-class WorldnovelOnlineParser extends Parser{
+class WorldnovelOnlineParser extends Parser {
     constructor() {
         super();
     }
@@ -11,7 +11,7 @@ class WorldnovelOnlineParser extends Parser{
         let chapters = [];
         let category = dom.body.getAttribute("attr");
         let numTocPages = [...dom.querySelectorAll("div[data-paged]")].length;
-        for(let page = 1; page <= numTocPages; ++page) {
+        for (let page = 1; page <= numTocPages; ++page) {
             let url = "https://www.worldnovel.online/wp-json/novel-id/v1/dapatkan_chapter_dengan_novel?category=" + 
                 category + "&perpage=100&order=ASC&paged=" + page;
             let partialList = (await HttpClient.fetchJson(url)).json

--- a/plugin/js/parsers/WtrlabParser.js
+++ b/plugin/js/parsers/WtrlabParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("wtr-lab.com", () => new WtrlabParser());
 
-class WtrlabParser extends Parser{
+class WtrlabParser extends Parser {
     constructor() {
         super();
         this.minimumThrottle = 12000;
@@ -86,7 +86,7 @@ class WtrlabParser extends Parser{
                 "retry":false,
                 "force_retry":false
             };
-        let header = {"Content-Type": "application/json;charset=UTF-8"}
+        let header = {"Content-Type": "application/json;charset=UTF-8"};
         let options = {
             method: "POST",
             body: JSON.stringify(formData),
@@ -97,7 +97,7 @@ class WtrlabParser extends Parser{
         return this.buildChapter(json, url);
     }
     
-    isCustomError(response){
+    isCustomError(response) {
         if (response.json.data?.data?.body?false:true) {
             return true;
         }
@@ -107,7 +107,7 @@ class WtrlabParser extends Parser{
         return false;
     }
 
-    setCustomErrorResponse(url, wrapOptions, checkedresponse){
+    setCustomErrorResponse(url, wrapOptions, checkedresponse) {
         if (checkedresponse.json.requireTurnstile || checkedresponse.json.code == 1401) {
             let newresp = {};
             newresp.url = url;
@@ -129,7 +129,7 @@ class WtrlabParser extends Parser{
         }
     }
 
-    PostToUrl(url, body){
+    PostToUrl(url, body) {
         let hostname = new URL(url).hostname;
         let translate = body.translate;
         let language = body.language;

--- a/plugin/js/parsers/WuxiaBlogParser.js
+++ b/plugin/js/parsers/WuxiaBlogParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("wuxia.blog", () => new WuxiaBlogParser());
 
-class WuxiaBlogParser extends Parser{
+class WuxiaBlogParser extends Parser {
     constructor() {
         super();
     }
@@ -28,8 +28,8 @@ class WuxiaBlogParser extends Parser{
         if (paginationUrl !== null) {
             let index = paginationUrl.lastIndexOf("/");
             let maxPage = parseInt(paginationUrl.substring(index + 1));
-            let prefix = paginationUrl.substring(0, index + 1)
-            for(let i = 2; i <= maxPage; ++i) {
+            let prefix = paginationUrl.substring(0, index + 1);
+            for (let i = 2; i <= maxPage; ++i) {
                 urls.push(prefix + i);
             }
         }

--- a/plugin/js/parsers/WuxiacityParser.js
+++ b/plugin/js/parsers/WuxiacityParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("wuxia.city", () => new WuxiacityParser());
 
-class WuxiacityParser extends Parser{
+class WuxiacityParser extends Parser {
     constructor() {
         super();
     }
@@ -20,7 +20,7 @@ class WuxiacityParser extends Parser{
         return ({
             sourceUrl:  link.href,
             title: link.querySelector(".chapter-name").textContent.replace(/\n/g, " ")
-        })
+        });
     }
 
     findContent(dom) {

--- a/plugin/js/parsers/WuxiaworldCoParser.js
+++ b/plugin/js/parsers/WuxiaworldCoParser.js
@@ -1,13 +1,13 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("wuxiaworld.co", function() { return new WuxiaworldCoParser() });
+parserFactory.register("wuxiaworld.co", function() { return new WuxiaworldCoParser(); });
 //dead url
 parserFactory.register("m.wuxiaworld.co", () => new WuxiaworldCoParser());
 //dead url
 parserFactory.register("novelupdates.cc", () => new WuxiaworldCoParser());
 
-class WuxiaworldCoParser extends Parser{
+class WuxiaworldCoParser extends Parser {
     constructor() {
         super();
     }
@@ -15,15 +15,15 @@ class WuxiaworldCoParser extends Parser{
     async getChapterUrls(dom) {
         let list = dom.querySelector("ul.chapter-list");
         return util.hyperlinksToChapterList(list);
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div.section-list");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.book-name");
-    };
+    }
 
     extractAuthor(dom) {
         return dom.querySelector("div.author span.name").textContent;

--- a/plugin/js/parsers/WuxiaworldParser.js
+++ b/plugin/js/parsers/WuxiaworldParser.js
@@ -3,7 +3,7 @@
 */
 "use strict";
 
-parserFactory.register("wuxiaworld.com", function() { return new WuxiaworldParser() });
+parserFactory.register("wuxiaworld.com", function() { return new WuxiaworldParser(); });
 
 class WuxiaworldParser extends Parser {
     constructor() {
@@ -34,7 +34,7 @@ class WuxiaworldParser extends Parser {
     static getChapterArc(link) {
         let isPanel = function(element) {
             return (element.tagName.toLowerCase() === "div")
-                && (element.className === "panel panel-default")
+                && (element.className === "panel panel-default");
         };
         
         let parent = link;

--- a/plugin/js/parsers/WuxiaworldWorldParser.js
+++ b/plugin/js/parsers/WuxiaworldWorldParser.js
@@ -5,7 +5,7 @@
 //dead url/ parser
 parserFactory.register("wuxiaworld.world", () => new WuxiaworldWorldParser());
 
-class WuxiaworldWorldParser extends Parser{
+class WuxiaworldWorldParser extends Parser {
     constructor() {
         super();
     }
@@ -13,20 +13,20 @@ class WuxiaworldWorldParser extends Parser{
     getChapterUrls(dom) {
         let menu = dom.querySelector("div.manga_chapter_list");
         return Promise.resolve(util.hyperlinksToChapterList(menu).reverse());
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div.list_img");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.manga_name h1");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("div.manga_des a");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 
     findChapterTitle(dom) {
         return dom.querySelector("div.manga_view_name h1");

--- a/plugin/js/parsers/WuxiaworldeuParser.js
+++ b/plugin/js/parsers/WuxiaworldeuParser.js
@@ -3,7 +3,7 @@
 parserFactory.register("wuxiaworld.eu", () => new WuxiaworldeuParser());
 parserFactory.register("wuxia.click", () => new WuxiaworldeuParser());
 
-class WuxiaworldeuParser extends Parser{
+class WuxiaworldeuParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/XbiqugeParser.js
+++ b/plugin/js/parsers/XbiqugeParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("xbiquge.so", () => new XbiqugeParser());
 
-class XbiqugeParser extends Parser{
+class XbiqugeParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/XenforoBatchParser.js
+++ b/plugin/js/parsers/XenforoBatchParser.js
@@ -1,10 +1,10 @@
 "use strict";
 parserFactory.registerManualSelect(
     "Xenforo Batch Post Parser",
-    function() { return new XenforoBatchParser() }
+    function() { return new XenforoBatchParser(); }
 );
 
-class XenforoBatchParser extends Parser{
+class XenforoBatchParser extends Parser {
     constructor() {
         super();
         this.cache = new FetchCache();
@@ -82,15 +82,15 @@ class XenforoBatchParser extends Parser{
 
     findContent(dom) {
         return this.getSubParser(dom).findContent(dom);
-    };
+    }
 
     extractTitleImpl(dom) {
         return this.getSubParser(dom).extractTitleImpl(dom);
-    };
+    }
 
     extractAuthor(dom) {
         return this.getSubParser(dom).extractAuthor(dom);
-    };
+    }
 
     //addTitleToChapter(newDoc, parent) {}
 

--- a/plugin/js/parsers/XiaoshubaoParser.js
+++ b/plugin/js/parsers/XiaoshubaoParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("xiaoshubao.net", () => new XiaoshubaoParser());
 
-class XiaoshubaoParser extends Parser{
+class XiaoshubaoParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/XiaoshuoguiParser.js
+++ b/plugin/js/parsers/XiaoshuoguiParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("xiaoshuogui.com", () => new XiaoshuoguiParser());
 
-class XiaoshuoguiParser extends Parser{
+class XiaoshuoguiParser extends Parser {
     constructor() {
         super();
     }
@@ -11,20 +11,20 @@ class XiaoshuoguiParser extends Parser{
     getChapterUrls(dom) {
         let menu = dom.querySelector("#chapterList");
         return Promise.resolve(util.hyperlinksToChapterList(menu));
-    };
+    }
 
     findContent(dom) {
         return dom.querySelector("div#mlfy_main_text");
-    };
+    }
 
     extractTitleImpl(dom) {
         return dom.querySelector("div.d_title h1");
-    };
+    }
 
     extractAuthor(dom) {
         let authorLabel = dom.querySelector("span.p_author a");
         return (authorLabel === null) ? super.extractAuthor(dom) : authorLabel.textContent;
-    };
+    }
 
     extractLanguage() {
         return "zh";
@@ -36,7 +36,7 @@ class XiaoshuoguiParser extends Parser{
 
     fetchChapter(url) {
         // site does not tell us gb18030 is used to encode text
-        return HttpClient.wrapFetch(url, this.makeOptions()).then(function (xhr) {
+        return HttpClient.wrapFetch(url, this.makeOptions()).then(function(xhr) {
             return Promise.resolve(xhr.responseXML);
         });
     }

--- a/plugin/js/parsers/XiaxuenovelsParser.js
+++ b/plugin/js/parsers/XiaxuenovelsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("xiaxuenovels.xyz", () => new XiaxuenovelsParser());
 
-class XiaxuenovelsParser extends Parser{
+class XiaxuenovelsParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/XklxswParser.js
+++ b/plugin/js/parsers/XklxswParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("m.xklxsw.net", () => new XklxswParser());
 
-class XklxswParser extends Parser{
+class XklxswParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/YushuboParser.js
+++ b/plugin/js/parsers/YushuboParser.js
@@ -3,7 +3,7 @@
 //dead url/ parser
 parserFactory.register("yushubo.net", () => new YushuboParser());
 
-class YushuboParser extends Parser{
+class YushuboParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/ZenithNovelsParser.js
+++ b/plugin/js/parsers/ZenithNovelsParser.js
@@ -1,7 +1,7 @@
 "use strict";
 
 //dead url/ parser
-parserFactory.register("zenithnovels.com", function() { return new ZenithNovelsParser() });
+parserFactory.register("zenithnovels.com", function() { return new ZenithNovelsParser(); });
 
 class ZenithNovelsParser extends WordpressBaseParser {
     constructor() {
@@ -14,7 +14,7 @@ class ZenithNovelsParser extends WordpressBaseParser {
             ZenithNovelsParser.getUrlsOfTocPages,
             chapterUrlsUI
         ).then(l => l.reverse());
-    };
+    }
 
     static getUrlsOfTocPages(dom) {
         return [...dom.querySelectorAll("ul.lcp_paginator a:not(.lcp_nextlink)")]

--- a/plugin/js/parsers/ZenithtlsParser.js
+++ b/plugin/js/parsers/ZenithtlsParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("zenithtls.com", () => new ZenithtlsParser());
 
-class ZenithtlsParser extends Parser{
+class ZenithtlsParser extends Parser {
     constructor() {
         super();
     }
@@ -19,7 +19,7 @@ class ZenithtlsParser extends Parser{
         }));
     }
     
-    async loadEpubMetaInfo(dom){
+    async loadEpubMetaInfo(dom) {
         let leaves = dom.baseURI.split("/");
         let id = leaves[leaves.length - 1];
         let bookinfo = (await HttpClient.fetchJson("https://www.zenithtls.com/api/novels/" + id)).json;
@@ -92,7 +92,7 @@ class ZenithtlsParser extends Parser{
         return this.buildChapter(json[longestindex], url);
     }
 
-    parseNextjsHydration(nextjs){
+    parseNextjsHydration(nextjs) {
         let malformedjson = nextjs.match(/{.*}/s);
         let json;
         if (malformedjson == null) {

--- a/plugin/js/parsers/ZeonicrepublicParser.js
+++ b/plugin/js/parsers/ZeonicrepublicParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("zeonic-republic.net", () => new ZeonicrepublicParser());
 
-class ZeonicrepublicParser extends Parser{
+class ZeonicrepublicParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/ZhenhunxiaoshuoParser.js
+++ b/plugin/js/parsers/ZhenhunxiaoshuoParser.js
@@ -2,7 +2,7 @@
 
 parserFactory.register("zhenhunxiaoshuo.com", () => new ZhenhunxiaoshuoParser());
 
-class ZhenhunxiaoshuoParser extends Parser{
+class ZhenhunxiaoshuoParser extends Parser {
     constructor() {
         super();
     }

--- a/plugin/js/parsers/ZirusMusingsParser.js
+++ b/plugin/js/parsers/ZirusMusingsParser.js
@@ -4,7 +4,7 @@
 "use strict";
 
 //dead url
-parserFactory.register("zirusmusings.com", function() { return new ZirusMusingsParser() });
+parserFactory.register("zirusmusings.com", function() { return new ZirusMusingsParser(); });
 parserFactory.register("zirusmusings.net", () => new ZirusMusingsParser());
 
 class ZirusMusingsParser extends Parser {
@@ -29,7 +29,7 @@ class ZirusMusingsParser extends Parser {
         }));
     }
     
-    async loadEpubMetaInfo(dom){
+    async loadEpubMetaInfo(dom) {
         let tocHtml = (await HttpClient.wrapFetch(dom.baseURI)).responseXML;
         let nextjsraw = tocHtml.querySelector("#__NEXT_DATA__").innerHTML;
         let nextjsjson = JSON.parse(nextjsraw);

--- a/readme.md
+++ b/readme.md
@@ -674,8 +674,9 @@ Open Firefox and visit [WebToEpub on Firefox Add-ons][firefox-add-ons].
    - This will produce 3 files in the eslint directory.
      - WebToEpub0.0.0.x.xpi (Firefox version of plug-in)
      - WebToEpub0.0.0.x.zip (Chrome version of plug-in)
-     - packed.js
+     - packed.js (concatenated JS for linting - don't edit this file directly)
    - Lint tests are OK if output ends with `Wrote Zip to disk; Done in XXXs.`
+   - To auto-fix lint errors run `npm run lint:fix`
 
 3. Install extension in browser of choice, using instructions above.
 
@@ -884,7 +885,7 @@ Project Link: [https://github.com/dteviot/WebToEpub](https://github.com/dteviot/
 [issues-shield]: https://img.shields.io/github/issues/dteviot/WebToEpub.svg?style=for-the-badge
 [issues-url]: https://github.com/dteviot/WebToEpub/issues
 
-<!-- GitHub can't automtically ID the current license so let's hard code it -->
+<!-- GitHub can't automatically ID the current license so let's hard code it -->
 
 [license-shield]: https://img.shields.io/badge/LICENSE-GPLv3-%23555555?style=for-the-badge&label=LICENSE&color=285959
 [license-url]: /LICENSE.md


### PR DESCRIPTION
- Additional eslint rules for consistent spacing, semicolon usage, and some code formatting.
- Added command `npm run lint:fix` to make fixing what doesn't match the rules easy.
- File changes from running the new command with the new rules.

This continues to help me reduce diffs with the versions of the plugin I run all the time: (https://github.com/crybx/WebToEpub/tree/dev-v2 if interested. Despite the diverging ahead/behind commit numbers, I keep cherry picking or rebasing updates from the original repo and merging the diffs is a pain, and this branch is from before I started merging with another extension 😭)