### PR TITLE
Add "Split EPUB every N chapters" feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
     { "name": "nothing0074", "email": "phong322010@proton.me" },
     { "name": "Justin Mott", "email": "justinmmott@gmail.com" },
     { "name": "mobedoor" },
-    { "name": "nitramkh", "email": "nitramkh@gmail.com" }
+    { "name": "nitramkh", "email": "nitramkh@gmail.com" },
+    { "name": "Adoldev40", "email": "ladolfojafet@hotmail.com" }
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -363,6 +363,10 @@
 		"message": "Max chapters per EPUB",
 		"description": "Label for control to set max chapters to put in single EPUB"
 	},
+	"__MSG_label_Split_chapters_per_epub__": {
+		"message": "Split EPUB every N chapters (0 = disabled)",
+		"description": "Label for control to split output into multiple EPUB files after N chapters"
+	},
 	"__MSG_label_Max_pages_to_fetch_simultaneously__": {
 		"message": "Max web pages to fetch simultaneously",
 		"description": "Label for drop down for maximum number of web pages to request at same time"

--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -107,6 +107,7 @@ class UserPreferences { // eslint-disable-line no-unused-vars
         this.removeTranslated = this.addPreference("removeTranslated", "removeTranslatedCheckbox", false);
         this.skipChaptersThatFailFetch = this.addPreference("skipChaptersThatFailFetch", "skipChaptersThatFailFetchCheckbox", false);
         this.maxChaptersPerEpub = this.addPreference("maxChaptersPerEpub", "maxChaptersPerEpubTag", "10,000");
+        this.splitChaptersPerEpub = this.addPreference("splitChaptersPerEpub", "splitChaptersPerEpubTag", "0");
         this.manualDelayPerChapter = this.addPreference("manualDelayPerChapter", "manualDelayPerChapterTag", "0");
         this.overrideMinimumDelay = this.addPreference("overrideMinimumDelay", "overrideMinimumDelayCheckbox", false);
         this.skipImages = this.addPreference("skipImages", "skipImagesCheckbox", false);

--- a/plugin/js/main.js
+++ b/plugin/js/main.js
@@ -130,6 +130,56 @@ var main = (function() {
         }
     }
 
+    function makeNovelBaseName() {
+        let baseName = getValueFromUiField("fileNameInput") ?? "web";
+        let base = baseName
+            .replace(/[<>:"/\\|?*~]/g, "")
+            .split("")
+            .filter(character => character.charCodeAt(0) >= 32)
+            .join("")
+            .replace(/\s+/g, " ")
+            .trim();
+        return util.isNullOrEmpty(base) ? "web" : base;
+    }
+
+    function getSplitChapterCount() {
+        let splitSize = parseInt(userPreferences.splitChaptersPerEpub.value, 10);
+        return isNaN(splitSize) ? 0 : Math.max(0, splitSize);
+    }
+
+    async function saveSplitEpubs(metaInfo, splitSize, overwriteExisting, backgroundDownload, novelBaseName) {
+        let pages = [...parser.getPagesToFetch().values()];
+        let selectedPages = pages.filter(page => page.isIncludeable);
+        if (selectedPages.length === 0) {
+            throw new Error("No chapters selected for split output.");
+        }
+
+        let originalIsIncludeable = new Map(pages.map(page => [page.sourceUrl, page.isIncludeable]));
+        try {
+            let totalSelected = selectedPages.length;
+            for (let index = 0; index < totalSelected; index += splitSize) {
+                let chunk = selectedPages.slice(index, index + splitSize);
+                let chunkUrls = new Set(chunk.map(page => page.sourceUrl));
+                pages.forEach(page => page.isIncludeable = chunkUrls.has(page.sourceUrl));
+
+                let content = await packEpub(metaInfo);
+                let startChapter = index + 1;
+                let endChapter = Math.min(index + splitSize, totalSelected);
+                let fileName = makeSplitFileName(novelBaseName, startChapter, endChapter, totalSelected);
+                await Download.save(content, fileName, overwriteExisting, backgroundDownload);
+            }
+        } finally {
+            pages.forEach(page => page.isIncludeable = originalIsIncludeable.get(page.sourceUrl));
+        }
+    }
+
+    function makeSplitFileName(novelBaseName, startChapter, endChapter, totalSelected) {
+        let padSize = Math.max(2, String(totalSelected).length);
+        let paddedStart = String(startChapter).padStart(padSize, "0");
+        let paddedEnd = String(endChapter).padStart(padSize, "0");
+        return EpubPacker.addExtensionIfMissing(`${novelBaseName} ${paddedStart} - ${paddedEnd}`);
+    }
+
     async function fetchContentAndPackEpub() {
         let libclick = this;
         if (document.getElementById("noAdditionalMetadataCheckbox").checked == true) {
@@ -153,7 +203,6 @@ var main = (function() {
         replaceLibAddToLibrary();
         parser.onStartCollecting();
         await parser.fetchContent();
-        let content = await packEpub(metaInfo);
         // Enable button here.  If user cancels save dialog
         // the promise never returns
         window.workInProgress = false;
@@ -161,11 +210,20 @@ var main = (function() {
         replaceLibAddToLibrary();
         let overwriteExisting = userPreferences.overwriteExistingEpub.value;
         let backgroundDownload = userPreferences.noDownloadPopup.value;
-        let fileName = Download.CustomFilename();
+        let novelBaseName = makeNovelBaseName();
         if ("yes" == libclick.dataset.libclick || util.sleepController.signal.aborted) {
+            let content = await packEpub(metaInfo);
+            let fileName = Download.CustomFilename();
             await library.LibAddToLibrary(content, fileName, document.getElementById("startingUrlInput").value, overwriteExisting, backgroundDownload);
         } else {
-            await Download.save(content, fileName, overwriteExisting, backgroundDownload);
+            let splitSize = getSplitChapterCount();
+            if (splitSize > 0) {
+                await saveSplitEpubs(metaInfo, splitSize, overwriteExisting, backgroundDownload, novelBaseName);
+            } else {
+                let content = await packEpub(metaInfo);
+                let fileName = Download.CustomFilename();
+                await Download.save(content, fileName, overwriteExisting, backgroundDownload);
+            }
         }
         try {
             parser.updateReadingList();

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -466,6 +466,12 @@
                         </td>
                         <td>__MSG_label_Max_chapters_per_epub__</td>
                     </tr>
+                    <tr id="splitChaptersPerEpub">
+                        <td>
+                            <input id="splitChaptersPerEpubTag" type="number" name="splitChaptersPerEpubTag" min="0" step="1" style="width: 61px;" value="0">
+                        </td>
+                        <td>__MSG_label_Split_chapters_per_epub__</td>
+                    </tr>
                     <tr id="manualDelayPerChapter">
                         <td>
                             <input id="manualDelayPerChapterTag" type="number" name="manualDelayPerChapterTag" style="width: 61px;">

--- a/readme.md
+++ b/readme.md
@@ -814,6 +814,7 @@ Don't forget to give the project a star! Thanks again!
     <li>Justin Mott</li>
     <li>mobedoor</li>
     <li>nitramkh</li>
+    <li>Adoldev40</li>
   </ul>
 </details>
 


### PR DESCRIPTION
## Summary
Adds the ability to split a novel into multiple EPUB files based on a user-defined chapter count. Useful for very long novels where a single EPUB becomes too large.

## Changes

### New feature: Split EPUB by N chapters
- New option **"Split EPUB every N chapters"** in the UI (`popup.html`)
- Set to `0` (disabled) by default — existing behavior is unchanged
- When enabled (e.g. `N=20`), generates multiple EPUBs with padded filenames:
  - `NovelName 01 - 20.epub`
  - `NovelName 21 - 40.epub`
  - `NovelName 41 - 50.epub`
- Each split EPUB contains its own metadata, TOC, and images

### Filename sanitization
- `makeNovelBaseName()` removes characters invalid on Windows/Linux/macOS (`<>:"/\|?*~`) and control characters (0x00–0x1F)

## Files modified
| File | Change |
|------|--------|
| `plugin/js/main.js` | Core split logic: `saveSplitEpubs()`, `makeSplitFileName()`, `makeNovelBaseName()`, `getSplitChapterCount()` |
| `plugin/js/UserPreferences.js` | Added `splitChaptersPerEpub` preference (default: `"0"`) |
| `plugin/popup.html` | Added number input for split chapter count |
| `plugin/_locales/en/messages.json` | Added label string for the new option |
| `package.json` | Added contributor |
| `readme.md` | Added contributor to Credits |

## Checklist
- [x] All existing unit tests pass
- [x] No ESLint warnings or errors
- [x] Feature can be turned off (set to 0)
- [x] Feature is off by default
- [x] Contributors updated in `package.json`
- [x] Credits updated in `readme.md`
- [x] Committing to ExperimentalTabMode branch

## Anexo

<img width="1292" height="512" alt="{175ABA75-DAA5-4F09-85F2-5EB0372E5AEA}" src="https://github.com/user-attachments/assets/2926cc79-0d77-4d39-8920-84fc0ce06ba8" />

<img width="904" height="401" alt="{72AA9EF1-9722-4306-B497-E7CB18278C68}" src="https://github.com/user-attachments/assets/46c7ecb0-cc1a-49cf-9b8e-a97a04fb49e9" />
