### PR TITLE
[Feature Upgrade] Added handling of arc titles in Syosetu

### DIFF
--- a/plugin/js/parsers/SyosetuParser.js
+++ b/plugin/js/parsers/SyosetuParser.js
@@ -32,7 +32,26 @@ class SyosetuParser extends Parser {
 
     extractPartialChapterList(dom) {
         let chapterList = dom.querySelector("div.index_box") || dom.querySelector("div.p-eplist");
-        return [...chapterList.querySelectorAll("a")].map(a => util.hyperLinkToChapter(a));
+        if (!chapterList) {
+            return [];
+        }
+        let chapters = [];
+        let arcTitle = null;
+        for (let element of chapterList.querySelectorAll(
+            ".p-eplist__chapter-title, a"
+        )) {
+            if (element.classList?.contains("p-eplist__chapter-title")) {
+                arcTitle = element.textContent.trim();
+                continue;
+            }
+            let chapter = util.hyperLinkToChapter(element);
+            if (arcTitle) {
+                chapter.newArc = arcTitle;
+                arcTitle = null;
+            }
+            chapters.push(chapter);
+        }
+        return chapters;
     }
 
     findContent(dom) {

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebToEpub",
-  "version": "1.0.10.15",
+  "version": "1.0.10.16",
   "default_locale": "en",
   "icons": {
     "128": "book128.png"

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebToEpub",
-  "version": "1.0.10.16",
+  "version": "1.0.10.17",
   "default_locale": "en",
   "icons": {
     "128": "book128.png"


### PR DESCRIPTION
-Updated extractPartialChapterList to associate arc titles with chapters when parsing Syosetu's chapter list.
This improves support for stories with arcs by correctly grouping chapters under their respective arc titles.

-Added fallback logic when chapter list doesn't exist (Happens when process is not initiated on series page).
Instead of throwing an error, parser returns empty chapter list.

Tested and working on Syosetu and R18 Syosetu.