### PR TITLE
Consolidate UI text

### DIFF
--- a/eslint/.eslintrc.js
+++ b/eslint/.eslintrc.js
@@ -83,6 +83,7 @@ module.exports = {
         "ProgressBar": "readonly",
         "ReadingList": "readonly",
         "RoyalRoadParser": "readonly",
+        "UIText": "readonly",
         "UserPreferences": "readonly",
         "util": "readonly",
         "VariableSizeImageCollector": "readonly",

--- a/plugin/js/ChapterUrlsUI.js
+++ b/plugin/js/ChapterUrlsUI.js
@@ -133,8 +133,7 @@ class ChapterUrlsUI {
             .filter(c => c.checked)
             .map(c => c.parentElement.parentElement);
         if (max< selectedRows.length ) {
-            let message = chrome.i18n.getMessage("__MSG_More_than_max_chapters_selected__", 
-                [selectedRows.length, max]);
+            let message = UIText.Chapter.maxChaptersSelected(selectedRows.length, max);
             if (confirm(message) === false) {
                 for (let row of selectedRows.slice(max)) {
                     ChapterUrlsUI.setRowCheckboxState(row, false);
@@ -496,7 +495,7 @@ class ChapterUrlsUI {
         }
         ++ChapterUrlsUI.ConsecutiveRowClicks;
         if (ChapterUrlsUI.ConsecutiveRowClicks == 5) {
-            alert(chrome.i18n.getMessage("__MSG_Shift_Click__"));
+            alert(UIText.Chapter.shiftClickMessage);
         }
     }
 
@@ -713,10 +712,10 @@ ChapterUrlsUI.ImageForState = [
 ];
 ChapterUrlsUI.TooltipForSate = [
     null,
-    chrome.i18n.getMessage("__MSG_Tooltip_chapter_downloading__"),
-    chrome.i18n.getMessage("__MSG_Tooltip_chapter_downloaded__"),
-    chrome.i18n.getMessage("__MSG_Tooltip_chapter_sleeping__"),
-    chrome.i18n.getMessage("__MSG_Tooltip_chapter_previously_downloaded__")
+    UIText.Chapter.tooltipChapterDownloading,
+    UIText.Chapter.tooltipChapterDownloaded,
+    UIText.Chapter.tooltipChapterSleeping,
+    UIText.Chapter.tooltipChapterPreviouslyDownloaded
 ];
 
 ChapterUrlsUI.lastSelectedRow = null;

--- a/plugin/js/CoverImageUI.js
+++ b/plugin/js/CoverImageUI.js
@@ -46,7 +46,7 @@ class CoverImageUI { // eslint-disable-line no-unused-vars
         let imagesTable = CoverImageUI.getImageTableElement();
         let checkBoxIndex = 0;
         if (0 === images.length) {
-            imagesTable.parentElement.appendChild(document.createTextNode(chrome.i18n.getMessage("noImagesFoundLabel")));
+            imagesTable.parentElement.appendChild(document.createTextNode(UIText.CoverImage.noImagesFoundLabel));
         }
         else {
             images.forEach((imageInfo) => {
@@ -78,7 +78,7 @@ class CoverImageUI { // eslint-disable-line no-unused-vars
         checkbox.id = "setCoverCheckBox" + checkBoxIndex;
         checkbox.onclick = () => { CoverImageUI.onImageClicked(checkbox.id, sourceUrl); };
         label.appendChild(checkbox);
-        label.appendChild(document.createTextNode(chrome.i18n.getMessage("setCover")));
+        label.appendChild(document.createTextNode(UIText.CoverImage.setCover));
 
         // default to first image as cover image
         if (checkBoxIndex === 0) {

--- a/plugin/js/DefaultParserUI.js
+++ b/plugin/js/DefaultParserUI.js
@@ -143,7 +143,7 @@ class DefaultParserUI { // eslint-disable-line no-unused-vars
         let config = parser.siteConfigs.getConfigForSite(hostname);
         if (util.isNullOrEmpty(config.testUrl))
         {
-            alert(chrome.i18n.getMessage("warningNoChapterUrl"));
+            alert(UIText.Warning.warningNoChapterUrl);
             return;
         }
         try {
@@ -151,7 +151,7 @@ class DefaultParserUI { // eslint-disable-line no-unused-vars
             let webPage = { rawDom: util.sanitize(xhr.responseXML.querySelector("*")) };
             let content = parser.findContent(webPage.rawDom);
             if (content === null) {
-                let errorMsg = chrome.i18n.getMessage("errorContentNotFound", [config.testUrl]);
+                let errorMsg = UIText.Error.errorContentNotFound(config.testUrl);
                 throw new Error(errorMsg);
             }
             parser.removeUnwantedElementsFromContentElement(content);

--- a/plugin/js/Download.js
+++ b/plugin/js/Download.js
@@ -42,9 +42,7 @@ class Download {
             CustomFilename = CustomFilename.replaceAll(key, value);
         }
         if (Download.isFileNameIllegalOnWindows(CustomFilename)) {
-            ErrorLog.showErrorMessage(chrome.i18n.getMessage("errorIllegalFileName",
-                [CustomFilename, Download.illegalWindowsFileNameChars]
-            ));
+            ErrorLog.showErrorMessage(UIText.Error.errorIllegalFileName(CustomFilename, Download.illegalWindowsFileNameChars));
             return EpubPacker.addExtensionIfMissing("IllegalFileName");
         }
         return EpubPacker.addExtensionIfMissing(CustomFilename);

--- a/plugin/js/EpubItem.js
+++ b/plugin/js/EpubItem.js
@@ -50,9 +50,7 @@ class EpubItem {
         let xml = util.xmlToString(this.makeChapterDoc(emptyDocFactory));
         let errorMessage = contentValidator(xml);
         if (errorMessage) {
-            let errorMsg = chrome.i18n.getMessage("convertToXhtmlWarning",
-                [this.chapterTitle, this.sourceUrl, errorMessage]
-            );
+            let errorMsg = UIText.Error.convertToXhtmlWarning(this.chapterTitle, this.sourceUrl, errorMessage);
             ErrorLog.log(errorMsg);
         }
         return xml;

--- a/plugin/js/EpubMetaInfo.js
+++ b/plugin/js/EpubMetaInfo.js
@@ -15,9 +15,9 @@
 */
 class EpubMetaInfo {
     constructor() {
-        this.uuid = chrome.i18n.getMessage("defaultUUID");
-        this.title = chrome.i18n.getMessage("defaultTitle");
-        this.author = chrome.i18n.getMessage("defaultAuthor");
+        this.uuid = UIText.Default.uuid;
+        this.title = UIText.Default.title;
+        this.author = UIText.Default.author;
 
         this.language = "en";
         this.fileName = "web.epub";

--- a/plugin/js/EpubPacker.js
+++ b/plugin/js/EpubPacker.js
@@ -189,7 +189,7 @@ class EpubPacker {
         let item = this.createAndAppendChildNS(manifest, ns, "item");
         let relativeHref = this.makeRelative(href);
         if (mediaType === "image/webp") {
-            let errorMsg = chrome.i18n.getMessage("warningWebpImage", [relativeHref]);
+            let errorMsg = UIText.Warning.warningWebpImage(relativeHref);
             ErrorLog.log(errorMsg);
         }
         item.setAttributeNS(null, "href", relativeHref);

--- a/plugin/js/ErrorLog.js
+++ b/plugin/js/ErrorLog.js
@@ -107,7 +107,7 @@ class ErrorLog {
                 close();
                 msg.cancelAction();
             };
-            cancelButton.textContent = chrome.i18n.getMessage("__MSG_button_error_Cancel__");
+            cancelButton.textContent = UIText.Common.cancel;
             if (msg.cancelLabel !== undefined) {
                 cancelButton.textContent =  msg.cancelLabel;
             }

--- a/plugin/js/HttpClient.js
+++ b/plugin/js/HttpClient.js
@@ -8,20 +8,20 @@ class FetchErrorHandler {
     }
 
     makeFailMessage(url, error) {
-        return chrome.i18n.getMessage("htmlFetchFailed", [url, error]);
+        return UIText.Error.htmlFetchFailed(url, error);
     }
 
     makeFailCanRetryMessage(url, error) {
         return this.makeFailMessage(url, error) + " " +
-            chrome.i18n.getMessage("httpFetchCanRetry");
+            UIText.Warning.httpFetchCanRetry;
     }
 
     getCancelButtonText() {
-        return chrome.i18n.getMessage("__MSG_button_error_Cancel__");
+        return UIText.Common.cancel;
     }
 
     static cancelButtonText() {
-        return chrome.i18n.getMessage("__MSG_button_error_Cancel__");
+        return UIText.Common.cancel;
     }
 
     onFetchError(url, error) {
@@ -59,7 +59,7 @@ class FetchErrorHandler {
     promptUserForRetry(url, wrapOptions, response, failError) {
         let msg;
         if (wrapOptions.retry.HTTP === 403) { 
-            msg = new Error(chrome.i18n.getMessage("warning403ErrorResponse", new URL(response.url).hostname) + this.makeFailCanRetryMessage(url, response.status));
+            msg = new Error(UIText.Warning.warning403ErrorResponse(new URL(response.url).hostname) + this.makeFailCanRetryMessage(url, response.status));
         } else {
             msg = new Error(new Error(this.makeFailCanRetryMessage(url, response.status)));
         }
@@ -123,7 +123,7 @@ class FetchErrorHandler {
         let host = new URL(response.url).hostname;
         if (!FetchErrorHandler.rateLimitedHosts.has(host)) {
             FetchErrorHandler.rateLimitedHosts.add(host);
-            alert(chrome.i18n.getMessage("warning429ErrorResponse", host));
+            alert(UIText.Warning.warning429ErrorResponse(host));
         }
     }
 }
@@ -136,11 +136,11 @@ class FetchImageErrorHandler extends FetchErrorHandler { // eslint-disable-line 
     }
 
     makeFailMessage(url, error) {
-        return chrome.i18n.getMessage("imageFetchFailed", [url, this.parentPageUrl, error]);
+        return UIText.Error.imageFetchFailed(url, this.parentPageUrl, error);
     }
 
     getCancelButtonText() {
-        return chrome.i18n.getMessage("__MSG_button_error_Skip__");
+        return UIText.Common.skip;
     }
 }
 

--- a/plugin/js/ImageCollector.js
+++ b/plugin/js/ImageCollector.js
@@ -418,7 +418,7 @@ class ImageCollector {
                     return this.findImageFileUrlUsingDataOrigFileUrl(imageInfo);
                 }
                 let baseUri = xhr.responseXML.baseURI;
-                let errorMsg = chrome.i18n.getMessage("gotHtmlExpectedImageWarning", [baseUri]);
+                let errorMsg = UIText.Error.gotHtmlExpectedImageWarning(baseUri);
                 ErrorLog.log(errorMsg);
                 temp = imageInfo.sourceUrl;
             }

--- a/plugin/js/Imgur.js
+++ b/plugin/js/Imgur.js
@@ -16,8 +16,7 @@ class Imgur { // eslint-disable-line no-unused-vars
                     Imgur.replaceGalleryHyperlinkWithImages(link, xhr.responseXML);
                     return Promise.resolve();
                 }).catch((err) => {
-                    let errorMsg = chrome.i18n.getMessage("imgurFetchFailed", 
-                        [link.href, parentPageUrl, err]);
+                    let errorMsg = UIText.Error.imgurFetchFailed(link.href, parentPageUrl, err);
                     ErrorLog.log(errorMsg);
                     return Promise.resolve();
                 });

--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -39,9 +39,7 @@ class Library { // eslint-disable-line no-unused-vars
         if (document.getElementById("LibDownloadEpubAfterUpdateCheckbox").checked) {
             fileName = EpubPacker.addExtensionIfMissing(await Library.LibGetFromStorage("LibFilename" + LibidURL));
             if (Download.isFileNameIllegalOnWindows(fileName)) {
-                ErrorLog.showErrorMessage(chrome.i18n.getMessage("errorIllegalFileName",
-                    [fileName, Download.illegalWindowsFileNameChars]
-                ));
+                ErrorLog.showErrorMessage(UIText.Error.errorIllegalFileName(fileName, Download.illegalWindowsFileNameChars));
                 return;
             }
             return Download.save(MergedEpub, fileName, overwriteExisting, backgroundDownload);
@@ -627,7 +625,7 @@ class Library { // eslint-disable-line no-unused-vars
             
             let regex1 = opfFile.match(new RegExp("<dc:title>.+?</dc:creator>", "gs"));
             if ( regex1 == null) {
-                ErrorLog.showErrorMessage(chrome.i18n.getMessage("errorEditMetadata"));
+                ErrorLog.showErrorMessage(UIText.Error.errorEditMetadata);
                 return;
             }
             let LibSaveMetadataString = "";
@@ -644,7 +642,7 @@ class Library { // eslint-disable-line no-unused-vars
             let content = await EpubZipWrite.close();
             Library.LibHandleUpdate(-1, content, await Library.LibGetFromStorage("LibStoryURL"+obj.dataset.libepubid), await Library.LibGetFromStorage("LibFilename"+obj.dataset.libepubid), obj.dataset.libepubid);
         } catch {
-            ErrorLog.showErrorMessage(chrome.i18n.getMessage("errorEditMetadata"));
+            ErrorLog.showErrorMessage(UIText.Error.errorEditMetadata);
             return;
         }
     }

--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -125,7 +125,7 @@ class Parser {
         util.removeEmptyDivElements(content);
         util.removeTrailingWhiteSpace(content);
         if (util.isElementWhiteSpace(content)) {
-            let errorMsg = chrome.i18n.getMessage("warningNoVisibleContent", [webPage.sourceUrl]);
+            let errorMsg = UIText.Warning.warningNoVisibleContent(webPage.sourceUrl);
             ErrorLog.showErrorMessage(errorMsg);
         }
         return content;
@@ -232,9 +232,7 @@ class Parser {
 
     makePlaceholderEpubItem(webPage, epubItemIndex) {
         let temp = Parser.makeEmptyDocForContent(webPage.sourceUrl);
-        temp.content.textContent = chrome.i18n.getMessage("chapterPlaceholderMessage",
-            [webPage.sourceUrl, webPage.error]
-        );
+        temp.content.textContent = UIText.Default.chapterPlaceholderMessage(webPage.sourceUrl, webPage.error);
         util.convertPreTagToPTags(temp.dom, temp.content);
         return [new ChapterEpubItem(webPage, temp.content, epubItemIndex)];
     }
@@ -404,13 +402,13 @@ class Parser {
     }
 
     makeInformationEpubItem(dom) {
-        let titleText = chrome.i18n.getMessage("informationPageTitle");
+        let titleText = UIText.Default.informationPageTitle;
         let title = document.createElement("h1");
         title.appendChild(document.createTextNode(titleText));
         let div = document.createElement("div");
         let urlElement = document.createElement("p");
         let bold = document.createElement("b");
-        bold.textContent = chrome.i18n.getMessage("tableOfContentsUrl");
+        bold.textContent = UIText.Default.tableOfContentsUrl;
         urlElement.appendChild(bold);
         urlElement.appendChild(document.createTextNode(this.state.chapterListUrl));
         div.appendChild(urlElement);
@@ -509,7 +507,7 @@ class Parser {
 
     onFetchChaptersClicked() {
         if (0 == this.state.webPages.size) {
-            ErrorLog.showErrorMessage(chrome.i18n.getMessage("noChaptersFoundAndFetchClicked"));
+            ErrorLog.showErrorMessage(UIText.Error.noChaptersFoundAndFetchClicked);
         } else {
             this.fetchWebPages();
         }
@@ -577,7 +575,7 @@ class Parser {
             pageParser.removeUnusedElementsToReduceMemoryConsumption(webPageDom);
             let content = pageParser.findContent(webPage.rawDom);
             if (content == null) {
-                let errorMsg = chrome.i18n.getMessage("errorContentNotFound", [webPage.sourceUrl]);
+                let errorMsg = UIText.Error.errorContentNotFound(webPage.sourceUrl);
                 throw new Error(errorMsg);
             }
             return pageParser.fetchImagesUsedInDocument(content, webPage);

--- a/plugin/js/ReadingList.js
+++ b/plugin/js/ReadingList.js
@@ -157,7 +157,7 @@ class ReadingList {
             link.textContent = e;
             this.appendColumnToRow(row, link);
             let button = document.createElement("button");
-            button.textContent = chrome.i18n.getMessage("__MSG_button_Remove__");
+            button.textContent = UIText.Common.remove;
             this.appendColumnToRow(row, button);
         }
     }

--- a/plugin/js/UIText.js
+++ b/plugin/js/UIText.js
@@ -1,0 +1,119 @@
+"use strict";
+
+/**
+ * Centralized UI text constants
+ * User-facing text that needs to be localized should be defined here for easier management
+ */
+class UIText { // eslint-disable-line no-unused-vars
+    // Chapter-related text
+    static Chapter = {
+        tooltipChapterDownloading: chrome.i18n.getMessage("__MSG_Tooltip_chapter_downloading__"),
+        tooltipChapterDownloaded: chrome.i18n.getMessage("__MSG_Tooltip_chapter_downloaded__"),
+        tooltipChapterSleeping: chrome.i18n.getMessage("__MSG_Tooltip_chapter_sleeping__"),
+        tooltipChapterPreviouslyDownloaded: chrome.i18n.getMessage("__MSG_Tooltip_chapter_previously_downloaded__"),
+        maxChaptersSelected: (selectedCount, maxChapters) => chrome.i18n.getMessage("__MSG_More_than_max_chapters_selected__", [selectedCount, maxChapters]),
+        shiftClickMessage: chrome.i18n.getMessage("__MSG_Shift_Click__")
+    };
+    
+    // Library-related text
+    static Library = {
+        deleteEpub: chrome.i18n.getMessage("__MSG_button_Lib_Template_Delete_EPUB__"),
+        searchNewChapter: chrome.i18n.getMessage("__MSG_button_Lib_Template_Search_new_Chapters__"),
+        updateNewChapter: chrome.i18n.getMessage("__MSG_button_Lib_Template_Update_new_Chapters__"),
+        download: chrome.i18n.getMessage("__MSG_button_Lib_Template_Download_EPUB__"),
+        newChapter: chrome.i18n.getMessage("__MSG_label_Lib_Template_New_Chapter__"),
+        storyURL: chrome.i18n.getMessage("__MSG_label_Lib_Template_Story_URL__"),
+        filename: chrome.i18n.getMessage("__MSG_label_Lib_Template_Filename__"),
+        updateAll: chrome.i18n.getMessage("__MSG_button_Lib_Template_Update_All__"),
+        clearLibrary: chrome.i18n.getMessage("__MSG_button_Lib_Template_Clear_Library__"),
+        exportLibrary: chrome.i18n.getMessage("__MSG_button_Lib_Template_Export_Library__"),
+        importLibrary: chrome.i18n.getMessage("__MSG_button_Lib_Template_Import_Library__"),
+        addToLibrary: chrome.i18n.getMessage("__MSG_button_Lib_Template_Add_List_To_Library__"),
+        mergeUpload: chrome.i18n.getMessage("__MSG_button_Lib_Template_Add_Chapter_from_different_EPUB__"),
+        editMetadata: chrome.i18n.getMessage("__MSG_button_Lib_Template_Edit_Metadata__"),
+        warningURLChange: chrome.i18n.getMessage("__MSG_label_Lib_Template_Warning_URL_Change__"),
+        warningInProgress: chrome.i18n.getMessage("__MSG_label_Lib_Warning_In_Progress___"),
+        confirmClearLibrary: chrome.i18n.getMessage("__MSG_confirm_Clear_Library__")
+    };
+    
+    // Metadata-related text
+    static Metadata = {
+        title: chrome.i18n.getMessage("__MSG_label_Title__"),
+        author: chrome.i18n.getMessage("__MSG_label_Author__"),
+        language: chrome.i18n.getMessage("__MSG_label_Language__"),
+        subject: chrome.i18n.getMessage("__MSG_label_Metadata_subject__"),
+        description: chrome.i18n.getMessage("__MSG_label_Metadata_description__"),
+        save: chrome.i18n.getMessage("__MSG_label_Metadata_Save__")
+    };
+    
+    // Common UI elements
+    static Common = {
+        ok: chrome.i18n.getMessage("__MSG_button_error_OK__"),
+        cancel: chrome.i18n.getMessage("__MSG_button_error_Cancel__"),
+        retry: chrome.i18n.getMessage("__MSG_button_error_Retry__"),
+        help: chrome.i18n.getMessage("__MSG_button_Help__"),
+        remove: chrome.i18n.getMessage("__MSG_button_Remove__"),
+        skip: chrome.i18n.getMessage("__MSG_button_error_Skip__"),
+        addToLibrary: chrome.i18n.getMessage("__MSG_button_Add_to_Library__")
+    };
+    
+    
+    // Error messages
+    static Error = {
+        noParserFound: chrome.i18n.getMessage("noParserFound"),
+        noChaptersFound: chrome.i18n.getMessage("noChaptersFound"),
+        noChaptersFoundAndFetchClicked: chrome.i18n.getMessage("noChaptersFoundAndFetchClicked"),
+        noImagesFound: chrome.i18n.getMessage("noImagesFound"),
+        unhandledFieldTypeError: chrome.i18n.getMessage("unhandledFieldTypeError"),
+        errorContentNotFound: (url) => chrome.i18n.getMessage("errorContentNotFound", [url]),
+        errorIllegalFileName: (filename, illegalChars) => chrome.i18n.getMessage("errorIllegalFileName", [filename, illegalChars]),
+        errorEditMetadata: chrome.i18n.getMessage("errorEditMetadata"),
+        errorAddToLibraryLibraryAddPageWithChapters: chrome.i18n.getMessage("errorAddToLibraryLibraryAddPageWithChapters"),
+        htmlFetchFailed: (url, error) => chrome.i18n.getMessage("htmlFetchFailed", [url, error]),
+        imageFetchFailed: (url, parentUrl, error) => chrome.i18n.getMessage("imageFetchFailed", [url, parentUrl, error]),
+        imgurFetchFailed: (url, parentUrl, error) => chrome.i18n.getMessage("imgurFetchFailed", [url, parentUrl, error]),
+        gotHtmlExpectedImageWarning: (url) => chrome.i18n.getMessage("gotHtmlExpectedImageWarning", [url]),
+        convertToXhtmlWarning: (filename, url, errorMessage) => chrome.i18n.getMessage("convertToXhtmlWarning", [filename, url, errorMessage])
+    };
+    
+    // Warning messages
+    static Warning = {
+        warningNoChapterUrl: chrome.i18n.getMessage("warningNoChapterUrl"),
+        warningNoVisibleContent: (url) => chrome.i18n.getMessage("warningNoVisibleContent", [url]),
+        warning403ErrorResponse: (hostname) => chrome.i18n.getMessage("warning403ErrorResponse", [hostname]),
+        warning429ErrorResponse: (hostname) => chrome.i18n.getMessage("warning429ErrorResponse", [hostname]),
+        warningParserDisabledComradeMao: chrome.i18n.getMessage("warningParserDisabledComradeMao"),
+        parserDisabledNotification: chrome.i18n.getMessage("parserDisabledNotification"),
+        httpFetchCanRetry: chrome.i18n.getMessage("httpFetchCanRetry"),
+        warningWebpImage: (relativeHref) => chrome.i18n.getMessage("warningWebpImage", [relativeHref])
+    };
+
+    // Default/Placeholder text
+    static Default = {
+        uuid: chrome.i18n.getMessage("defaultUUID"),
+        title: chrome.i18n.getMessage("defaultTitle"),
+        author: chrome.i18n.getMessage("defaultAuthor"),
+        chapterPlaceholderMessage: (title, url) => chrome.i18n.getMessage("chapterPlaceholderMessage", [title, url]),
+        informationPageTitle: chrome.i18n.getMessage("informationPageTitle"),
+        tableOfContentsUrl: chrome.i18n.getMessage("tableOfContentsUrl")
+    };
+
+    // Cover image related text
+    static CoverImage = {
+        noImagesFoundLabel: chrome.i18n.getMessage("noImagesFoundLabel"),
+        setCover: chrome.i18n.getMessage("setCover")
+    };
+
+    // HTTP Client specific messages
+    static HttpClient = {
+        makeFailCanRetryMessage: chrome.i18n.getMessage("httpFetchCanRetry")
+    };
+
+    // Utility method for localizing UI elements
+    static localizeElement(element) {
+        let localized = chrome.i18n.getMessage(element.textContent.trim());
+        if (localized && localized !== element.textContent.trim()) {
+            element.textContent = localized;
+        }
+    }
+}

--- a/plugin/js/UIText.js
+++ b/plugin/js/UIText.js
@@ -111,8 +111,9 @@ class UIText { // eslint-disable-line no-unused-vars
 
     // Utility method for localizing UI elements
     static localizeElement(element) {
-        let localized = chrome.i18n.getMessage(element.textContent.trim());
-        if (localized && localized !== element.textContent.trim()) {
+        let key = element.textContent.trim();
+        let localized = chrome.i18n.getMessage(key);
+        if (!util.isNullOrEmpty(localized) && localized !== key) {
             element.textContent = localized;
         }
     }

--- a/plugin/js/main.js
+++ b/plugin/js/main.js
@@ -95,7 +95,7 @@ var main = (function() {
         if (util.isTextInputField(element) || util.isTextAreaField(element)) {
             element.value = (value == null) ? "" : value;
         } else {
-            throw new Error(chrome.i18n.getMessage("unhandledFieldTypeError"));
+            throw new Error(UIText.Error.unhandledFieldTypeError);
         }
     }
 
@@ -126,7 +126,7 @@ var main = (function() {
         if (util.isTextInputField(element) || util.isTextAreaField(element)) {
             return (element.value === "") ? null : element.value;
         } else {
-            throw new Error(chrome.i18n.getMessage("unhandledFieldTypeError"));
+            throw new Error(UIText.Error.unhandledFieldTypeError);
         }
     }
 
@@ -140,7 +140,7 @@ var main = (function() {
 
         if ("yes" == libclick.dataset.libclick) {
             if (document.getElementById("chaptersPageInChapterListCheckbox").checked) {
-                ErrorLog.showErrorMessage(chrome.i18n.getMessage("errorAddToLibraryLibraryAddPageWithChapters"));
+                ErrorLog.showErrorMessage(UIText.Error.errorAddToLibraryLibraryAddPageWithChapters);
                 return;
             }
         }
@@ -289,7 +289,7 @@ var main = (function() {
             parser = parserFactory.manuallySelectParser(manualSelect);
         }
         if (parser === undefined) {
-            ErrorLog.showErrorMessage(chrome.i18n.getMessage("noParserFound"));
+            ErrorLog.showErrorMessage(UIText.Error.noParserFound);
             return false;
         }
         getLoadAndAnalyseButton().hidden = true;
@@ -414,20 +414,12 @@ var main = (function() {
         document.getElementById("manuallySelectParserTag").selectedIndex = -1;
     }
 
-    function localize(element) {
-        let localized = chrome.i18n.getMessage(element.textContent.trim());
-        if (!util.isNullOrEmpty(localized)) {
-            element.innerText = localized;
-        }
-    }
-
-    function localizeHtmlPage()
-    {
+    function localizeHtmlPage() {
         // can't use a single select, because there are buttons in td elements
         for (let selector of ["button, option", "td, th", ".i18n"]) {
             for (let element of [...document.querySelectorAll(selector)]) {
                 if (element.textContent.startsWith("__MSG_")) {
-                    localize(element);
+                    UIText.localizeElement(element);
                 }
             }
         }

--- a/plugin/js/parsers/BakaTsukiParser.js
+++ b/plugin/js/parsers/BakaTsukiParser.js
@@ -393,7 +393,7 @@ class BakaTsukiParser extends Parser {
 
     onFetchImagesClicked() {
         if (0 == this.imageCollector.imageInfoList.length) {
-            ErrorLog.showErrorMessage(chrome.i18n.getMessage("noImagesFound"));
+            ErrorLog.showErrorMessage(UIText.Error.noImagesFound);
         } else {
             this.fetchContent();
         }

--- a/plugin/js/parsers/Brittanypage43Parser.js
+++ b/plugin/js/parsers/Brittanypage43Parser.js
@@ -8,7 +8,7 @@ class Brittanypage43Parser extends Parser {
     }
 
     disabled() {
-        return chrome.i18n.getMessage("parserDisabledNotification");
+        return UIText.Warning.parserDisabledNotification;
     }
     
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/ComrademaoParser.js
+++ b/plugin/js/parsers/ComrademaoParser.js
@@ -9,7 +9,7 @@ class ComrademaoParser extends Parser {
     }
 
     disabled() {
-        return chrome.i18n.getMessage("parserDisabledNotification");
+        return UIText.Warning.parserDisabledNotification;
     }
 
     populateUIImpl() {

--- a/plugin/js/parsers/MtlnationParser.js
+++ b/plugin/js/parsers/MtlnationParser.js
@@ -8,7 +8,7 @@ class MtlnationParser extends MadaraParser {
     }
 
     disabled() {
-        return chrome.i18n.getMessage("parserDisabledNotification");
+        return UIText.Warning.parserDisabledNotification;
     }
 
     findContent(dom) {

--- a/plugin/js/parsers/ReadLightNovelParser.js
+++ b/plugin/js/parsers/ReadLightNovelParser.js
@@ -22,7 +22,7 @@ class ReadLightNovelParser extends Parser {
             return Promise.resolve(chapters);
         }
         else {
-            return Promise.reject(new Error(chrome.i18n.getMessage("noChaptersFound")));
+            return Promise.reject(new Error(UIText.Error.noChaptersFound));
         }
     }
 

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -551,6 +551,7 @@
 
     <span id="scriptContainer">
         <!-- scripts go here -->
+        <script src="js/UIText.js"></script>
         <script src="js/ReadingList.js"></script>
         <script src="js/UserPreferences.js"></script>
         <script src="js/EpubMetaInfo.js"></script>

--- a/unitTest/Tests.html
+++ b/unitTest/Tests.html
@@ -18,6 +18,7 @@
     <script src="TestUtils.js"></script>
     <script src="../plugin/js/ReadingList.js"></script>
     <script src="../plugin/js/UserPreferences.js"></script>
+    <script src="../plugin/js/UIText.js"></script>
     <script src="../plugin/js/EpubMetaInfo.js"></script>
     <script src="../plugin/js/ErrorLog.js"></script>
     <script src="../plugin/js/Util.js"></script>


### PR DESCRIPTION
Why do this?

- All the chrome.i18n.getMessage calls in a one place make it easier to find and update messages (IDE renaming can auto find all uses of a property, in js files at least)
- Less likely to typo any given string/key (more benefit if the same text is used multiple times)
- Auto-complete works elsewhere in the code with the text as properties
- Code is slightly more readable
- My personal versions of WebToEpub have a lot more UI features and the increased amount of UI text made me make this change in the first place. So doing it here too reduces diffs for me when I rebase on latest changes or break things up into PRs