### PR TITLE
Move meta name before content + remove duplicate function

### DIFF
--- a/plugin/js/EpubPacker.js
+++ b/plugin/js/EpubPacker.js
@@ -160,8 +160,11 @@ class EpubPacker {
     appendMetaContent(parent, opf_ns, name, content) {
         let that = this;
         let meta = that.createAndAppendChildNS(parent, opf_ns, "meta");
-        meta.setAttributeNS(null, "content", content);
+        // Some e-book readers such as the Nook fail to recognize covers if the content
+        // attribute comes before the name attribute. For maximum compatibility move
+        // the name attribute before the content attribute.
         meta.setAttributeNS(null, "name", name);
+        meta.setAttributeNS(null, "content", content);
     }
     
     buildManifest(opf, ns, epubItemSupplier) {
@@ -274,17 +277,10 @@ class EpubPacker {
 
     populateHead(head, ns, depth) {
         let that = this;
-        that.buildHeadMeta(head, ns, that.metaInfo.uuid, "dtb:uid");
-        that.buildHeadMeta(head, ns, (depth < 2) ? "2" : depth, "dtb:depth");
-        that.buildHeadMeta(head, ns, "0", "dtb:totalPageCount");
-        that.buildHeadMeta(head, ns, "0", "dtb:maxPageNumber");
-    }
-
-    buildHeadMeta(head, ns, content, name) {
-        let that = this;
-        let meta = that.createAndAppendChildNS(head, ns, "meta");
-        meta.setAttributeNS(null, "content", content);
-        meta.setAttributeNS(null, "name", name);
+        that.appendMetaContent(head, ns, "dtb:uid", that.metaInfo.uuid);
+        that.appendMetaContent(head, ns, "dtb:depth", (depth < 2) ? "2" : depth);
+        that.appendMetaContent(head, ns, "dtb:totalPageCount", "0");
+        that.appendMetaContent(head, ns, "dtb:maxPageNumber", "0");
     }
 
     buildDocTitle(ncx, ns) {

--- a/unitTest/UtestEpubPacker.js
+++ b/unitTest/UtestEpubPacker.js
@@ -70,8 +70,8 @@ test("buildContentOpf", function (assert) {
             "<dc:creator opf:file-as=\"Dummy &amp; Author\" opf:role=\"aut\">Dummy &amp; Author</dc:creator>" +
             "<dc:identifier id=\"BookId\" opf:scheme=\"URI\">Dummy UUID</dc:identifier>"+
             "<dc:contributor opf:role=\"bkp\">[https://github.com/dteviot/WebToEpub] (ver. unknown)</dc:contributor>"+
-            "<meta content=\"BakaSeries\" name=\"calibre:series\"/>" +
-            "<meta content=\"666\" name=\"calibre:series_index\"/>" +
+            "<meta name=\"calibre:series\" content=\"BakaSeries\"/>" +
+            "<meta name=\"calibre:series_index\" content=\"666\"/>" +
             "<dc:source id=\"id.xhtml0000\">http://dummy.com/Title0</dc:source>" +
             "<dc:source id=\"id.xhtml0001\">http://dummy.com/Title1</dc:source>" +
             "</metadata>"+
@@ -120,8 +120,8 @@ test("buildEpub3ContentOpf", function (assert) {
             "<meta property=\"dcterms:modified\">2015-10-17T21:04:54Z</meta>" +
             "<dc:contributor id=\"packingTool\">[https://github.com/dteviot/WebToEpub] (ver. unknown)</dc:contributor>"+
             "<meta refines=\"#packingTool\" property=\"role\">bkp</meta>" +
-            "<meta content=\"BakaSeries\" name=\"calibre:series\"/>" +
-            "<meta content=\"666\" name=\"calibre:series_index\"/>" +
+            "<meta name=\"calibre:series\" content=\"BakaSeries\"/>" +
+            "<meta name=\"calibre:series_index\" content=\"666\"/>" +
             "<dc:source id=\"id.xhtml0000\">http://dummy.com/Title0</dc:source>" +
             "<dc:source id=\"id.xhtml0001\">http://dummy.com/Title1</dc:source>" +
             "</metadata>"+
@@ -167,7 +167,7 @@ test("buildContentOpfWithCover", function (assert) {
             "<dc:creator opf:file-as=\"Dummy &amp; Author\" opf:role=\"aut\">Dummy &amp; Author</dc:creator>" +
             "<dc:identifier id=\"BookId\" opf:scheme=\"URI\">Dummy UUID</dc:identifier>" +
             "<dc:contributor opf:role=\"bkp\">[https://github.com/dteviot/WebToEpub] (ver. unknown)</dc:contributor>"+
-            "<meta content=\"cover-image\" name=\"cover\"/>" +
+            "<meta name=\"cover\" content=\"cover-image\"/>" +
             "<dc:source id=\"id.cover-image\">http://bp.org/thepic.jpeg</dc:source>" +
             "<dc:source id=\"id.xhtml0000\">http://dummy.com/Title0</dc:source>" +
             "<dc:source id=\"id.xhtml0001\">http://dummy.com/Title1</dc:source>" +
@@ -213,8 +213,8 @@ test("buildContentOpfWithTranslatorAndAuthorFileAs", function (assert) {
             "<dc:contributor opf:file-as=\"Baka-Tsuki staff\" opf:role=\"trl\">Baka-Tsuki staff</dc:contributor>" +
             "<dc:identifier id=\"BookId\" opf:scheme=\"URI\">Dummy UUID</dc:identifier>" +
             "<dc:contributor opf:role=\"bkp\">[https://github.com/dteviot/WebToEpub] (ver. unknown)</dc:contributor>"+
-            "<meta content=\"BakaSeries\" name=\"calibre:series\"/>" +
-            "<meta content=\"666\" name=\"calibre:series_index\"/>" +
+            "<meta name=\"calibre:series\" content=\"BakaSeries\"/>" +
+            "<meta name=\"calibre:series_index\" content=\"666\"/>" +
             "<dc:source id=\"id.xhtml0000\">http://dummy.com/Title0</dc:source>" +
             "<dc:source id=\"id.xhtml0001\">http://dummy.com/Title1</dc:source>" +
             "</metadata>" +
@@ -239,10 +239,10 @@ test("buildTableOfContents", function (assert) {
         "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
         "<ncx xmlns=\"http://www.daisy.org/z3986/2005/ncx/\" version=\"2005-1\" xml:lang=\"en\">" +
           "<head>" +
-            "<meta content=\"Dummy UUID\" name=\"dtb:uid\"/>" +
-            "<meta content=\"2\" name=\"dtb:depth\"/>" +
-            "<meta content=\"0\" name=\"dtb:totalPageCount\"/>" +
-            "<meta content=\"0\" name=\"dtb:maxPageNumber\"/>" +
+            "<meta name=\"dtb:uid\" content=\"Dummy UUID\"/>" +
+            "<meta name=\"dtb:depth\" content=\"2\"/>" +
+            "<meta name=\"dtb:totalPageCount\" content=\"0\"/>" +
+            "<meta name=\"dtb:maxPageNumber\" content=\"0\"/>" +
           "</head>" +
           "<docTitle>" +
             "<text>Dummy &lt;Title&gt;</text>" +
@@ -282,10 +282,10 @@ test("buildNestedTableOfContents", function (assert) {
         "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
         "<ncx xmlns=\"http://www.daisy.org/z3986/2005/ncx/\" version=\"2005-1\" xml:lang=\"en\">" +
           "<head>" +
-            "<meta content=\"Dummy UUID\" name=\"dtb:uid\"/>" +
-            "<meta content=\"2\" name=\"dtb:depth\"/>" +
-            "<meta content=\"0\" name=\"dtb:totalPageCount\"/>" +
-            "<meta content=\"0\" name=\"dtb:maxPageNumber\"/>" +
+            "<meta name=\"dtb:uid\" content=\"Dummy UUID\"/>" +
+            "<meta name=\"dtb:depth\" content=\"2\"/>" +
+            "<meta name=\"dtb:totalPageCount\" content=\"0\"/>" +
+            "<meta name=\"dtb:maxPageNumber\" content=\"0\"/>" +
           "</head>" +
           "<docTitle>" +
             "<text>Dummy &lt;Title&gt;</text>" +


### PR DESCRIPTION
Fixes this error in Calibre. I don't think Calibre used to check for this in earlier versions.

<img width="1912" height="747" alt="error" src="https://github.com/user-attachments/assets/27d24853-784e-4596-8b78-2a46ef24d6e7" />
