### PR TITLE
SyosetuParser Update

### DIFF
--- a/plugin/js/parsers/SyosetuParser.js
+++ b/plugin/js/parsers/SyosetuParser.js
@@ -59,11 +59,7 @@ class SyosetuParser extends Parser {
     }
 
     preprocessRawDom(dom) {
-        let notes = dom.querySelector(".p-novel__text--afterword");
-        if ((notes != null) && !this.userPreferences.removeAuthorNotes.value) {
-            this.tagAuthorNotes([notes]);
-            this.findContent(dom).appendChild(notes);
-        }
+        this.tagAuthorNotesBySelector(dom,".p-novel__text--preface, .p-novel__text--afterword");
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/SyosetuParser.js
+++ b/plugin/js/parsers/SyosetuParser.js
@@ -55,7 +55,15 @@ class SyosetuParser extends Parser {
     }
 
     findContent(dom) {
-        return dom.querySelector("div.p-novel__body");
+        return dom.querySelector("div.p-novel__text");
+    }
+
+    preprocessRawDom(dom) {
+        let notes = dom.querySelector(".p-novel__text--afterword");
+        if ((notes != null) && !this.userPreferences.removeAuthorNotes.value) {
+            this.tagAuthorNotes([notes]);
+            this.findContent(dom).appendChild(notes);
+        }
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/SyosetuParser.js
+++ b/plugin/js/parsers/SyosetuParser.js
@@ -55,11 +55,12 @@ class SyosetuParser extends Parser {
     }
 
     findContent(dom) {
-        return dom.querySelector("div.p-novel__text");
+        return dom.querySelector("div.p-novel__body");
     }
 
     preprocessRawDom(dom) {
-        this.tagAuthorNotesBySelector(dom,".p-novel__text--preface, .p-novel__text--afterword");
+        let content = this.findContent(dom);
+        this.tagAuthorNotesBySelector(content,"div.p-novel__text--preface, div.p-novel__text--afterword");
     }
 
     extractTitleImpl(dom) {


### PR DESCRIPTION
-Updated parser to fetch content properly, separating author notes at the beginning and ending via tagging.
Currently, the author notes get mixed up with the chapter content as the div seperating them gets removed. This patch fixes the issue by properly tagging the notes and fetching the exact content.
@dteviot 

Edit: Comment updated to reflect latest commit.