### PR TITLE
Fix https://ranovel.com/

### DIFF
--- a/plugin/js/parsers/MadaraParser.js
+++ b/plugin/js/parsers/MadaraParser.js
@@ -69,9 +69,8 @@ class MadaraParser extends WordpressBaseParser {
         return descriptionElement === null ? "" : descriptionElement.textContent.trim();
     }
     
-
     removeUnwantedElementsFromContentElement(element) {
-        util.removeChildElementsMatchingSelector(element, "div.addtoany_share_save_container");
+        util.removeChildElementsMatchingSelector(element, "div.addtoany_share_save_container, div.code-block");
         super.removeUnwantedElementsFromContentElement(element);
     }
 


### PR DESCRIPTION
In response to #2508.

The site already naturally falls under the [MadaraParser](https://github.com/dteviot/WebToEpub/blob/ExperimentalTabMode/plugin/js/parsers/MadaraParser.js) and mostly works. I was able to replicate #2508 (on both webstore and dev build), but only if I trigger WebToEpub before the page has completed loading. If you wait until the chapter list has finished loading everything seemingly works; except the full chapter titles which this fixes.

Finally, a question: I created a sub-class for this parser following the example of the [KdtnovelsParser](https://github.com/dteviot/WebToEpub/blob/824aaed97e7babc2273279d6bc22a2c6c140e04f/plugin/js/parsers/MadaraParser.js#L143). But this seems deeply overkill, and since [MadaraParser](https://github.com/dteviot/WebToEpub/blob/ExperimentalTabMode/plugin/js/parsers/MadaraParser.js) already seems to be a multi-parser; should this change instead be a logic branch inside the [MadaraParser](https://github.com/dteviot/WebToEpub/blob/ExperimentalTabMode/plugin/js/parsers/MadaraParser.js)?

Anyways, if there are any issues I'm happy to fix ;)

EDIT: The tests failed before my force push because I'm dumb and did a: change - git add - change - git commit; so my local lint succeeded but not the remote... my bad...

## Pull Request Check List

- **Do all existing unit tests pass?**
Yes.

- **Have all warnings and errors reported by eslint been fixed?**
Yes.

- **If you've added new behavior ...**
No.

- **Have you updated the "contributors" section of packages.json with your name and email?**
Already there.

- **Have you updated the "Credits" section of readme.md with your name?**
Already there.

- **Are you committing to the ExperimentalTab branch?**
Yes.

- **Have you rebased your commit?**
Yes.