### PR TITLE
fix old chrome recognition

### DIFF
--- a/plugin/js/Util.js
+++ b/plugin/js/Util.js
@@ -32,9 +32,15 @@ const util = (function() {
         }
         else
         {
-            // this only works as long as firefox hasn't implemented this 
-            // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformNaclArch
-            return (typeof (browser.runtime.PlatformNaclArch) == "undefined");
+            if ((typeof (browser) !== "undefined")) {
+                // it could be chrome version 144+ or firefox                
+                // this only works as long as firefox hasn't implemented this 
+                // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformNaclArch
+                return (typeof (browser?.runtime?.PlatformNaclArch) == "undefined");
+            } else {
+                //old chrome version (not firefox)
+                return false;
+            }
         }
     }
 


### PR DESCRIPTION
@gamebeaker 

Given older versions of chrome DON'T implement browser, possibly this code should be

```javascript
return (typeof (browser?.runtime?.PlatformNaclArch) == "undefined");
```

_Originally posted by @dteviot in https://github.com/dteviot/WebToEpub/issues/2425#issuecomment-3780480328_

That doesn't work as the old code was a `!==` and not `==` from the logic.

I tested it in chrome 144.0.7559.59 and firefox 147.0

@dteviot can you please test an old chrome version? (I use nixos and don't know how to run a dev chrome build.)
The command to download an old chrome version is: (This will create a folder with an old chrome version)
```
npx @puppeteer/browsers install chrome@128.0.6612.0
```

@dteviot should you find a better way you can change it in the branch. I published the branch to your github repo so you schould be able to check it out and make changes to it. (Or create another pr.)