### PR TITLE
Update `LightNovelsTranslationsParser` to Include Author

### DIFF
--- a/plugin/js/parsers/LightNovelsTranslationsParser.js
+++ b/plugin/js/parsers/LightNovelsTranslationsParser.js
@@ -27,4 +27,13 @@ class LightNovelsTranslationsParser extends WordpressBaseParser {
     getInformationEpubItemChildNodes(dom) {
         return [...dom.querySelectorAll("div.novel_text")];
     }
+
+    extractAuthor(dom) {
+        const authorEl = dom.querySelector("div.novel_detail_info > ul > li:nth-child(1)");
+        if (authorEl) {
+            return authorEl.textContent.replace("Author: ", "");
+        }
+
+        return "<unknown>";
+    }
 }


### PR DESCRIPTION
Added logic to extract the author of the novel for Light Novels Translations and return `<unknown>` if one is not found.

It seems to work when there is an author and when there is not (I manually deleted the div with the novel info when testing that it worked when no author el was present). I used <https://lightnovelstranslations.com/novel/gosick/?tab=table_contents&status=complete> to test that it worked with an author.

We may want to also add a check that the content of the author after the replace is not empty before returning it. But I am not sure if this will happen. So I did not add the extra check for now.