### PR TITLE
Fix NCX Id and OPF Id Descrepancy for Epub 3 Generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     { "name": "basitcodeenv"},
     { "name": "X-Xadro"},
     { "name": "Yomafil"},
-    { "name": "Varun Patkar", "email": "varunpatkar501@gmail.com" }
+    { "name": "Varun Patkar", "email": "varunpatkar501@gmail.com" },
+    { "name": "Peter Kaufman", "email": "PeterJamesKaufman@gmail.com" }
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/js/EpubPacker.js
+++ b/plugin/js/EpubPacker.js
@@ -274,7 +274,7 @@ class EpubPacker {
     }
 
     populateHead(head, ns, depth) {
-        this.appendMetaContent(head, ns, "dtb:uid", this.metaInfo.uuid);
+        this.appendMetaContent(head, ns, "dtb:uid", (this.version === EpubPacker.EPUB_VERSION_3 ? "uri:" : "") + this.metaInfo.uuid);
         this.appendMetaContent(head, ns, "dtb:depth", (depth < 2) ? "2" : depth);
         this.appendMetaContent(head, ns, "dtb:totalPageCount", "0");
         this.appendMetaContent(head, ns, "dtb:maxPageNumber", "0");

--- a/readme.md
+++ b/readme.md
@@ -802,6 +802,7 @@ Don't forget to give the project a star! Thanks again!
     <li>X-Xadro</li>
     <li>Yomafil</li>
     <li>Varun Patkar</li>
+    <li>Peter Kaufman</li>
   </ul>
 </details>
 


### PR DESCRIPTION
When creating an epub version 3, we prefix the epub's OPF id with `uri:` as per the logic [here](https://github.com/dteviot/WebToEpub/blob/2678b0e8c623e67a8cf119d90ee501570325a5a8/plugin/js/EpubPacker.js#L112-L114). However we don't currently do that for the NCX file. I am not sure if this is intentionally left out, but the EPUBCheck validator throws the following error for me locally when the file is generated:
``` bash
Validating using EPUB version 3.3 rules.
ERROR(NCX-001): ./Gosick.epub/OEBPS/toc.ncx(-1,-1): NCX identifier ("https://lightnovelstranslations.com/novel/gosick/?tab=table_contents&status=complete") does not match OPF identifier ("uri:https://lightnovelstranslations.com/novel/gosick/?tab=table_contents&status=complete").
ERROR(RSC-005): ./Gosick.epub/OEBPS/Text/Cover.xhtml(1,110): Error while parsing file: Element "title" must not be empty.

Check finished with errors
Messages: 0 fatals / 2 errors / 0 warnings / 0 infos

EPUBCheck completed
```

I can include the generated epub if that is helpful as well. Thanks for making this extension!

_Note that the second issue is a separate issue that seems to be specific to epub 3 as well, so I will ignore that for this PR._