### PR TITLE
Update FenrirRealm reader-area id

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
     { "name": "Yomafil"},
     { "name": "Varun Patkar", "email": "varunpatkar501@gmail.com" },
     { "name": "Peter Kaufman", "email": "PeterJamesKaufman@gmail.com" },
-    { "name": "MD Shabrez" }
+    { "name": "MD Shabrez" },
+    { "name": "jurassicplayer" }
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/js/parsers/FenrirealmParser.js
+++ b/plugin/js/parsers/FenrirealmParser.js
@@ -22,7 +22,7 @@ class FenrirealmParser extends Parser {
     }
 
     findContent(dom) {
-        return dom.querySelector("#reader-area");
+        return dom.querySelector("[id^='reader-area']");
     }
 
     extractTitleImpl(dom) {

--- a/readme.md
+++ b/readme.md
@@ -804,6 +804,7 @@ Don't forget to give the project a star! Thanks again!
     <li>Varun Patkar</li>
     <li>Peter Kaufman</li>
     <li>MD Shabrez</li>
+    <li>jurassicplayer</li>
   </ul>
 </details>
 


### PR DESCRIPTION
FenrirRealm updated the reader area id to have a numerical id added to the end.
<img width="1603" height="16" alt="image" src="https://github.com/user-attachments/assets/69d53cf4-8894-4f61-ae0d-b8c3e556fdda" />

I did some quick checks on the other class names, but they look the same at a glance. Should work, untested though.