### PR TITLE
Fixed Knoxtspace parser

### DIFF
--- a/plugin/js/parsers/NoblemtlParser.js
+++ b/plugin/js/parsers/NoblemtlParser.js
@@ -149,6 +149,8 @@ class KnoxtspaceParser extends NoblemtlParser {
             }
             parent.removeChild(block);
         }
+        util.removeElements([...webPageDom.querySelectorAll("p")]
+            .filter(p => !p.textContent.trim()));
     }
 
     cleanInformationNode(node) {

--- a/plugin/js/parsers/NoblemtlParser.js
+++ b/plugin/js/parsers/NoblemtlParser.js
@@ -139,6 +139,24 @@ class KnoxtspaceParser extends NoblemtlParser {
     findChapterTitle(dom) {
         return NoblemtlParser.buildChapterTitle(dom);
     }
+
+    preprocessRawDom(webPageDom) {
+        // On Knoxt chapters, first code-block contain chapter text.
+        for (let block of webPageDom.querySelectorAll("div.code-block")) {
+            let parent = block.parentNode;
+            while (block.firstChild) {
+                parent.insertBefore(block.firstChild, block);
+            }
+            parent.removeChild(block);
+        }
+    }
+
+    cleanInformationNode(node) {
+        util.removeChildElementsMatchingSelector(
+            node,
+            "center, div.ad-container"
+        );
+    }
 }
 
 class WhitemoonlightnovelsParser extends NoblemtlParser {


### PR DESCRIPTION
Addresses #2407, #2414 and other improvements.
-Adds preprocessing to prevent removal of chapter text from first ad block.
-Removes ad blocks from information page.
-Removes empty paragraphs from chapters to enhance readability.