### PR TITLE
Fix http://noveldex.io/ relative url resolution

### DIFF
--- a/plugin/js/parsers/NoveldexParser.js
+++ b/plugin/js/parsers/NoveldexParser.js
@@ -53,16 +53,16 @@ class NoveldexParser extends Parser { // eslint-disable-line no-unused-vars
          * 
          * @type { NodeListOf<HTMLAnchorElement> }
          */
-        let chapterLinksElements = dom.querySelectorAll("div[id] div[data-state] a[href*='chapter']:not(:has(svg.lucide-lock))");
+        const chapterLinksElements = dom.querySelectorAll("div[id] div[data-state] a[href*='chapter']:not(:has(svg.lucide-lock))");
 
-        let chapterLinks = Array.from(chapterLinksElements, a => {
+        const chapterLinks = Array.from(chapterLinksElements, a => {
             /**
              * The separate the queries are needed because the first-of-type
              * doesn't work in an all selector when the spans are are nested.
              * 
              * @type { NodeListOf<HTMLSpanElement> }
              */
-            let titleSpans = a.querySelector("div:first-of-type").querySelectorAll("span");
+            const titleSpans = a.querySelector("div:first-of-type").querySelectorAll("span");
 
             return {
                 sourceUrl: a.href,
@@ -81,7 +81,7 @@ class NoveldexParser extends Parser { // eslint-disable-line no-unused-vars
         const scripts = Array.from(dom.querySelectorAll("script:not([src])"), script => script.innerHTML);
 
         // Look for blocks of text enclosed by invisible characters.
-        let mainRegex = /(?:[\uFEFF\u200B\u200C\u200D]+)(.+?)(?:[\uFEFF\u200B\u200C\u200D]+)/;
+        const mainRegex = /(?:[\uFEFF\u200B\u200C\u200D]+)(.+?)(?:[\uFEFF\u200B\u200C\u200D]+)/;
 
         let foundContent = null;
         for (const script of scripts) {
@@ -99,7 +99,7 @@ class NoveldexParser extends Parser { // eslint-disable-line no-unused-vars
         const unescaped = JSON.parse(`["${foundContent}"]`)[0];
 
         // Parse partially unescaped HTML.
-        let elementified = document.createElement("div");
+        const elementified = dom.createElement("div");
         elementified.innerHTML = unescaped;
 
         // Unescape HTML-escaped tags, and remove nested <p> tags.
@@ -115,7 +115,7 @@ class NoveldexParser extends Parser { // eslint-disable-line no-unused-vars
      */
     extractTitleImpl(dom) {
         /** @type { HTMLHeadingElement } */
-        let storyTitle = dom.querySelector("main h1:first-of-type");
+        const storyTitle = dom.querySelector("main h1:first-of-type");
         
         return storyTitle;
     }
@@ -136,9 +136,9 @@ class NoveldexParser extends Parser { // eslint-disable-line no-unused-vars
          * Translator team's name is stored in a massive escaped JSON blob under
          * team -> name.
          */
-        let translator = /(?:\\"team\\":.+?\\"name\\":\\")(.*?)(?:\\")/.exec(dom.body.innerHTML);
+        const translator = /(?:\\"team\\":.+?\\"name\\":\\")(.*?)(?:\\")/.exec(dom.body.innerHTML);
 
-        const combined = [author, translator[1]].filter(s => s != null && s !== "").join(", ");
+        const combined = [author, translator?.[1]].filter(s => s != null && s !== "").join(", ");
 
         return combined !== "" ? combined : super.extractAuthor(dom);
     }


### PR DESCRIPTION
Amendment to #2471/#2546.

1. [This comment](https://github.com/dteviot/WebToEpub/issues/2471#issuecomment-4087236158) noted that images doesn't work. I tracked it down to me calling `createElement()` on **document** instead of **dom**; making all relative URL resolutions fail as they used the extension's base URI.

2. I found a missing null-check wherein theoretically if it fails to find the name of the translator it would error out, instead of listing only the author.

3. Changed a bunch of `let` to `const` where possible.

As always, if there are any changes you want I'm happy to fix ;)

<details>

<summary>Pull request checklist</summary>

1. ✅ Do all existing unit tests pass?
2. ✅ Have all warnings and errors reported by eslint been fixed?
3. ❌ Have you added new behaviour?
    1. ⬜ Can you turn it off?
    2. ⬜ Is it off by default?
6. ✅ Are you in the contributors and credits?
7. ✅ Are you committing to the ExperimentalTabMode branch?
8. ✅ Have you rebased your commits?
9. ✅ Have you ensured you committed all relevant changes?

</details>