### PR TITLE
Fix Patreon collections view(s) CSS selectors to skip locked posts

### DIFF
--- a/plugin/js/parsers/PatreonParser.js
+++ b/plugin/js/parsers/PatreonParser.js
@@ -29,7 +29,8 @@ class PatreonParser extends Parser {
             let getLink = (e) => {
                 return e.querySelector("a");
             };
-            let linksContainer = [...dom.querySelectorAll("div.ListPost-module__d2AM5a__listPost div:not([class])")];
+            // The SVG check skips all locked chapters.
+            let linksContainer = [...dom.querySelectorAll("div.ListPost-module__d2AM5a__listPost:not(:has(svg[data-tag='IconLock']))")];
             return linksContainer.map(linkContainer => {
                 return {
                     sourceUrl: getLink(linkContainer).href,
@@ -38,7 +39,8 @@ class PatreonParser extends Parser {
             });
         }
         
-        let links = [...dom.querySelectorAll("a.CollectionPostList-module__IhO0fW__gridCard")];
+        // The SVG check skips all locked chapters.
+        let links = [...dom.querySelectorAll("a.CollectionPostList-module__IhO0fW__gridCard:not(:has(svg[data-tag='IconLock']))")];
         return links.map(link => ({
             sourceUrl: link.href,
             title: getTitle(link),


### PR DESCRIPTION
An amendment to #2502 after @Kiradien's notes. I broke the automatic locked post skipping, and this now undoes that.

I also looked over the CSS selectors to see if there were any more appropriate ones but I don't believe so. I added the comments because I like that; but as always if you want me to change anything just tell me and I will fix it ASAP.

Finally, I added the lock checks "at the top level" unlike before where it (presumably) looked for the  direct `<div>` container of the lock svg, as I saw no reason to do otherwise; but if I'm missing some reason why this is bad please let me know ;)

## Pull Request Check List

- **Do all existing unit tests pass?**
Yes.

- **Have all warnings and errors reported by eslint been fixed?**
Technically no, but no eslint warning for the files I've touched.

- **If you've added new behavior ...**
No.

- **Have you updated the "contributors" section of packages.json with your name? (and ideally email, so I can contact you easily.)**
Yes, in a previous commit.

- **Have you updated the "Credits" section of readme.md with your name?**
Yes, in a previous commit.

- **Are you committing to the ExperimentalTab branch?**
Yes.

- **Have you rebased your commit?**
Yes.