### PR TITLE
Add xbanxia.cc parser support

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
     { "name": "nothing0074", "email": "phong322010@proton.me" },
     { "name": "Justin Mott", "email": "justinmmott@gmail.com" },
     { "name": "mobedoor" },
-    { "name": "nitramkh", "email": "nitramkh@gmail.com" }
+    { "name": "nitramkh", "email": "nitramkh@gmail.com" },
+    { "name": "s4daharu", "email": "s4daharu@gmail.com" }
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/js/parsers/XbanxiaParser.js
+++ b/plugin/js/parsers/XbanxiaParser.js
@@ -1,0 +1,73 @@
+"use strict";
+
+parserFactory.register("xbanxia.cc", () => new XbanxiaParser());
+
+class XbanxiaParser extends Parser {
+    constructor() {
+        super();
+    }
+
+    async getChapterUrls(dom) {
+        let chapterList = dom.querySelector("#content-list > div.book-list.clearfix > ul");
+        return util.hyperlinksToChapterList(chapterList);
+    }
+
+    findContent(dom) {
+        return dom.querySelector("#nr1");
+    }
+
+    findChapterTitle(dom) {
+        return dom.querySelector("#nr_title");
+    }
+
+    extractTitleImpl(dom) {
+        return dom.querySelector(".book-describe h1");
+    }
+
+    extractAuthor(dom) {
+        let authorLink = dom.querySelector(".book-describe a[href*='/author/']");
+        return authorLink?.textContent ?? super.extractAuthor(dom);
+    }
+
+    extractLanguage() {
+        return "zh";
+    }
+
+    extractSubject(dom) {
+        return this.extractLabeledValue(dom, ["类型", "類型"]);
+    }
+
+    extractDescription(dom) {
+        let description = dom.querySelector(".describe-html");
+        return description?.textContent?.trim() ?? "";
+    }
+
+    findCoverImageUrl(dom) {
+        let image = dom.querySelector("#content-list > div.book-intro.clearfix > div.book-img img");
+        return image?.getAttribute("data-original") ?? image?.src ?? null;
+    }
+
+    removeUnwantedElementsFromContentElement(element) {
+        util.removeChildElementsMatchingSelector(element, "script, span");
+        super.removeUnwantedElementsFromContentElement(element);
+    }
+
+    extractLabeledValue(dom, labels) {
+        let paragraphs = [...dom.querySelectorAll(".book-describe p")];
+        for (let paragraph of paragraphs) {
+            let text = paragraph.textContent?.replace(/\s+/g, " ").trim();
+            if (text == null) {
+                continue;
+            }
+
+            for (let label of labels) {
+                let match = text.match(new RegExp(`^${label}[：:︰]\\s*(.+)$`));
+                if (match != null) {
+                    return match[1].trim();
+                }
+            }
+        }
+
+        return "";
+    }
+}

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -976,6 +976,7 @@
         <script src="js/parsers/WuxiaworldParser.js"></script>
         <script src="js/parsers/WuxiaworldWorldParser.js"></script>
         <script src="js/parsers/WxscsPaser.js"></script>
+        <script src="js/parsers/XbanxiaParser.js"></script>
         <script src="js/parsers/XbiqugeParser.js"></script>
         <script src="js/parsers/XenforoBatchParser.js"></script>
         <script src="js/parsers/XiaoshubaoParser.js"></script>

--- a/readme.md
+++ b/readme.md
@@ -814,6 +814,7 @@ Don't forget to give the project a star! Thanks again!
     <li>Justin Mott</li>
     <li>mobedoor</li>
     <li>nitramkh</li>
+    <li>s4daharu</li>
   </ul>
 </details>
 

--- a/unitTest/Tests.html
+++ b/unitTest/Tests.html
@@ -80,6 +80,7 @@
     <script src="../plugin/js/parsers/WebNovelOnlineParser.js"></script>
     <script src="../plugin/js/parsers/WuxiaBlogParser.js"></script>
     <script src="../plugin/js/parsers/WuxiaworldParser.js"></script>
+    <script src="../plugin/js/parsers/XbanxiaParser.js"></script>
     <script src="../plugin/js/parsers/ZirusMusingsParser.js"></script>
     <script src="../plugin/@zip.js/zip.js/dist/zip-no-worker.min.js"></script>
     <script src="../plugin/js/EpubItemSupplier.js"></script>
@@ -142,6 +143,7 @@
     <script src="UtestWebNovelOnlineParser.js"></script>
     <script src="UtestWuxiaBlogParser.js"></script>
     <script src="UtestWuxiaworldParser.js"></script>
+    <script src="UtestXbanxiaParser.js"></script>
     <script src='UtestParserFactory.js'></script>
 
     <!-- elements Plug-in needs in its HTML -->

--- a/unitTest/UtestXbanxiaParser.js
+++ b/unitTest/UtestXbanxiaParser.js
@@ -1,0 +1,121 @@
+"use strict";
+
+module("XbanxiaParser");
+
+QUnit.test("parserSelection", function(assert) {
+    let parser = parserFactory.fetch("https://www.xbanxia.cc/books/143300.html");
+    assert.ok(parser instanceof XbanxiaParser);
+});
+
+QUnit.test("getChapterUrls", function(assert) {
+    let done = assert.async();
+    let dom = new DOMParser().parseFromString(XbanxiaSeriesPageSample, "text/html");
+
+    new XbanxiaParser().getChapterUrls(dom).then(function(chapters) {
+        assert.deepEqual(chapters, [
+            {sourceUrl: "https://www.xbanxia.cc/books/143300/28251880.html", title: "作品相关", newArc: null},
+            {sourceUrl: "https://www.xbanxia.cc/books/143300/28251886.html", title: "第1章 替嫁", newArc: null}
+        ]);
+        done();
+    });
+});
+
+QUnit.test("findContent", function(assert) {
+    let dom = new DOMParser().parseFromString(XbanxiaChapterPageSample, "text/html");
+    let content = new XbanxiaParser().findContent(dom);
+
+    assert.equal(content.id, "nr1");
+    assert.ok(content.textContent.includes("章节内容"));
+});
+
+QUnit.test("findChapterTitle", function(assert) {
+    let dom = new DOMParser().parseFromString(XbanxiaChapterPageSample, "text/html");
+    let title = new XbanxiaParser().findChapterTitle(dom);
+
+    assert.equal(title.textContent.trim(), "作品相关");
+});
+
+QUnit.test("findCoverImageUrl-prefersDataOriginal", function(assert) {
+    let dom = new DOMParser().parseFromString(XbanxiaSeriesPageSample, "text/html");
+    let actual = new XbanxiaParser().findCoverImageUrl(dom);
+
+    assert.equal(actual, "https://image.xbanxia.cc/files/article/image/143/143300/143300s.jpg");
+});
+
+QUnit.test("removeUnwantedElementsFromContentElement", function(assert) {
+    let dom = TestUtils.makeDomWithBody("<div id='nr1'><span>promo</span><script>bad()</script><p>keep</p></div>");
+    let content = dom.querySelector("#nr1");
+
+    new XbanxiaParser().removeUnwantedElementsFromContentElement(content);
+
+    assert.equal(content.innerHTML, "<p>keep</p>");
+});
+
+QUnit.test("extractMetadata", function(assert) {
+    let parser = new XbanxiaParser();
+    let dom = new DOMParser().parseFromString(XbanxiaSeriesPageSample, "text/html");
+
+    assert.equal(parser.extractTitle(dom), "嫁给残疾皇子后");
+    assert.equal(parser.extractAuthor(dom), "李寂v5");
+    assert.equal(parser.extractSubject(dom), "古装迷情");
+    assert.equal(parser.extractLanguage(dom), "zh");
+    assert.ok(parser.extractDescription(dom).includes("四皇子裴原一朝获罪"));
+});
+
+let XbanxiaSeriesPageSample =
+`<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <title>嫁给残疾皇子后 - 半夏小说</title>
+    <base href="https://www.xbanxia.cc/books/143300.html" />
+    <meta property="og:image" content="https://image.xbanxia.cc/files/article/image/143/143300/143300s.jpg">
+</head>
+<body>
+    <div id="content-list">
+        <div class="book-intro clearfix">
+            <div class="book-img">
+                <img src="https://www.xbanxia.cc/static/nocover.jpg"
+                    data-original="https://image.xbanxia.cc/files/article/image/143/143300/143300s.jpg"
+                    alt="嫁给残疾皇子后">
+            </div>
+            <div class="book-describe">
+                <h1>嫁给残疾皇子后</h1>
+                <p>作者︰<a href="/author/%E6%9D%8E%E5%AF%82v5/">李寂v5</a></p>
+                <p>類型︰古装迷情</p>
+                <p>最新章节︰<a href="/books/143300/28252727.html">第164章 （正文完）</a></p>
+                <div class="describe-html">
+                    <p>四皇子裴原一朝获罪，从心狠手辣臭名昭著的濟北王变成了瘫痪的废人。</p>
+                </div>
+            </div>
+        </div>
+        <div class="book-list clearfix">
+            <ul>
+                <li><a href="/books/143300/28251880.html">作品相关</a></li>
+                <li><a href="/books/143300/28251886.html">第1章 替嫁</a></li>
+            </ul>
+        </div>
+    </div>
+</body>
+</html>`;
+
+let XbanxiaChapterPageSample =
+`<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <title>嫁给残疾皇子后 作品相关 - 半夏小说</title>
+    <base href="https://www.xbanxia.cc/books/143300/28251880.html" />
+</head>
+<body>
+    <article class="post clearfix">
+        <header id="posthead" class="post-header clearfix">
+            <h1 id="nr_title" class="post-title">作品相关</h1>
+        </header>
+        <div id="nr1">
+            <div style="height: 0px;"></div>
+            章节内容
+            <span>推广</span>
+            <script>bad()</script>
+        </div>
+    </article>
+</body>
+</html>`;


### PR DESCRIPTION
## Summary
Add first-class parser support for \\xbanxia.cc\\.

This adds a dedicated \\XbanxiaParser\\ for:
- chapter list extraction
- chapter title/content extraction
- cover image extraction
- metadata extraction
- site-specific cleanup

It also updates the contributor checklist items by adding \\s4daharu\\ to \\package.json\\ and the Credits section in \\eadme.md\\.

## Validation
- \\
pm run lint\\ passes
- produced:
  - \\eslint/WebToEpub1.0.12.2.xpi\\
  - \\eslint/WebToEpub1.0.12.2.zip\\
  - \\eslint/packed.js\\
- \\XbanxiaParser\\ QUnit coverage passes locally

## Notes
The full \\unitTest/Tests.html\\ suite still shows 6 unrelated pre-existing \\DOMPurify is not defined\\ failures in existing tests. This PR is intentionally scoped to \\xbanxia.cc\\ parser support plus the contribution-guide credit updates.