### PR TITLE
Refactor/2116

### DIFF
--- a/eslint/.eslintrc.js
+++ b/eslint/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
         "browser": true,
         "es6": true,
         "webextensions": true,
+        "node": true,
     },
     "parserOptions": {
         "ecmaVersion": 2022

--- a/eslint/pack.js
+++ b/eslint/pack.js
@@ -12,26 +12,26 @@ var extractFileListFromHtml = function(htmlAsString) {
             .map(e => e.getAttribute("src"));
     }
     return [];
-}
+};
 
 var getFileList = function(fileName) {
     return readFilePromise(fileName).then(function(data) {
         return extractFileListFromHtml(data.toString());
     });
-}
+};
 
 var adjustedFileListForEslint = function(fileList) {
     return fileList
         .filter(e => e !== "@zip.js/zip.js/dist/zip-no-worker.min.js")
         .filter(e => e !== "dompurify/dist/purify.min.js")
         .map(f => "../plugin/" + f);
-}
+};
 
 // wrap readFile in a promise
 var readFilePromise = function(fileName) {
     return new Promise(function(resolve, reject) {
         console.log("reading file: " + fileName);
-        fs.readFile(fileName, function (err, data) {
+        fs.readFile(fileName, function(err, data) {
             if (err) { 
                 reject(err); 
             } else {
@@ -39,12 +39,12 @@ var readFilePromise = function(fileName) {
             }
         });
     });
-}
+};
 
 var writeFilePromise = function(fileName, buffer) {
     return new Promise(function(resolve, reject) {
         console.log("writing file: " + fileName);
-        fs.writeFile(fileName, new Buffer(buffer), function (err) {    
+        fs.writeFile(fileName, new Buffer(buffer), function(err) {    
             if (err) { 
                 reject(err); 
             } else {
@@ -52,12 +52,12 @@ var writeFilePromise = function(fileName, buffer) {
             }
         });
     });
-}
+};
 
 // package geting all the files
 var readAllFiles = function(fileList, loadedFiles) {
     return fileList.reduce(function(sequence, fileName) {
-        return sequence.then(function () {
+        return sequence.then(function() {
             return readFilePromise(fileName);
         }).then(function(data) {
             console.log("saving file:  " + fileName);
@@ -67,15 +67,15 @@ var readAllFiles = function(fileList, loadedFiles) {
             });
         });
     }, Promise.resolve());
-}
+};
 
 var countLines = function(fileText) {
     return fileText.split("\n").filter(s => s != "").length;
-}
+};
 
 var makeIndexLine = function(fileName, startIndex, count) {
     return "\"" + fileName + "\", " + (startIndex + 1) + ", " + (startIndex + count) + "\r\n";
-}
+};
 
 
 //=================================================================
@@ -87,11 +87,11 @@ getFileList("../plugin/popup.html").then(function(fileList) {
     fileList =  adjustedFileListForEslint(fileList);
     console.log(fileList);
     return readAllFiles(fileList, loadedFiles);
-}).then(function (data) {
+}).then(function() {
     let temp = "";
     let lineCount = 0;
     let index = "";
-    for(let f of loadedFiles) {
+    for (let f of loadedFiles) {
         temp += f.text;
         let count = countLines(f.text);
         index +=  makeIndexLine(f.fileName, lineCount, count);
@@ -99,7 +99,7 @@ getFileList("../plugin/popup.html").then(function(fileList) {
     }
     fs.writeFileSync("packed.js", temp);
     fs.writeFileSync("index.csv", index);
-}).catch(function (err) {
+}).catch(function(err) {
     console.log(err);
 });
 
@@ -107,31 +107,31 @@ getFileList("../plugin/popup.html").then(function(fileList) {
 // This is bit where we pack the extension into a zip & xpi files.
 
 var addToZipFile = function(zip, nameInZip, filePath) {
-    return readFilePromise(filePath).then(function (data) {
+    return readFilePromise(filePath).then(function(data) {
         zip.add(nameInZip, new zipjs.Uint8ArrayReader(data));
     });
-}
+};
 
 var writeZipToDisk = function(zip, filePath) {
     console.log("writeZipToDisk " + filePath);
-    return zip.close().then(function (buffer) {
-        buffer.arrayBuffer().then(function (arraybuffer) {
+    return zip.close().then(function(buffer) {
+        buffer.arrayBuffer().then(function(arraybuffer) {
             return writeFilePromise(filePath, arraybuffer);
-        })
+        });
     });
-}
+};
 
 var addFilesToZip = function(zip, fileList) {
     return fileList.reduce(function(sequence, fileName) {
-        return sequence.then(function () {
+        return sequence.then(function() {
             return addToZipFile(zip, fileName, "../plugin/" + fileName);
         });
     }, Promise.resolve());
-}
+};
 
 var getLocaleFilesNames = function() {
     return new Promise(function(resolve, reject) {
-        fs.readdir("../plugin/_locales", function (err, files) {
+        fs.readdir("../plugin/_locales", function(err, files) {
             if (err) { 
                 reject(err); 
             } else {
@@ -139,75 +139,75 @@ var getLocaleFilesNames = function() {
             }
         });
     });
-}
+};
 
 var addPopupHtmlToZip = function(zip) {
     return readFilePromise("../plugin/popup.html")
-        .then(function (data) {
+        .then(function(data) {
             let htmlAsString = data.toString()
                 .split("\r")
                 .filter(s => !s.includes("/experimental/"))
                 .join("\r");
             zip.add("popup.html", new zipjs.TextReader(htmlAsString));
-        })
-}
+        });
+};
 
 var addBinaryFileToZip = function(zip, fileName, nameInZip) {
     return readFilePromise(fileName)
         .then(function(data) {
             zip.add(nameInZip, new zipjs.Uint8ArrayReader(data));
         });
-}
+};
 
 var addImageFileToZip = function(zip, fileName) {
     let dest = "images/" + fileName;
     return addBinaryFileToZip(zip, "../plugin/" + dest, dest);
-}
+};
 
 var addCssFileToZip = function(zip, fileName) {
     let dest = "css/" + fileName;
     return addBinaryFileToZip(zip, "../plugin/" + dest, dest);
-}
+};
 
 var packNonManifestExtensionFiles = function(zip, packedFileName) {
     return addBinaryFileToZip(zip, "../plugin/book128.png", "book128.png")
-        .then(function () {
+        .then(function() {
             return addImageFileToZip(zip, "ChapterStateDownloading.svg");
-        }).then(function () {
+        }).then(function() {
             return addImageFileToZip(zip, "ChapterStateLoaded.svg");
-        }).then(function () {
+        }).then(function() {
             return addImageFileToZip(zip, "ChapterStateNone.svg");
-        }).then(function () {
+        }).then(function() {
             return addImageFileToZip(zip, "ChapterStateSleeping.svg");
-        }).then(function () {
+        }).then(function() {
             return addImageFileToZip(zip, "FileEarmarkCheck.svg");
-        }).then(function () {
+        }).then(function() {
             return addImageFileToZip(zip, "FileEarmarkCheckFill.svg");
-        }).then(function () {
+        }).then(function() {
             return addCssFileToZip(zip, "default.css");
-        }).then(function () {
+        }).then(function() {
             return addCssFileToZip(zip, "alwaysDark.css");
-        }).then(function () {
+        }).then(function() {
             return addCssFileToZip(zip, "autoDark.css");
-        }).then(function () {
+        }).then(function() {
             return getFileList("../plugin/popup.html");
         }).then(function(fileList) {
             return getLocaleFilesNames().then(function(localeNames) {
                 return ["js/ContentScript.js"].concat(localeNames)
                     .concat(fileList.filter(n => !n.includes("/experimental/")));
             });
-        }).then(function (fileList) {
+        }).then(function(fileList) {
             return addFilesToZip(zip, fileList);
-        }).then(function () {
+        }).then(function() {
             return addPopupHtmlToZip(zip);
         }).then(function() {
             return writeZipToDisk(zip, packedFileName);
         }).then(function() {
             console.log("Wrote Zip to disk");
-        }).catch(function (err) {
+        }).catch(function(err) {
             console.log(err);    
         });
-}
+};
 
 var makeManifestForFirefox = function(data) {
     let manifest = JSON.parse(data.toString());
@@ -228,7 +228,7 @@ var makeManifestForFirefox = function(data) {
     manifest.browser_action = manifest.action;
     delete manifest.action;
     return manifest;    
-}
+};
 
 var makeManifestForChrome = function(data) {
     let manifest = JSON.parse(data.toString());
@@ -237,20 +237,20 @@ var makeManifestForChrome = function(data) {
     manifest.permissions = manifest.permissions
         .filter(p => !p.startsWith("webRequest"));
     return manifest;    
-}
+};
 
 var packExtension = function(manifest, fileExtension) {
     let zipFileWriter = new zipjs.BlobWriter("application/epub+zip");
     let zipWriter = new zipjs.ZipWriter(zipFileWriter, {useWebWorkers: false,compressionMethod: 8, extendedTimestamp: false});
     zipWriter.add("manifest.json", new zipjs.TextReader(JSON.stringify(manifest)));
     return packNonManifestExtensionFiles(zipWriter, "WebToEpub" + manifest.version + fileExtension);
-}
+};
 
 // pack the extensions for Chrome and firefox
 readFilePromise("../plugin/manifest.json")
-    .then(function (data) {
+    .then(function(data) {
         packExtension(makeManifestForFirefox(data), ".xpi");
         packExtension(makeManifestForChrome(data), ".zip");
-    }).catch(function (err) {
+    }).catch(function(err) {
         console.log(err);
     });

--- a/eslint/pack.js
+++ b/eslint/pack.js
@@ -44,7 +44,7 @@ var readFilePromise = function(fileName) {
 var writeFilePromise = function(fileName, buffer) {
     return new Promise(function(resolve, reject) {
         console.log("writing file: " + fileName);
-        fs.writeFile(fileName, new Buffer(buffer), function(err) {    
+        fs.writeFile(fileName, Buffer.from(buffer), function(err) {    
             if (err) { 
                 reject(err); 
             } else {

--- a/eslint/release.js
+++ b/eslint/release.js
@@ -25,7 +25,7 @@ execSync("npm run lint");
 
 let chromeName = `./eslint/WebToEpub${version}.zip`;
 let firefoxName = `./eslint/WebToEpub${version}.xpi`;
-let chromeCopyName = `./eslint/WebToEpub.chrome.${nameVersion}.zip`
+let chromeCopyName = `./eslint/WebToEpub.chrome.${nameVersion}.zip`;
 let firefoxCopyName = `./eslint/WebToEpub.firefox.${nameVersion}.zip`;
 
 fs.copyFileSync(chromeName, chromeCopyName);
@@ -45,5 +45,5 @@ let command = `
 `.replace(/\n\t?/g, " ").trim();
 
 
-console.log(command)
+console.log(command);
 execSync(command, {stdio: "inherit"});

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "postinstall-DOMpurify": "copyfiles -V -u 1 node_modules/dompurify/dist/purify.min.js plugin",
     "postinstall": "npm run -s postinstall-zip && npm run -s postinstall-DOMpurify",
     "test": "http-server -o unitTest/Tests.html",
-    "lint": "cd eslint && node pack.js && eslint packed.js",
+    "lint": "cd eslint && node pack.js && eslint *.js",
     "lint:fix": "eslint --config eslint/.eslintrc.js --fix plugin/js",
     "web-ext": "cd eslint && cp *.xpi temp.xpi && web-ext lint -w -s temp.xpi && rm temp.xpi",
     "build": "cd eslint && node pack.js",

--- a/plugin/js/ImageCollector.js
+++ b/plugin/js/ImageCollector.js
@@ -427,7 +427,7 @@ class ImageCollector {
         }
     }
 
-    findImageFileUrl(xhr, imageInfo, dataOrigFileUrl, fetchOptions) {
+    async findImageFileUrl(xhr, imageInfo, dataOrigFileUrl, fetchOptions) {
         // with Baka-Tsuki, the link wrapping the image will return an HTML
         // page with a set of images.  We need to pick the desired image
         if (xhr.isHtml()) {
@@ -436,7 +436,7 @@ class ImageCollector {
             let temp = this.selectImageUrlFromImagePage(xhr.responseXML);
             if (temp == null) {
                 if (dataOrigFileUrl != null) {
-                    return this.findImageFileUrlUsingDataOrigFileUrl(imageInfo);
+                    return await this.findImageFileUrlUsingDataOrigFileUrl(imageInfo);
                 }
                 if (!this.userPreferences?.disableImageResError?.value) {
                     let baseUri = xhr.responseXML.baseURI;
@@ -452,14 +452,13 @@ class ImageCollector {
             // page wasn't HTML, so assume is actual image
             imageInfo.sourceUrl = xhr.response.url;
             this.urlIndex.set(xhr.response.url, imageInfo.index);
-            return Promise.resolve(xhr);
+            return xhr;
         }
     }
 
-    findImageFileUrlUsingDataOrigFileUrl(imageInfo) {
-        return HttpClient.wrapFetch(imageInfo.dataOrigFileUrl).then(
-            xhr => this.findImageFileUrl(xhr, imageInfo, null)
-        );
+    async findImageFileUrlUsingDataOrigFileUrl(imageInfo) {
+        let xhr = await HttpClient.wrapFetch(imageInfo.dataOrigFileUrl);
+        await this.findImageFileUrl(xhr, imageInfo, null);
     }
     
     imagesToPackInEpub() {
@@ -522,21 +521,21 @@ class ImageCollector {
         return null;
     }
 
-    preprocessImageTags(content, parentPageUrl) {
+    async preprocessImageTags(content, parentPageUrl) {
         if (this.userPreferences.skipImages.value) {
             util.removeChildElementsMatchingSelector(content, "img, image");
-            return Promise.resolve(content);
+            return content;
         } else {
-            return ImageCollector.replaceHyperlinksToImagesWithImages(content, parentPageUrl);
+            return await ImageCollector.replaceHyperlinksToImagesWithImages(content, parentPageUrl);
         }
     }
 
-    static replaceHyperlinksToImagesWithImages(content, parentPageUrl) {
+    static async replaceHyperlinksToImagesWithImages(content, parentPageUrl) {
         let toReplace = util.getElements(content, "a", ImageCollector.isHyperlinkToImage);
         for (let hyperlink of toReplace.filter(h => !ImageCollector.linkContainsImageTag(h))) {
             ImageCollector.replaceHyperlinkWithImg(hyperlink);
         }
-        return Imgur.expandGalleries(content, parentPageUrl);
+        return await Imgur.expandGalleries(content, parentPageUrl);
     }
 
     /** @private */

--- a/plugin/js/Imgur.js
+++ b/plugin/js/Imgur.js
@@ -7,25 +7,18 @@ class Imgur { // eslint-disable-line no-unused-vars
     constructor() {
     }
 
-    static expandGalleries(content, parentPageUrl) {
-        let sequence = Promise.resolve();
+    static async expandGalleries(content, parentPageUrl) {
         for (let link of Imgur.getGalleryLinksToReplace(content)) {
-            sequence = sequence.then(() => {
-                let href = Imgur.fixupImgurGalleryUrl(link.href);
-                return HttpClient.wrapFetch(href).then((xhr) => {
-                    Imgur.replaceGalleryHyperlinkWithImages(link, xhr.responseXML);
-                    return Promise.resolve();
-                }).catch((err) => {
-                    let errorMsg = UIText.Error.imgurFetchFailed(link.href, parentPageUrl, err);
-                    ErrorLog.log(errorMsg);
-                    return Promise.resolve();
-                });
-            });
+            let href = Imgur.fixupImgurGalleryUrl(link.href);
+            try { 
+                let xhr = await HttpClient.wrapFetch(href);
+                Imgur.replaceGalleryHyperlinkWithImages(link, xhr.responseXML);
+            } catch (err) {
+                let errorMsg = UIText.Error.imgurFetchFailed(link.href, parentPageUrl, err);
+                ErrorLog.log(errorMsg);
+            }
         }
-        sequence = sequence.then(() => {
-            return Promise.resolve(content);
-        });
-        return sequence; 
+        return content; 
     }
 
     static isImgurGallery(dom) {

--- a/plugin/js/main.js
+++ b/plugin/js/main.js
@@ -152,22 +152,22 @@ var main = (function() {
         main.getPackEpubButton().disabled = true;
         replaceLibAddToLibrary();
         parser.onStartCollecting();
-        await parser.fetchContent().then(() => {
-            return packEpub(metaInfo);
-        }).then((content) => {
-            // Enable button here.  If user cancels save dialog
-            // the promise never returns
-            window.workInProgress = false;
-            main.getPackEpubButton().disabled = false;
-            replaceLibAddToLibrary();
-            let overwriteExisting = userPreferences.overwriteExistingEpub.value;
-            let backgroundDownload = userPreferences.noDownloadPopup.value;
-            let fileName = Download.CustomFilename();
-            if ("yes" == libclick.dataset.libclick || util.sleepController.signal.aborted) {
-                return library.LibAddToLibrary(content, fileName, document.getElementById("startingUrlInput").value, overwriteExisting, backgroundDownload);
-            }
-            return Download.save(content, fileName, overwriteExisting, backgroundDownload);
-        }).then(() => {
+        await parser.fetchContent();
+        let content = await packEpub(metaInfo);
+        // Enable button here.  If user cancels save dialog
+        // the promise never returns
+        window.workInProgress = false;
+        main.getPackEpubButton().disabled = false;
+        replaceLibAddToLibrary();
+        let overwriteExisting = userPreferences.overwriteExistingEpub.value;
+        let backgroundDownload = userPreferences.noDownloadPopup.value;
+        let fileName = Download.CustomFilename();
+        if ("yes" == libclick.dataset.libclick || util.sleepController.signal.aborted) {
+            await library.LibAddToLibrary(content, fileName, document.getElementById("startingUrlInput").value, overwriteExisting, backgroundDownload);
+        } else {
+            await Download.save(content, fileName, overwriteExisting, backgroundDownload);
+        }
+        try {
             parser.updateReadingList();
             if (util.sleepController.signal.aborted) {
                 util.sleepController = new AbortController;
@@ -179,7 +179,7 @@ var main = (function() {
                 ErrorLog.showLogToUser();
                 dumpErrorLogToFile();
             }
-        }).catch((err) => {
+        } catch (err) {
             window.workInProgress = false;
             main.getPackEpubButton().disabled = false;
             if (util.sleepController.signal.aborted) {
@@ -187,7 +187,7 @@ var main = (function() {
             }
             replaceLibAddToLibrary();
             ErrorLog.showErrorMessage(err);
-        });
+        }
     }
 
     function replaceLibAddToLibrary() {
@@ -277,7 +277,7 @@ var main = (function() {
         util.setBaseTag(url, initialWebPage);
         await processInitialHtml(url, initialWebPage);
         if (document.getElementById("autosearchmetadataCheckbox").checked == true) {
-            autosearchadditionalmetadata();
+            await autosearchadditionalmetadata();
         }
     }
 
@@ -336,20 +336,19 @@ var main = (function() {
         userPreferences.readFromUi();
     }
 
-    function openTabWindow() {
+    async function openTabWindow() {
         // open new tab window, passing ID of open tab with content to convert to epub as query parameter.
-        getActiveTab().then((tabId) => {
-            let url = chrome.runtime.getURL("popup.html") + "?id=";
-            url += tabId;
-            try {
-                chrome.tabs.create({ url: url, openerTabId: tabId });
-            }
-            catch (err) {
-                //firefox android catch
-                chrome.tabs.create({ url: url});
-            }
-            window.close();
-        });
+        let tabId = await getActiveTab();
+        let url = chrome.runtime.getURL("popup.html") + "?id=";
+        url += tabId;
+        try {
+            chrome.tabs.create({ url: url, openerTabId: tabId });
+        }
+        catch (err) {
+            //firefox android catch
+            chrome.tabs.create({ url: url});
+        }
+        window.close();
     }
 
     function getActiveTab() {
@@ -368,13 +367,14 @@ var main = (function() {
         // load page via XmlHTTPRequest
         let url = getValueFromUiField("startingUrlInput");
         getLoadAndAnalyseButton().disabled = true;
-        return HttpClient.wrapFetch(url).then(async (xhr) => {
+        try {
+            let xhr = await HttpClient.wrapFetch(url);
             await populateControlsWithDom(url, xhr.responseXML);
             getLoadAndAnalyseButton().disabled = false;
-        }).catch((error) => {
+        } catch (error) {
             getLoadAndAnalyseButton().disabled = false;
             ErrorLog.showErrorMessage(error);
-        });
+        }
     }
 
     function configureForTabMode() {
@@ -548,50 +548,52 @@ var main = (function() {
 	
 	
     // Additional metadata
-    function autosearchadditionalmetadata() {
+    async function autosearchadditionalmetadata() {
         getPackEpubButton().disabled = true;
         document.getElementById("LibAddToLibrary").disabled = true;
         let titlename = getValueFromUiField("titleInput");
         let url ="https://www.novelupdates.com/series-finder/?sf=1&sh="+titlename;
         if (getValueFromUiField("subjectInput")==null) {
-            autosearchnovelupdates(url, titlename);
+            await autosearchnovelupdates(url, titlename);
         }   
         getPackEpubButton().disabled = false; 
         document.getElementById("LibAddToLibrary").disabled = false;    
     }
 	
-    function autosearchnovelupdates(url, titlename) {
-        return HttpClient.wrapFetch(url).then((xhr) => {
-            findnovelupdatesurl(url, xhr.responseXML, titlename);
-        }).catch((error) => {
+    async function autosearchnovelupdates(url, titlename) {
+        try {
+            let xhr = await HttpClient.wrapFetch(url);
+            await findnovelupdatesurl(url, xhr.responseXML, titlename);
+        } catch (error) {
             getLoadAndAnalyseButton().disabled = false;
             ErrorLog.showErrorMessage(error);
-        });
+        }
     }
 
-    function findnovelupdatesurl(url, dom, titlename) {
+    async function findnovelupdatesurl(url, dom, titlename) {
         try {    
             let searchurl = [...dom.querySelectorAll("a")].filter(a => a.textContent==titlename)[0];
             setUiFieldToValue("metadataUrlInput", searchurl.href);
             url = getValueFromUiField("metadataUrlInput");
             if (url.includes("novelupdates.com") == true) {
-                onLoadMetadataButtonClick();
+                await onLoadMetadataButtonClick();
             }
         } catch {
             //
         }
     }
 	
-    function onLoadMetadataButtonClick() {
+    async function onLoadMetadataButtonClick() {
         getPackEpubButton().disabled = true;
         document.getElementById("LibAddToLibrary").disabled = true;
         let url = getValueFromUiField("metadataUrlInput");
-        return HttpClient.wrapFetch(url).then((xhr) => {
+        try {
+            let xhr = await HttpClient.wrapFetch(url);
             populateMetadataAddWithDom(url, xhr.responseXML);
-        }).catch((error) => {
+        } catch (error) {
             getLoadAndAnalyseButton().disabled = false;
             ErrorLog.showErrorMessage(error);
-        });
+        }
     }
 
     function populateMetadataAddWithDom(url, dom) {
@@ -613,7 +615,7 @@ var main = (function() {
     }
 
     // actions to do when window opened
-    window.onload = () => {
+    window.onload = async () => {
         userPreferences = UserPreferences.readFromLocalStorage();
         if (isRunningInTabMode()) { 
             ErrorLog.SuppressErrorLog =  false;
@@ -626,7 +628,7 @@ var main = (function() {
                 Firefox.startWebRequestListeners();
             }
         } else {
-            openTabWindow();
+            await openTabWindow();
         }
     };
 


### PR DESCRIPTION
Refactor with the original goal of completing [2116](https://github.com/dteviot/WebToEpub/issues/2116).

- Added `pack.js` and `release.js` to eslint
- Fixed Buffer() deprecation
- Changed .then()s to await for those listed in 2116.
  - Some of those changes were already accomplished in [453bea9](https://github.com/justinmmott/WebToEpub/commit/453bea9ae61a179dba8cfc698046c9e21caaa6a3#diff-77f1c72b88f0d58a5f5fbae2778915b5f40b116d6a1ba597373aaf7d4be72cd9)
  - Did a couple of extra so that any file edited had no .then()s
  - The issue listed `KobatochanParser.js`, which would have been an easy change. However, I noticed that this website has been down since 2021, so I didn't make the change. 
    - https://www.reddit.com/r/Trashero/comments/17elj8z/what_happened_to_kobatochan_translations/
    - https://www.patreon.com/kobatochan
      - The most recent post from 2021 says, "We are down"

I wasn't sure if there was a reason that only these files were listed in the issue, so I didn't go any further in the refactor. Would be happy to change the rest of the .then()s in another refactor if that is wanted.