### PR TITLE
Fixed embedded image links that caused issue 2451

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
     { "name": "meson1271" },
     { "name": "AgatZan" },
     { "name": "Joel Sunil" },
-    { "name": "nothing0074", "email": "phong322010@proton.me" }
+    { "name": "nothing0074", "email": "phong322010@proton.me" },
+    { "name": "Justin Mott", "email": "justinmmott@gmail.com" }
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/js/parsers/RoyalRoadParser.js
+++ b/plugin/js/parsers/RoyalRoadParser.js
@@ -25,6 +25,16 @@ class RoyalRoadParser extends Parser {
             e => (e.className === "portlet-body") &&
             (e.querySelector("div.chapter-inner") !== null)
         );
+
+        // fix embeded image links 
+        content.querySelector(".author-note").querySelectorAll("a").forEach((e) => 
+        {
+            let img = e.querySelector("img");
+            if (img !== null) 
+            {
+                e.href = img.src;
+            }
+        });
         return content || dom.querySelector(".page-content-wrapper");
     }
 

--- a/readme.md
+++ b/readme.md
@@ -811,6 +811,7 @@ Don't forget to give the project a star! Thanks again!
     <li>AgatZan (Parser for ficbook.net)</li>
     <li>Joel Sunil</li>
     <li>nothing0074</li>
+    <li>Justin Mott</li>
   </ul>
 </details>
 


### PR DESCRIPTION
Fixed [issue 2451](https://github.com/dteviot/WebToEpub/issues/2451). 

The issue was caused by multiple images linking to the author's Patreon. Similar to patch [581e762](https://github.com/dteviot/WebToEpub/commit/581e762c6fb86d812092fc201aeac1ace25be084), thanks to @gamebeaker for pointing that out. 