### PR TITLE
Added options for image compression

### DIFF
--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -255,8 +255,12 @@
 		"message": "Compress Images",
 		"description": "Label for checkbox and value to compress images to a certain size"
 	},
+	"__MSG_label_Compress_Images_Format__": {
+		"message": "Compressed Image Format",
+		"description": "Label for mime type of compressed image"
+	},
 	"__MSG_label_Compress_Images_Resolution__": {
-		"message": "Resolution",
+		"message": "Compressed Resolution",
 		"description": "Label for number input for maximum dimension size of pixel height or width in image"
 	},
 	"__MSG_label_Cover_from_URL__": {
@@ -554,6 +558,10 @@
 	"__MSG_Searching_For_URLs_Please_Wait__": {
 		"message": "Searching for URLs.  Please wait.",
 		"description": "Message shown while looking for list of Chapter URLs."
+	},
+	"__MSG_option_value_auto__": {
+		"message": "auto",
+		"description": "Generic option text for 'automatic'"
 	},
 	"__MSG_Shift_Click__": {
 		"message": "You can select or unselect a range of chapters by clicking on the checkbox for the first chapter, then  hold down the shift key and click the last chapter in the range.",

--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -255,6 +255,10 @@
 		"message": "Compress Images",
 		"description": "Label for checkbox and value to compress images to a certain size"
 	},
+	"__MSG_label_Compress_Images_JPG_Cover__": {
+		"message": "Restrict Cover Image to JPEG",
+		"description": "Label for JPEG cover restriction checkbox"
+	},
 	"__MSG_label_Compress_Images_Format__": {
 		"message": "Compressed Image Format",
 		"description": "Label for mime type of compressed image"

--- a/plugin/js/ImageCollector.js
+++ b/plugin/js/ImageCollector.js
@@ -326,6 +326,9 @@ class ImageCollector {
             {
                 let outputType = "image/jpeg";
                 switch (this.userPreferences.compressImagesType.value) {
+                    case "auto":
+                        outputType = util.detectMimeType(imageInfo.getBase64(25));
+                        break;
                     case "webp":
                         outputType = "image/webp";
                         break;

--- a/plugin/js/ImageCollector.js
+++ b/plugin/js/ImageCollector.js
@@ -324,6 +324,19 @@ class ImageCollector {
         return new Promise((resolve, reject) => {
             if (this.userPreferences.compressImages.value) 
             {
+                let outputType = "image/jpeg";
+                switch (this.userPreferences.compressImagesType.value) {
+                    case "webp":
+                        outputType = "image/webp";
+                        break;
+                    case "png":
+                        outputType = "image/png";
+                        break;
+                    case "jpg":
+                    default:
+                        outputType = "image/jpeg";
+                        break;
+                }
                 let c = document.createElement("canvas");
                 let ctx = c.getContext("2d");
                 let maxResolution = this.userPreferences.compressImagesMaxResolution.value;            
@@ -350,13 +363,13 @@ class ImageCollector {
                     try {
                         imageInfo.height = c.height;
                         imageInfo.width = c.width;
-                        imageInfo.mediaType = "image/jpeg";
+                        imageInfo.mediaType = outputType;
                         imageInfo.arraybuffer = await cBlob.arrayBuffer();
                         resolve();
                     } catch (e) {
                         reject();
                     }
-                }, "image/jpeg", 0.9);
+                }, outputType, 0.9);
             }
             else
             {

--- a/plugin/js/ImageCollector.js
+++ b/plugin/js/ImageCollector.js
@@ -340,6 +340,11 @@ class ImageCollector {
                         outputType = "image/jpeg";
                         break;
                 }
+
+                if (imageInfo.isCover && this.userPreferences.compressImagesJpgCover.value)
+                {
+                    outputType = "image/jpeg";
+                }
                 let c = document.createElement("canvas");
                 let ctx = c.getContext("2d");
                 let maxResolution = this.userPreferences.compressImagesMaxResolution.value;            

--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -101,7 +101,6 @@ class RadioUserPreference extends UserPreference {
     }
 
     readFromUi() {
-        console.log(this.getSelected().value);
         this.value = this.getSelected().value;
     }
 
@@ -150,7 +149,7 @@ class UserPreferences { // eslint-disable-line no-unused-vars
         this.overrideMinimumDelay = this.addPreference("overrideMinimumDelay", "overrideMinimumDelayCheckbox", false);
         this.skipImages = this.addPreference("skipImages", "skipImagesCheckbox", false);
         this.compressImages = this.addPreference("compressImages", "compressImagesCheckbox", false);
-        this.compressImagesType = this.addPreference("compressImagesType", "compressImagesTypeGroup", "jpg");
+        this.compressImagesType = this.addPreferenceRadio("compressImagesType", "compressImagesTypeGroup", "jpg");
         this.compressImagesMaxResolution = this.addPreference("compressImagesMaxResolution", "compressImagesMaxResolutionTag", "1080");
         this.overwriteExistingEpub = this.addPreference("overwriteExistingEpub", "overwriteEpubWhenDuplicateFilenameCheckbox", false);
         this.themeColor = this.addPreference("themeColor", "themeColorTag", "");
@@ -173,16 +172,20 @@ class UserPreferences { // eslint-disable-line no-unused-vars
     /** @private */
     addPreference(storageName, uiElementName, defaultValue) {
         let preference = null;
-        if (uiElementName.indexOf("Group") >= 0)
-        {
-            preference = new RadioUserPreference(storageName, uiElementName, defaultValue);
-        } else if (typeof(defaultValue) === "boolean") {
+        if (typeof(defaultValue) === "boolean") {
             preference = new BoolUserPreference(storageName, uiElementName, defaultValue);
         } else if (typeof(defaultValue) === "string") {
             preference = new StringUserPreference(storageName, uiElementName, defaultValue);
         } else {
             throw new Error("Unknown preference type");
         }
+        this.preferences.push(preference);
+        return preference;
+    }
+
+    /** @private */
+    addPreferenceRadio(storageName, uiElementName, defaultValue) {
+        let preference = new RadioUserPreference(storageName, uiElementName, defaultValue);
         this.preferences.push(preference);
         return preference;
     }

--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -149,7 +149,7 @@ class UserPreferences { // eslint-disable-line no-unused-vars
         this.overrideMinimumDelay = this.addPreference("overrideMinimumDelay", "overrideMinimumDelayCheckbox", false);
         this.skipImages = this.addPreference("skipImages", "skipImagesCheckbox", false);
         this.compressImages = this.addPreference("compressImages", "compressImagesCheckbox", false);
-        this.compressImagesType = this.addPreferenceRadio("compressImagesType", "compressImagesTypeGroup", "jpg");
+        this.compressImagesType = this.addPreference("compressImagesType", "compressImagesType", "jpg");
         this.compressImagesMaxResolution = this.addPreference("compressImagesMaxResolution", "compressImagesMaxResolutionTag", "1080");
         this.overwriteExistingEpub = this.addPreference("overwriteExistingEpub", "overwriteEpubWhenDuplicateFilenameCheckbox", false);
         this.themeColor = this.addPreference("themeColor", "themeColorTag", "");
@@ -179,13 +179,6 @@ class UserPreferences { // eslint-disable-line no-unused-vars
         } else {
             throw new Error("Unknown preference type");
         }
-        this.preferences.push(preference);
-        return preference;
-    }
-
-    /** @private */
-    addPreferenceRadio(storageName, uiElementName, defaultValue) {
-        let preference = new RadioUserPreference(storageName, uiElementName, defaultValue);
         this.preferences.push(preference);
         return preference;
     }

--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -150,7 +150,7 @@ class UserPreferences { // eslint-disable-line no-unused-vars
         this.overrideMinimumDelay = this.addPreference("overrideMinimumDelay", "overrideMinimumDelayCheckbox", false);
         this.skipImages = this.addPreference("skipImages", "skipImagesCheckbox", false);
         this.compressImages = this.addPreference("compressImages", "compressImagesCheckbox", false);
-        this.compressImagesType = this.addPreference("compressImagesType", "compressImagesTypeGroup", "jpg")
+        this.compressImagesType = this.addPreference("compressImagesType", "compressImagesTypeGroup", "jpg");
         this.compressImagesMaxResolution = this.addPreference("compressImagesMaxResolution", "compressImagesMaxResolutionTag", "1080");
         this.overwriteExistingEpub = this.addPreference("overwriteExistingEpub", "overwriteEpubWhenDuplicateFilenameCheckbox", false);
         this.themeColor = this.addPreference("themeColor", "themeColorTag", "");

--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -110,6 +110,7 @@ class UserPreferences { // eslint-disable-line no-unused-vars
         this.overrideMinimumDelay = this.addPreference("overrideMinimumDelay", "overrideMinimumDelayCheckbox", false);
         this.skipImages = this.addPreference("skipImages", "skipImagesCheckbox", false);
         this.compressImages = this.addPreference("compressImages", "compressImagesCheckbox", false);
+        this.compressImagesJpgCover = this.addPreference("compressImagesJpgCover", "compressImagesJpgCoverCheckbox", false);
         this.compressImagesType = this.addPreference("compressImagesType", "compressImagesType", "jpg");
         this.compressImagesMaxResolution = this.addPreference("compressImagesMaxResolution", "compressImagesMaxResolutionTag", "1080");
         this.overwriteExistingEpub = this.addPreference("overwriteExistingEpub", "overwriteEpubWhenDuplicateFilenameCheckbox", false);

--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -76,45 +76,6 @@ class StringUserPreference extends UserPreference {
     }
 }
 
-class RadioUserPreference extends UserPreference {
-    commonSelector = null;
-    constructor(storageName, uiElementName, defaultValue) {
-        super(storageName, uiElementName, defaultValue);
-        this.commonSelector = `[name="${this.uiElementName}"]`;
-    }
-
-    getUiElements() {
-        return document.querySelectorAll(this.commonSelector);
-    }
-    getUiElement() {
-        return document.querySelector(`${this.commonSelector}[value="${this.value}"]`) || document.querySelector(`${this.commonSelector}[value="${this.defaultValue}"]`);
-    }
-    getSelected() {
-        return document.querySelector(`${this.commonSelector}:checked`);
-    }
-
-    readFromLocalStorage() {
-        let test = window.localStorage.getItem(this.storageName);
-        if (test !== null) {
-            this.value = test;
-        }
-    }
-
-    readFromUi() {
-        this.value = this.getSelected().value;
-    }
-
-    writeToUi() {
-        this.getUiElement().checked = true;
-    }
-
-    hookupUi(readFromUi) {
-        this.getUiElements().forEach(item => {
-            item.onclick = readFromUi;
-        });
-    }
-}
-
 /** The collection of all preferences for user  */
 class UserPreferences { // eslint-disable-line no-unused-vars
     constructor() {

--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -76,6 +76,46 @@ class StringUserPreference extends UserPreference {
     }
 }
 
+class RadioUserPreference extends UserPreference {
+    commonSelector = null;
+    constructor(storageName, uiElementName, defaultValue) {
+        super(storageName, uiElementName, defaultValue);
+        this.commonSelector = `[name="${this.uiElementName}"]`;
+    }
+
+    getUiElements() {
+        return document.querySelectorAll(this.commonSelector);
+    }
+    getUiElement() {
+        return document.querySelector(`${this.commonSelector}[value="${this.value}"]`) || document.querySelector(`${this.commonSelector}[value="${this.defaultValue}"]`);
+    }
+    getSelected() {
+        return document.querySelector(`${this.commonSelector}:checked`);
+    }
+
+    readFromLocalStorage() {
+        let test = window.localStorage.getItem(this.storageName);
+        if (test !== null) {
+            this.value = test;
+        }
+    }
+
+    readFromUi() {
+        console.log(this.getSelected().value);
+        this.value = this.getSelected().value;
+    }
+
+    writeToUi() {
+        this.getUiElement().checked = true;
+    }
+
+    hookupUi(readFromUi) {
+        this.getUiElements().forEach(item => {
+            item.onclick = readFromUi;
+        });
+    }
+}
+
 /** The collection of all preferences for user  */
 class UserPreferences { // eslint-disable-line no-unused-vars
     constructor() {
@@ -110,6 +150,7 @@ class UserPreferences { // eslint-disable-line no-unused-vars
         this.overrideMinimumDelay = this.addPreference("overrideMinimumDelay", "overrideMinimumDelayCheckbox", false);
         this.skipImages = this.addPreference("skipImages", "skipImagesCheckbox", false);
         this.compressImages = this.addPreference("compressImages", "compressImagesCheckbox", false);
+        this.compressImagesType = this.addPreference("compressImagesType", "compressImagesTypeGroup", "jpg")
         this.compressImagesMaxResolution = this.addPreference("compressImagesMaxResolution", "compressImagesMaxResolutionTag", "1080");
         this.overwriteExistingEpub = this.addPreference("overwriteExistingEpub", "overwriteEpubWhenDuplicateFilenameCheckbox", false);
         this.themeColor = this.addPreference("themeColor", "themeColorTag", "");
@@ -132,7 +173,10 @@ class UserPreferences { // eslint-disable-line no-unused-vars
     /** @private */
     addPreference(storageName, uiElementName, defaultValue) {
         let preference = null;
-        if (typeof(defaultValue) === "boolean") {
+        if (uiElementName.indexOf("Group") >= 0)
+        {
+            preference = new RadioUserPreference(storageName, uiElementName, defaultValue);
+        } else if (typeof(defaultValue) === "boolean") {
             preference = new BoolUserPreference(storageName, uiElementName, defaultValue);
         } else if (typeof(defaultValue) === "string") {
             preference = new StringUserPreference(storageName, uiElementName, defaultValue);

--- a/plugin/js/Util.js
+++ b/plugin/js/Util.js
@@ -1047,8 +1047,9 @@ const util = (function() {
         return retval;
     }
     function detectMimeType(b64) {
+        let b64b = atob(b64);
         for (var s in MIME_TYPE_SIGNATURES) {
-            if (b64.indexOf(s) === 0) {
+            if (b64b.indexOf(atob(s)) === 0) {
                 return MIME_TYPE_SIGNATURES[s][0];
             }
         }

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -349,6 +349,7 @@
                             <table>
                                 <tr>
                                     <td style="width: 70px; padding-right: 20px;">__MSG_label_Compress_Images_Resolution__</td>
+                                    <td>auto</td>
                                     <td>jpg</td>
                                     <td>webp</td>
                                     <td>png</td>
@@ -357,6 +358,9 @@
                                 <tr>
                                     <td>
                                         <input id="compressImagesMaxResolutionTag" type="number" name="compressImagesMaxResolutionTag" style="width: 61px;" value="1080" min="100">
+                                    </td>
+                                    <td>
+                                        <input type="radio" id="compressImagesTypeGroupAuto" name="compressImagesTypeGroup" value="auto">
                                     </td>
                                     <td>
                                         <input type="radio" id="compressImagesTypeGroupJpg" name="compressImagesTypeGroup" value="jpg">

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -340,7 +340,7 @@
                         <td>__MSG_label_Fetch_Highest_Resolution_Images__</td>
                     </tr>
                     <tr id="compressImagesRow">
-                        <td style="vertical-align: top;"><input id="compressImagesCheckbox" type="checkbox" name="compressImagesCheckbox" value="false"></td>
+                        <td><input id="compressImagesCheckbox" type="checkbox" name="compressImagesCheckbox" value="false"></td>
                         <td>__MSG_label_Compress_Images__</td>
                     </tr>
                     <tr>
@@ -363,6 +363,12 @@
                                     </select>
                                 </td>
                                 <td>__MSG_label_Compress_Images_Format__</td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <input id="compressImagesJpgCoverCheckbox" type="checkbox" name="compressImagesJpgCover" value="false">
+                                </td>
+                                <td>__MSG_label_Compress_Images_JPG_Cover__</td>
                             </tr>
                         </table>
                     </td>

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -340,40 +340,32 @@
                         <td>__MSG_label_Fetch_Highest_Resolution_Images__</td>
                     </tr>
                     <tr id="compressImagesRow">
-                        <td><input id="compressImagesCheckbox" type="checkbox" name="compressImagesCheckbox" value="false"></td>
+                        <td style="vertical-align: top;"><input id="compressImagesCheckbox" type="checkbox" name="compressImagesCheckbox" value="false"></td>
                         <td>__MSG_label_Compress_Images__</td>
                     </tr>
                     <tr>
-                        <td></td>
-                        <td>
-                            <table>
-                                <tr>
-                                    <td style="width: 70px; padding-right: 20px;">__MSG_label_Compress_Images_Resolution__</td>
-                                    <td>auto</td>
-                                    <td>jpg</td>
-                                    <td>webp</td>
-                                    <td>png</td>
-                                    <td style="width: 90%;"></td>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <input id="compressImagesMaxResolutionTag" type="number" name="compressImagesMaxResolutionTag" style="width: 61px;" value="1080" min="100">
-                                    </td>
-                                    <td>
-                                        <input type="radio" id="compressImagesTypeGroupAuto" name="compressImagesTypeGroup" value="auto">
-                                    </td>
-                                    <td>
-                                        <input type="radio" id="compressImagesTypeGroupJpg" name="compressImagesTypeGroup" value="jpg">
-                                    </td>
-                                    <td>
-                                        <input type="radio" id="compressImagesTypeGroupWebp" name="compressImagesTypeGroup" value="webp">
-                                    </td>
-                                    <td>
-                                        <input type="radio" id="compressImagesTypeGroupPng" name="compressImagesTypeGroup" value="png">
-                                    </td>
-                                </tr>
-                            </table>
-                        </td>
+                    <td></td>
+                    <td>
+                        <table>
+                            <tr>
+                                <td>
+                                    <input id="compressImagesMaxResolutionTag" type="number" name="compressImagesMaxResolutionTag" style="width: 61px;" value="1080" min="100">
+                                </td>
+                                <td>__MSG_label_Compress_Images_Resolution__</td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <select id="compressImagesType" name="compressImagesType">
+                                        <option value="auto">__MSG_option_value_auto__</option>
+                                        <option value="jpg">jpg</option>
+                                        <option value="webp">webp</option>
+                                        <option value="png">png</option>
+                                    </select>
+                                </td>
+                                <td>__MSG_label_Compress_Images_Format__</td>
+                            </tr>
+                        </table>
+                    </td>
                     </tr>
                     <tr id="unSuperScriptAlternateTranslations" hidden="true">
                         <td><input id="unSuperScriptCheckboxInput" type="checkbox" name="unSuperScriptCheckboxInput" value="true"></td>

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -341,19 +341,35 @@
                     </tr>
                     <tr id="compressImagesRow">
                         <td><input id="compressImagesCheckbox" type="checkbox" name="compressImagesCheckbox" value="false"></td>
+                        <td>__MSG_label_Compress_Images__</td>
+                    </tr>
+                    <tr>
+                        <td></td>
                         <td>
                             <table>
                                 <tr>
-                                    <td>__MSG_label_Compress_Images__</td>
+                                    <td style="width: 70px; padding-right: 20px;">__MSG_label_Compress_Images_Resolution__</td>
+                                    <td>jpg</td>
+                                    <td>webp</td>
+                                    <td>png</td>
+                                    <td style="width: 90%;"></td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <input id="compressImagesMaxResolutionTag" type="number" name="compressImagesMaxResolutionTag" style="width: 61px;" value="1080" min="100">
+                                    </td>
+                                    <td>
+                                        <input type="radio" id="compressImagesTypeGroupJpg" name="compressImagesTypeGroup" value="jpg">
+                                    </td>
+                                    <td>
+                                        <input type="radio" id="compressImagesTypeGroupWebp" name="compressImagesTypeGroup" value="webp">
+                                    </td>
+                                    <td>
+                                        <input type="radio" id="compressImagesTypeGroupPng" name="compressImagesTypeGroup" value="png">
+                                    </td>
                                 </tr>
                             </table>
                         </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <input id="compressImagesMaxResolutionTag" type="number" name="compressImagesMaxResolutionTag" style="width: 61px;" value="1080" min="100">
-                        </td>
-                        <td>__MSG_label_Compress_Images_Resolution__</td>
                     </tr>
                     <tr id="unSuperScriptAlternateTranslations" hidden="true">
                         <td><input id="unSuperScriptCheckboxInput" type="checkbox" name="unSuperScriptCheckboxInput" value="true"></td>


### PR DESCRIPTION
Turns out webp averages around 30% better compression than jpeg - who knew?
- Added webp and png options for compression (Note, png may result in larger files despite compressed resolution)
- Added 'radio button'/group logic for user preferences

Not entirely sure if this is the path we'd want to go with for the 'grouped' logic for radiobuttons; basing it off the name could trigger issues, but it works in a fundamentally different way. Best alternative is to create a second "addPreference" for grouped items - perhaps "addPreferenceGroup" or fall back on a select box.