### PR TITLE
Add `NovelsOnline.org` to NovelsOnline Parser and Extract Author

### DIFF
--- a/plugin/js/parsers/NovelsOnlineParser.js
+++ b/plugin/js/parsers/NovelsOnlineParser.js
@@ -1,6 +1,7 @@
 "use strict";
 
 parserFactory.register("novelsonline.net", () => new NovelsOnlineParser());
+parserFactory.register("novelsonline.org", () => new NovelsOnlineParser());
 
 class NovelsOnlineParser extends Parser {
     constructor() {

--- a/plugin/js/parsers/NovelsOnlineParser.js
+++ b/plugin/js/parsers/NovelsOnlineParser.js
@@ -47,7 +47,10 @@ class NovelsOnlineParser extends Parser {
         if (detailOptionEls) {
             for (const el of detailOptionEls) {
                 if (el.textContent.includes("Author(s)")) {
-                    return el.textContent.replace("Author(s)", "").trim();
+                    const author = el.textContent.replace("Author(s)", "").trim();
+                    if (author != "" && author != "N/A") {
+                        return author;
+                    }
                 }
             }
         }

--- a/plugin/js/parsers/NovelsOnlineParser.js
+++ b/plugin/js/parsers/NovelsOnlineParser.js
@@ -41,4 +41,17 @@ class NovelsOnlineParser extends Parser {
     getInformationEpubItemChildNodes(dom) {
         return [dom.querySelector(".novel-right .novel-detail-body")];
     }
+
+    extractAuthor(dom) {
+        const detailOptionEls = dom.querySelectorAll("div.novel-left > div.novel-details > div.novel-detail-item");
+        if (detailOptionEls) {
+            for (const el of detailOptionEls) {
+                if (el.textContent.includes("Author(s)")) {
+                    return el.textContent.replace("Author(s)", "").trim();
+                }
+            }
+        }
+
+        return "<unknown>";
+    }
 }


### PR DESCRIPTION
I am not sure if the site is a clone or just a rebrand of the other one, but `novelsonline.org` seems to have the exact same structure as what was expected for `novelsonline.net`. So I just added it as an option for download. It seems to have identified the data as expected.

I also went ahead and included the extraction of the author. I was not sure if we could guarantee that the author would always be at a specific child index in the html, so I instead opted to iterate over the possible elements and find it that way. It should work relatively quickly, but if we want to hard code the child element instead, that could be done too.