### PR TITLE
Fix Novel543Parser: correctly combine multi-page chapters

### DIFF
--- a/plugin/js/parsers/Novel543Parser.js
+++ b/plugin/js/parsers/Novel543Parser.js
@@ -42,12 +42,27 @@ class Novel543Parser extends Parser {
         return this.walkPagesOfChapter(url, this.moreChapterTextUrl);
     }
 
-    moreChapterTextUrl(dom) {
-        let has2underscores = (s) => ((s.match(/_/g) || []).length === 2);
-        let nextUrl = [...dom.querySelectorAll(".foot-nav a")].pop();
-        return ((nextUrl != null) && has2underscores(nextUrl.href))
-            ? nextUrl.href
-            : null;
+    moreChapterTextUrl(dom, baseUrl) {
+        // Extract chapter base from original URL (e.g., "8096_1" from "8096_1.html" or "8096_1_2.html")
+        let getChapterBase = (url) => {
+            let match = url.match(/\/(\d+_\d+)(?:_\d+)?\.html/);
+            return match ? match[1] : null;
+        };
+        
+        let baseChapter = getChapterBase(baseUrl);
+        if (!baseChapter) return null;
+        
+        // Find the last link in foot-nav (next chapter link)
+        let nextLink = [...dom.querySelectorAll(".foot-nav a")].pop();
+        if (!nextLink) return null;
+        
+        let nextUrl = nextLink.href;
+        // Check if the next URL is a continuation of the same chapter
+        // (e.g., 8096_1_2.html is a continuation of 8096_1.html)
+        if (nextUrl.includes(`/${baseChapter}_`)) {
+            return nextUrl;
+        }
+        return null;
     }
 
     getInformationEpubItemChildNodes(dom) {


### PR DESCRIPTION
Title: Fix Novel543Parser: correctly combine multi-page chapters

Description:

Novel543.com splits long chapters into multiple pages (e.g., 8096_1.html → 8096_1_2.html). The previous 
moreChapterTextUrl
 logic only checked for exactly 2 underscores, which didn't correctly identify continuation pages.

This fix:

Extracts the chapter base from the original URL (e.g., 8096_1 from 8096_1.html)
Checks if the next link URL contains the base followed by an underscore (e.g., 8096_1_2.html)
Stops fetching when a new chapter is reached (e.g., 8096_2.html)
Tested: Verified that multi-page chapters are now correctly combined into single EPUB chapters.