### PR TITLE
Add UaaParser

### DIFF
--- a/plugin/js/parsers/UaaParser.js
+++ b/plugin/js/parsers/UaaParser.js
@@ -1,0 +1,54 @@
+"use strict";
+
+parserFactory.register("uaa.com", () => new UaaParser());
+
+class UaaParser extends Parser {
+    constructor() {
+        super();
+
+        this.minimumThrottle = 3000; //Might not be necessary, but keeping it just to be safe.
+    }
+
+    async getChapterUrls(dom) {
+        let menu = dom.querySelector(".catalog_ul");
+        return util.hyperlinksToChapterList(menu);
+    }
+
+    findContent(dom) {
+        return dom.querySelector(".article");
+    }
+
+    removeUnwantedElementsFromContentElement(element) {
+        util.removeChildElementsMatchingSelector(element, ".dizhi");
+        super.removeUnwantedElementsFromContentElement(element);
+    }
+
+    findChapterTitle(dom) {
+        return dom.querySelector(".title_box h2");
+    }
+
+    findCoverImageUrl(dom) {
+        return util.getFirstImgSrc(dom, ".cover"); // Cover Image is hidden being an API call. 
+    }
+
+    extractLanguage(dom) {
+        return dom.querySelector("html").getAttribute("lang");
+    }
+
+    extractTitleImpl(dom) {
+        return dom.querySelector(".info_box > h1");
+    }
+
+    extractAuthor(dom) {
+        let authorLabel = dom.querySelector(".info_box > div:nth-child(4) > a:nth-child(1)");
+        return authorLabel?.textContent ?? super.extractAuthor(dom);
+    }
+
+    extractDescription(dom) {
+        return dom.querySelector("div.txt").textContent.trim();
+    }
+
+    getInformationEpubItemChildNodes(dom) {
+        return [...dom.querySelectorAll(".detail_box")];
+    }
+}

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -904,6 +904,7 @@
         <script src="js/parsers/TruyenParser.js"></script>
         <script src="js/parsers/TrxsParser.js"></script>
         <script src="js/parsers/TumblrParser.js"></script>
+        <script src="js/parsers/UaaParser.js"></script>
         <script src="js/parsers/UltimaguilParser.js"></script>
         <script src="js/parsers/UnlimitedNovelFailuresParser.js"></script>
         <script src="js/parsers/UntamedAlleyParser.js"></script>


### PR DESCRIPTION
Added new parser for [www.uaa.com](https://www.uaa.com/novel/list)

Tested on free and member tier novels chapters, untested on unlocked paid novels chapters.

The website has three chapter tiers, free (游客), member (注册会员), and paid (? U币).
You need an account to get the content of a member chapter, and you can only read 50 chapters per day.

The tier of a chapter is stored in a span beside the chapter link.

I couldn't get the cover image to work as it's behind an API.
And I couldn't get the content of comics, as all images are behind the same API as the cover.