### PR TITLE
fix `npm run lint:fix`

### DIFF
--- a/eslint/.eslintrc.js
+++ b/eslint/.eslintrc.js
@@ -28,6 +28,8 @@ module.exports = {
         ],
         "no-undef": "error",
         "no-unused-vars": "error",
+        // needed to avoid no-redeclare errors for our project globals below
+        "no-redeclare": ["error", { "builtinGlobals": false }],
         "space-before-blocks": ["error", "always"],
         "space-before-function-paren": ["error", {
             "anonymous": "never",    // function() {}
@@ -41,7 +43,49 @@ module.exports = {
         }],
     },
     "globals": {
-        "zip": "readable",
+        // Third-party libraries
         "DOMPurify": "readonly",
+        "zip": "readonly",
+
+        // Project globals
+        "BakaTsukiImageCollector": "readonly",
+        "BakaTsukiParser": "readonly",
+        "BakaTsukiSeriesPageParser": "readonly",
+        "BlockedHostNames": "readonly",
+        "BlogspotParser": "readonly",
+        "ChapterEpubItem": "readonly",
+        "ChapterUrlsUI": "readonly",
+        "CoverImageUI": "readonly",
+        "DefaultParser": "readonly",
+        "DefaultParserSiteSettings": "readonly",
+        "DefaultParserUI": "readonly",
+        "Download": "readonly",
+        "EpubItem": "readonly",
+        "EpubItemSupplier": "readonly",
+        "EpubMetaInfo": "readonly",
+        "EpubPacker": "readonly",
+        "ErrorLog": "readonly",
+        "FetchCache": "readonly",
+        "FetchErrorHandler": "readonly",
+        "FetchImageErrorHandler": "readonly",
+        "Firefox": "readonly",
+        "FootnoteExtractor": "readonly",
+        "HttpClient": "readonly",
+        "ImageCollector": "readonly",
+        "ImageInfo": "readonly",
+        "Imgur": "readonly",
+        "Library": "readonly",
+        "MadaraParser": "readonly",
+        "main": "readonly",
+        "NovelfullParser": "readonly",
+        "Parser": "readonly",
+        "parserFactory": "readonly",
+        "ProgressBar": "readonly",
+        "ReadingList": "readonly",
+        "RoyalRoadParser": "readonly",
+        "UserPreferences": "readonly",
+        "util": "readonly",
+        "VariableSizeImageCollector": "readonly",
+        "WordpressBaseParser": "readonly"
     }
 };

--- a/plugin/js/CoverImageUI.js
+++ b/plugin/js/CoverImageUI.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /** Class that handles UI for selecting cover image */
-class CoverImageUI {
+class CoverImageUI { // eslint-disable-line no-unused-vars
     constructor() {
     }
 

--- a/plugin/js/DebugUtil.js
+++ b/plugin/js/DebugUtil.js
@@ -3,7 +3,7 @@
 
 
 /** Functions to help debugging.  Not included in release product */
-class DebugUtil {
+class DebugUtil { // eslint-disable-line no-unused-vars
     constructor() {
     }
 

--- a/plugin/js/DefaultParserUI.js
+++ b/plugin/js/DefaultParserUI.js
@@ -82,7 +82,7 @@ class DefaultParserSiteSettings {
 DefaultParserSiteSettings.storageName = "DefaultParserConfigs";
 
 /** Class that handles UI for configuring the Default Parser */
-class DefaultParserUI {
+class DefaultParserUI { // eslint-disable-line no-unused-vars
     constructor() {
     }
 

--- a/plugin/js/EpubItem.js
+++ b/plugin/js/EpubItem.js
@@ -125,7 +125,7 @@ class EpubItem {
 //==============================================================
 // Construct an Epub item from source where each chapter 
 // was a separate HTML file.
-class ChapterEpubItem extends EpubItem {
+class ChapterEpubItem extends EpubItem { // eslint-disable-line no-unused-vars
     constructor(chapter, content, index) {
         super(chapter.sourceUrl);
         super.setIndex(index);
@@ -167,7 +167,7 @@ class ChapterEpubItem extends EpubItem {
     height: "full size" image height 
     width: "full size" image width
 */
-class ImageInfo extends EpubItem {
+class ImageInfo extends EpubItem { // eslint-disable-line no-unused-vars
     constructor(wrappingUrl, index, sourceUrl, dataOrigFileUrl) {
         super(sourceUrl);
         super.index = index;

--- a/plugin/js/EpubItemSupplier.js
+++ b/plugin/js/EpubItemSupplier.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-class EpubItemSupplier {
+class EpubItemSupplier { // eslint-disable-line no-unused-vars
     constructor(parser, epubItems, imageCollector) {
         this.parser = parser;
         this.epubItems = [];

--- a/plugin/js/Firefox.js
+++ b/plugin/js/Firefox.js
@@ -3,7 +3,7 @@
 
 
 /** Functions specific to Firefox version of plug-in */
-class Firefox {
+class Firefox { // eslint-disable-line no-unused-vars
     constructor() {
     }
 

--- a/plugin/js/FootnoteExtractor.js
+++ b/plugin/js/FootnoteExtractor.js
@@ -1,4 +1,4 @@
-class FootnoteExtractor {
+class FootnoteExtractor { // eslint-disable-line no-unused-vars
     scriptElementsToFootnotes(dom) {
         let indexedFootnotes = new Map();
         [...dom.querySelectorAll("script")]

--- a/plugin/js/HttpClient.js
+++ b/plugin/js/HttpClient.js
@@ -129,7 +129,7 @@ class FetchErrorHandler {
 }
 FetchErrorHandler.rateLimitedHosts = new Set();
 
-class FetchImageErrorHandler extends FetchErrorHandler {
+class FetchImageErrorHandler extends FetchErrorHandler { // eslint-disable-line no-unused-vars
     constructor(parentPageUrl) {
         super();
         this.parentPageUrl = parentPageUrl;

--- a/plugin/js/ImageCollector.js
+++ b/plugin/js/ImageCollector.js
@@ -554,7 +554,7 @@ class ImageCollector {
 
 //==============================================================
 
-class VariableSizeImageCollector extends ImageCollector {
+class VariableSizeImageCollector extends ImageCollector { // eslint-disable-line no-unused-vars
     constructor() {
         super();
     }

--- a/plugin/js/Imgur.js
+++ b/plugin/js/Imgur.js
@@ -3,7 +3,7 @@
 */
 "use strict";
 
-class Imgur {
+class Imgur { // eslint-disable-line no-unused-vars
     constructor() {
     }
 

--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -5,7 +5,7 @@
 
 var LibFileReader = new FileReader();
 
-class Library {
+class Library { // eslint-disable-line no-unused-vars
     constructor() {
     }
     

--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -6,7 +6,7 @@
 /**
  * For sites that have multiple chapters per web page, this can minimize HTTP calls
  */
-class FetchCache {
+class FetchCache { // eslint-disable-line no-unused-vars
     constructor() {
         this.path = null;
         this.dom = null;

--- a/plugin/js/ProgressBar.js
+++ b/plugin/js/ProgressBar.js
@@ -4,7 +4,7 @@
 /**
    Code to manipulate the Progress Bar on the UI 
 */
-class ProgressBar {
+class ProgressBar { // eslint-disable-line no-unused-vars
     constructor() {
     }
 

--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -77,7 +77,7 @@ class StringUserPreference extends UserPreference {
 }
 
 /** The collection of all preferences for user  */
-class UserPreferences {
+class UserPreferences { // eslint-disable-line no-unused-vars
     constructor() {
         this.preferences = [];
         this.addPreference("removeDuplicateImages", "removeDuplicateImages", false);

--- a/plugin/js/parsers/Template.js
+++ b/plugin/js/parsers/Template.js
@@ -25,7 +25,7 @@ parserFactory.registerRule(
 );
 */
 
-class TemplateParser extends Parser {
+class TemplateParser extends Parser { // eslint-disable-line no-unused-vars
     constructor() {
         super();
         //Optional Parameters:


### PR DESCRIPTION
These are the most minimal changes I could figure out to keep 
```
"no-undef": "error",
"no-unused-vars": "error",
```
not set to "off" and have `npm run lint:fix` not throw errors like:
<img width="1139" height="1844" alt="no-undef" src="https://github.com/user-attachments/assets/94f5d653-4958-4d9f-aa15-5b0e3fd59e80" />
<img width="1312" height="1652" alt="no-unused-vars" src="https://github.com/user-attachments/assets/373ac330-3b40-4441-b23c-ca439343a5da" />

These things ARE all defined when the files are concatenated together into one big packed.js (or running and added with script tags to the html), but when running lint to auto fix the individual files without stitching them together, they don't exist.
