### PR TITLE
Set Cover Page Title

### DIFF
--- a/plugin/js/EpubItemSupplier.js
+++ b/plugin/js/EpubItemSupplier.js
@@ -39,11 +39,16 @@ class EpubItemSupplier { // eslint-disable-line no-unused-vars
         }
     }
 
-    makeCoverImageXhtmlFile(emptyDocFactory) {
+    makeCoverImageXhtmlFile(emptyDocFactory, title) {
         let doc = emptyDocFactory();
         let body = doc.getElementsByTagName("body")[0];
         let userPreferences = this.imageCollector.userPreferences;
         body.appendChild(this.coverImageInfo.createImageElement(userPreferences));
+
+        if (title) {
+            doc.querySelector("title").text = title;
+        }
+
         return util.xmlToString(doc);
     }
 

--- a/plugin/js/EpubPacker.js
+++ b/plugin/js/EpubPacker.js
@@ -345,7 +345,8 @@ class EpubPacker {
             file.packInEpub(zipWriter, this.emptyDocFactory, this.contentValidator);
         }
         if (epubItemSupplier.hasCoverImageFile()) {
-            let fileContent = epubItemSupplier.makeCoverImageXhtmlFile(this.emptyDocFactory);
+            let coverFileDefaultTitle = this.version === EpubPacker.EPUB_VERSION_3 ? this.metaInfo.title : "";
+            let fileContent = epubItemSupplier.makeCoverImageXhtmlFile(this.emptyDocFactory, coverFileDefaultTitle);
             zipWriter.add(EpubPacker.coverImageXhtmlHref(), new zip.TextReader(fileContent));
         }
     }

--- a/plugin/js/EpubPacker.js
+++ b/plugin/js/EpubPacker.js
@@ -345,8 +345,7 @@ class EpubPacker {
             file.packInEpub(zipWriter, this.emptyDocFactory, this.contentValidator);
         }
         if (epubItemSupplier.hasCoverImageFile()) {
-            let coverFileDefaultTitle = this.version === EpubPacker.EPUB_VERSION_3 ? this.metaInfo.title : "";
-            let fileContent = epubItemSupplier.makeCoverImageXhtmlFile(this.emptyDocFactory, coverFileDefaultTitle);
+            let fileContent = epubItemSupplier.makeCoverImageXhtmlFile(this.emptyDocFactory, "Cover");
             zipWriter.add(EpubPacker.coverImageXhtmlHref(), new zip.TextReader(fileContent));
         }
     }


### PR DESCRIPTION
There is an EPUBCheck error that gets thrown when generating an epub 3 using Web to Epub. The error states:
```
Validating using EPUB version 3.3 rules.
ERROR(RSC-005): ./Gosick.epub/OEBPS/Text/Cover.xhtml(1,110): Error while parsing file: Element "title" must not be empty.

Check finished with errors
Messages: 0 fatals / 1 errors / 0 warnings / 0 infos

EPUBCheck completed
```

To fix this issue, we just need to set a title. I at first thought about hardcoding the value to `Cover`, but that would possibly need localization. So I instead implemented the logic using the user input title for the book. It is possible to use a hardcoded value if that is what works best for the project.