### PR TITLE
Remove conflicting "tongrenshe.cc" Url from TrxsParser

### DIFF
--- a/plugin/js/parsers/TrxsParser.js
+++ b/plugin/js/parsers/TrxsParser.js
@@ -1,7 +1,6 @@
 "use strict";
 
 parserFactory.register("trxs.cc", () => new TrxsParser());
-parserFactory.register("tongrenshe.cc", () => new TrxsParser());
 
 class TrxsParser extends Parser {
     constructor() {


### PR DESCRIPTION
Removed the "tongrenshe.cc" URL from the TrxsParser.

When testing the new dev build, I found out that because TongrensheParser and TrxsParser registered to the same URL, they entered into conflict, leading to a bug.

This should fix this. Next time, I'll remember to sync with the ExperimentalTabMode branch before testing and submitting a pull request. My bad.

Error message:
"can't access lexical declaration 'TrxsParser' before initialization @moz-extension://904fb8f1-8dba-451b-b06d-f0f5a415a565/js/parsers/TrxsParser.js:3:41
fetchByUrl@moz-extension://904fb8f1-8dba-451b-b06d-f0f5a415a565/js/ParserFactory.js:77:20
fetch@moz-extension://904fb8f1-8dba-451b-b06d-f0f5a415a565/js/ParserFactory.js:90:27
setParser@moz-extension://904fb8f1-8dba-451b-b06d-f0f5a415a565/js/main.js:287:36
processInitialHtml@moz-extension://904fb8f1-8dba-451b-b06d-f0f5a415a565/js/main.js:40:22
populateControlsWithDom@moz-extension://904fb8f1-8dba-451b-b06d-f0f5a415a565/js/main.js:278:15
onLoadAndAnalyseButtonClick/main<@moz-extension://904fb8f1-8dba-451b-b06d-f0f5a415a565/js/main.js:372:19
promise callback*onLoadAndAnalyseButtonClick@moz-extension://904fb8f1-8dba-451b-b06d-f0f5a415a565/js/main.js:371:42
EventHandlerNonNull*addEventHandlers@moz-extension://904fb8f1-8dba-451b-b06d-f0f5a415a565/js/main.js:537:9
window.onload@moz-extension://904fb8f1-8dba-451b-b06d-f0f5a415a565/js/main.js:623:13
EventHandlerNonNull*main<@moz-extension://904fb8f1-8dba-451b-b06d-f0f5a415a565/js/main.js:616:5
@moz-extension://904fb8f1-8dba-451b-b06d-f0f5a415a565/js/main.js:640:3"