### PR TITLE
Update FalooParser

### DIFF
--- a/plugin/js/parsers/FalooParser.js
+++ b/plugin/js/parsers/FalooParser.js
@@ -12,15 +12,36 @@ class FalooParser extends Parser {
     }
 
     async getChapterUrls(dom) {
-        // If there are no VIP chapters, get all chapters
-        if (!dom.querySelector(".DivVip")) {
-            return [...dom.querySelectorAll("div.DivTable div div a")]
-                .map(a => util.hyperLinkToChapter(a));
+        let tocUrl = dom.querySelector(".T-L-T-C-Box2 a:nth-child(4)");
+
+        let tocDom = (await HttpClient.wrapFetch(tocUrl)).responseXML;
+
+        let nodes = [...tocDom.querySelectorAll("div.c_con_list, .c_con_viptitle")];
+
+        let isVipReached = false;
+        let chapters = [];
+
+        for (let node of nodes) {
+            if (node.classList.contains("c_con_viptitle")) {
+                isVipReached = true;
+                continue;
+            }
+
+            let links = node.querySelectorAll("div.c_con_li_detail_p a, a.c_con_li_detail");
+
+            for (let link of links) {
+                let span = link.querySelector("span");
+                let title = span.textContent.trim();
+
+                chapters.push({
+                    sourceUrl: link.href, 
+                    title: title,
+                    isIncludeable: !isVipReached
+                });
+            }
         }
 
-        // If there are VIP chapters, get only first volume
-        let menu = dom.querySelector("div.DivTable:nth-child(3)");
-        return util.hyperlinksToChapterList(menu);        
+        return chapters;
     }
 
     findContent(dom) {
@@ -37,7 +58,7 @@ class FalooParser extends Parser {
     }
 
     extractLanguage() {
-        return "Zh-CN";
+        return "zh-CN";
     }
 
     extractSubject(dom) {

--- a/plugin/js/parsers/FalooParser.js
+++ b/plugin/js/parsers/FalooParser.js
@@ -16,20 +16,14 @@ class FalooParser extends Parser {
 
         let tocDom = (await HttpClient.wrapFetch(tocUrl)).responseXML;
 
-        //Get all volumes and the VIP header, in order.
-        let nodes = [...tocDom.querySelectorAll("div.c_con_list, .c_con_viptitle")];
 
-        let isVipReached = false;
+        let nodes = [...tocDom.querySelectorAll("div.c_con_list")];
+
         let chapters = [];
 
         for (let node of nodes) {
-            //Find VIP header, all volumes after this only contains VIP chapters.
-            if (node.classList.contains("c_con_viptitle")) {
-                isVipReached = true;
-                continue;
-            }
 
-            //`div.c_con_li_detail_p a` = Free chapters? `a.c_con_li_detail` = VIP chapters?
+            //`div.c_con_li_detail_p a` = Free | `a.c_con_li_detail` = VIP
             let links = node.querySelectorAll("div.c_con_li_detail_p a, a.c_con_li_detail");
 
             for (let link of links) {
@@ -40,7 +34,7 @@ class FalooParser extends Parser {
                 chapters.push({
                     sourceUrl: link.href, 
                     title: title,
-                    isIncludeable: !isVipReached
+                    isIncludeable: !link.classList.contains("c_con_li_detail")
                 });
             }
         }

--- a/plugin/js/parsers/FalooParser.js
+++ b/plugin/js/parsers/FalooParser.js
@@ -16,20 +16,24 @@ class FalooParser extends Parser {
 
         let tocDom = (await HttpClient.wrapFetch(tocUrl)).responseXML;
 
+        //Get all volumes and the VIP header, in order.
         let nodes = [...tocDom.querySelectorAll("div.c_con_list, .c_con_viptitle")];
 
         let isVipReached = false;
         let chapters = [];
 
         for (let node of nodes) {
+            //Find VIP header, all volumes after this only contains VIP chapters.
             if (node.classList.contains("c_con_viptitle")) {
                 isVipReached = true;
                 continue;
             }
 
+            //`div.c_con_li_detail_p a` = Free chapters? `a.c_con_li_detail` = VIP chapters?
             let links = node.querySelectorAll("div.c_con_li_detail_p a, a.c_con_li_detail");
 
             for (let link of links) {
+                //Get non-truncated chapter from span.
                 let span = link.querySelector("span");
                 let title = span.textContent.trim();
 


### PR DESCRIPTION
Updated the FalooParser to now list all VIP chapters, but leave them unchecked by default.
Also, use the table of content to get the chapters, and get the non-truncated title of a chapter from it.