### PR TITLE
Omit data:uris from comments, metadata, and source in opf

### DIFF
--- a/plugin/js/EpubPacker.js
+++ b/plugin/js/EpubPacker.js
@@ -136,8 +136,11 @@ class EpubPacker {
         }
 
         for (let i of epubItemSupplier.manifestItems()) {
-            let source = this.createAndAppendChildNS(metadata, dc_ns, "dc:source", i.sourceUrl);
-            source.setAttributeNS(null, "id", "id." + i.getId());
+            let sourceUrl = util.clearIfDataUri(i.sourceUrl);
+            if (sourceUrl) {  // Only add dc:source if we have a valid URL
+                let source = this.createAndAppendChildNS(metadata, dc_ns, "dc:source", sourceUrl);
+                source.setAttributeNS(null, "id", "id." + i.getId());
+            }
         }
     }
 

--- a/plugin/js/Util.js
+++ b/plugin/js/Util.js
@@ -9,7 +9,7 @@
 
 const util = (function() {
     var sleepController = new AbortController;
-    
+
     function sleep(ms) {
         return new Promise(resolve => {
             function finished() {
@@ -84,6 +84,7 @@ const util = (function() {
         newImage.setAttributeNS(xlink_ns, "xlink:href", makeRelative(href));
         newImage.setAttributeNS(null, "width", width);
         newImage.setAttributeNS(null, "height", height);
+        origin = clearIfDataUri(origin);
         if (includeImageSourceUrl) {
             let desc = doc.createElementNS(svg_ns, "desc");
             svg.appendChild(desc);
@@ -92,6 +93,11 @@ const util = (function() {
             svg.appendChild(createComment(doc, origin));
         }
         return div;
+    }
+
+    function clearIfDataUri(content) {
+        // Filter out data: URIs to prevent massive base64 content
+        return (content && content.startsWith("data:")) ? "" : content;
     }
 
     // assumes we're making link from file in OEBPS\Text to OEBPS\Images
@@ -647,6 +653,7 @@ const util = (function() {
     }
 
     function createComment(doc, content) {
+        content = clearIfDataUri(content);
         // comments are not allowed to contain a double hyphen
         let escaped = content.replace(/--/g, "%2D%2D");
         return doc.createComment("  " + escaped + "  ");
@@ -1146,6 +1153,7 @@ const util = (function() {
         createEmptyHtmlDoc: createEmptyHtmlDoc,
         populateHead: populateHead,
         createSvgImageElement: createSvgImageElement,
+        clearIfDataUri: clearIfDataUri,
         resolveRelativeUrl: resolveRelativeUrl,
         log: log,
         extractHostName: extractHostName,


### PR DESCRIPTION
Since the image itself is in the epub, a data uri provides no additional info. It also causes file size errors and issues. In this example, this whole file is basically just the data uri and I've had chapters error when data uris were included in comments because the text content for a single chapter was "too large"

<img width="2717" height="1890" alt="image" src="https://github.com/user-attachments/assets/54a360da-83ed-4e44-bc01-2c4f6cbf3d7d" />
