### PR TITLE
WanderinginnParser fix, colors, and mrsha-italics

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
     { "name": "patiorjunrick"},
     { "name": "MD Shabrez" },
     { "name": "jurassicplayer" },
-    { "name": "X2E4VXpZKv" }
+    { "name": "X2E4VXpZKv" },
+    { "name": "johnpyp", "email": "johnpyp.dev@gmail.com" }
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/js/parsers/WanderinginnParser.js
+++ b/plugin/js/parsers/WanderinginnParser.js
@@ -8,8 +8,23 @@ class WanderinginnParser extends WordpressBaseParser {
     }
 
     async getChapterUrls(dom) {
-        return [...dom.querySelectorAll("#table-of-contents a:not(.book-title-num)")]
+        return [...dom.querySelectorAll("#table-of-contents a:not(.book-title-num, .volume-book-card)")]
             .map(a => util.hyperLinkToChapter(a));
+    }
+
+    findContent(dom) {
+        return dom.querySelector("div#reader-content");
+    }
+
+    findChapterTitle(dom) {
+        const titles = dom.querySelectorAll("h2.elementor-heading-title");
+        for (const title of titles) {
+            // default fetch of the page has a copy of title "loading..." preceding the real one, for some reason
+            if (title.textContent.trim() !== "loading...") {
+                return title;
+            }
+        }
+        return null;
     }
     
     extractTitleImpl() {
@@ -22,5 +37,24 @@ class WanderinginnParser extends WordpressBaseParser {
     
     removeNextAndPreviousChapterHyperlinks(webPage, content) {
         util.removeElements(content.querySelectorAll("a[href*='https://wanderinginn.com/']"));
+    }
+
+    preprocessRawDom(webPageDom) {
+        const content = this.findContent(webPageDom);
+        if (content) {
+            // Add italics to all .mrsha-write elements
+            // "mrsha-write" used to be italics, but is now is a custom font in the
+            // web reader which doesn't get copied over to the epub. This fixes that.
+            for (const element of content.querySelectorAll(".mrsha-write")) {
+                element.setAttribute("style", "font-style: italic;");
+            }
+
+            // Add iBooks dark theme class to spans with color styles
+            // This allows apple iBooks to display colors in dark mode, for specific elements.
+            // The Wandering Inn colors were already meant to be displayed in dark mode, so this works great!
+            for (const span of content.querySelectorAll("span[style*='color:']")) {
+                span.classList.add("ibooks-dark-theme-use-custom-text-color");
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dteviot/WebToEpub/issues/2330

- Fix `wanderinginn.com` parsing:
	-  new excluded toc class
	- `#reader-content` is used as the main content container, rather than `.entry-content`
	- `h2.elementor-heading-title` is now used for chapter title
- Add `mrsha-write` italics, to emulate the custom font used in the web
reader (which used to use italics, before switching to the custom font)
- Add ibooks dark-mode-allowed class to wherever inline color styles are
used
	- This makes ibooks display the colors used, while reading in dark mode. TWI colors are made for dark mode, so this works great!

---

I tested on some chapters of the book and confirmed that both the class additions and mrsha-write italics are working as expected, and work properly in iBooks to show both :)
