### PR TITLE
Add XTruyenParser and TruyenmoikkParser

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
     { "name": "Justin Mott", "email": "justinmmott@gmail.com" },
     { "name": "mobedoor" },
     { "name": "nitramkh", "email": "nitramkh@gmail.com" },
-    { "name": "s4daharu", "email": "s4daharu@gmail.com" }
+    { "name": "s4daharu", "email": "s4daharu@gmail.com" },
+	  { "name": "meowmereo" }
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/js/parsers/TruyenmoikkParser.js
+++ b/plugin/js/parsers/TruyenmoikkParser.js
@@ -1,0 +1,97 @@
+"use strict";
+
+parserFactory.register("truyenmoikk.com", () => new TruyenMoiKKParser());
+
+class TruyenMoiKKParser extends Parser {
+    constructor() {
+        super();
+    }
+
+    async getChapterUrls(dom, chapterUrlsUI) {
+        let chapters = await this.getChapterUrlsFromMultipleTocPages(
+            dom,
+            TruyenMoiKKParser.extractPartialChapterList,
+            TruyenMoiKKParser.getUrlsOfTocPages,
+            chapterUrlsUI
+        );
+
+        chapters.sort((a, b) => {
+            let numA = parseInt(a.sourceUrl.match(/chuong-(\d+)/)?.[1] || 0, 10);
+            let numB = parseInt(b.sourceUrl.match(/chuong-(\d+)/)?.[1] || 0, 10);
+            return numA - numB;
+        });
+
+        return chapters.filter((v, i, a) => a.findIndex(t => (t.sourceUrl === v.sourceUrl)) === i);
+    }
+
+    static getUrlsOfTocPages(dom) {
+        let urls = [];
+        let pageNodes = Array.from(dom.querySelectorAll("ul.pagination li a"));
+        let maxPage = 1;
+
+        pageNodes.forEach(a => {
+            let p = parseInt(a.textContent.trim(), 10);
+            if (!isNaN(p) && p > maxPage) {
+                maxPage = p;
+            }
+        });
+
+        let current = new URL(dom.baseURI);
+        let basePath = current.pathname.replace(/\/trang-\d+\/?$/, "");
+        if (!basePath.endsWith("/")) {
+            basePath += "/";
+        }
+
+        for (let i = 2; i <= maxPage; i++) {
+            let u = new URL(current);
+            u.hash = "";
+            u.search = "";
+            u.pathname = basePath + `trang-${i}`;
+            urls.push(u.toString());
+        }
+        return urls;
+    }
+
+    static extractPartialChapterList(dom) {
+        return [...dom.querySelectorAll("ul.list-chapter li a")]
+            .map(link => util.hyperLinkToChapter(link));
+    }
+
+    findContent(dom) {
+        return dom.querySelector("article.chapter-content");
+    }
+
+    extractTitleImpl(dom) {
+        return dom.querySelector("h1.story-title")?.textContent.trim();
+    }
+
+    extractAuthor(dom) {
+        return dom.querySelector("div[itemprop='author'] span[itemprop='name']")?.textContent.trim() || super.extractAuthor(dom);
+    }
+
+    findCoverImageUrl(dom) {
+        let metaThumb = dom.querySelector("meta[itemprop='thumbnailUrl']");
+        if (metaThumb && metaThumb.content) {
+            return metaThumb.content;
+        }
+        return util.getFirstImgSrc(dom, ".book img[itemprop='image']");
+    }
+
+    findChapterTitle(dom) {
+        let titleNode = dom.querySelector("a.chapter-title") || dom.querySelector("h2");
+        return titleNode ? titleNode.textContent.trim() : super.findChapterTitle(dom);
+    }
+
+    extractSubject(dom) {
+        let genres = Array.from(dom.querySelectorAll("a[itemprop='genre']"));
+        return genres.map(a => a.textContent.trim()).join(", ");
+    }
+
+    extractDescription(dom) {
+        return dom.querySelector(".desc-text")?.textContent.trim() || super.extractDescription(dom);
+    }
+
+    getInformationEpubItemChildNodes(dom) {
+        return [...dom.querySelectorAll(".desc-text")];
+    }
+}

--- a/plugin/js/parsers/XTruyenParser.js
+++ b/plugin/js/parsers/XTruyenParser.js
@@ -1,0 +1,183 @@
+"use strict";
+
+parserFactory.register("xtruyen.vn", () => new XTruyenParser());
+
+class XTruyenParser extends Parser {
+    constructor() {
+        super();
+    }
+
+    get filename() {
+        return this.title + ".epub";
+    }
+
+    getTocUrl(dom) {
+        let tocLink = dom.querySelector("#chapter-heading a");
+        if (tocLink) {
+            return tocLink.href;
+        }
+        return dom.querySelector("link[rel='canonical']")?.href || dom.baseURI;
+    }
+    // Handles lazy-loaded chapters //
+    async getChapterUrls(dom) {
+        let chapters = [];
+        let tocUrl = this.getTocUrl(dom);
+        let tocDom = dom;
+        
+        if (tocUrl && tocUrl !== dom.baseURI) {
+            try {
+                let response = await HttpClient.wrapFetch(tocUrl);
+                tocDom = response.responseXML;
+            } catch (e) {}
+        }
+
+        let baseUrl = tocDom.querySelector("link[rel='canonical']")?.href || tocDom.baseURI;
+        baseUrl = baseUrl.split('/chuong-')[0];
+        if (!baseUrl.endsWith('/')) {
+            baseUrl += '/';
+        }
+
+        let firstNum = 1;
+        let lastNum = 0;
+
+        let volumnsUl = tocDom.querySelector(".volumns");
+        if (volumnsUl) {
+            let lists = Array.from(tocDom.querySelectorAll("li.has-child"));
+            if(lists.length > 0) {
+               let lastList = lists[lists.length - 1];
+               let dataValue = lastList.getAttribute("data-value");
+               if(dataValue) {
+                   let matches = dataValue.match(/\d+/g);
+                   if(matches && matches.length >= 2) {
+                       lastNum = parseInt(matches[matches.length - 1]);
+                   }
+               }
+            }
+            if (lastNum === 0) {
+                let dataLast = volumnsUl.getAttribute("data-last");
+                if (dataLast) {
+                    let lMatch = dataLast.match(/\d+/);
+                    if (lMatch) {
+                        lastNum = parseInt(lMatch[0]);
+                    }
+                }
+            }
+        } else {
+            let volOptions = Array.from(tocDom.querySelectorAll("select.volume-select option"));
+            if (volOptions.length > 0) {
+                let lastOptionText = volOptions[volOptions.length - 1].textContent;
+                let matches = lastOptionText.match(/\d+/g);
+                if (matches && matches.length >= 1) {
+                    lastNum = parseInt(matches[matches.length - 1]);
+                }
+            }
+        }
+
+        let titleMap = {};
+
+        let allLinks = [...Array.from(tocDom.querySelectorAll("a")), ...Array.from(dom.querySelectorAll("a"))];
+        allLinks.forEach(a => {
+            let href = a.href || "";
+            let match = href.match(/chuong-(\d+)/);
+            if (match) {
+                let num = parseInt(match[1]);
+                let text = a.textContent.trim();
+                if (text && text.length > 3) {
+                    titleMap[num] = text;
+                }
+            }
+        });
+
+        let currentUrl = dom.querySelector("link[rel='canonical']")?.href || dom.baseURI;
+        let currentChapMatch = currentUrl.match(/chuong-(\d+)/);
+        if (currentChapMatch) {
+            let currentNum = parseInt(currentChapMatch[1]);
+            let currentTitleNode = dom.querySelector("h1#chapter-heading + h2") || dom.querySelector("h2");
+            if (currentTitleNode) {
+                titleMap[currentNum] = currentTitleNode.textContent.trim();
+            }
+        }
+
+        if (lastNum > 0) {
+            for (let i = firstNum; i <= lastNum; i++) {
+                chapters.push({
+                    sourceUrl: `${baseUrl}chuong-${i}/`,
+                    title: titleMap[i] || `Chương ${i}`
+                });
+            }
+            return chapters;
+        }
+
+        return chapters;
+    }
+
+    async fetchChapter(url) {
+        let dom = (await HttpClient.wrapFetch(url)).responseXML;
+        let scriptNode = dom.querySelector("#script-x");
+        if (scriptNode) {
+            let match = scriptNode.textContent.match(/const data_x\s*=\s*"([^"]+)"/);
+            if (match && match[1]) {
+                try {
+                    let decryptedText = await this.decryptContent(match[1]);
+                    let contentDiv = dom.querySelector("#chapter-reading-content");
+                    if (contentDiv) {
+                        contentDiv.innerHTML = decryptedText;
+                    }
+                } catch (e) {}
+            }
+        }
+        return dom;
+    }
+
+    //// Decrypts obfuscated 'data_x' (Anagram) ////
+    async decryptContent(data_x) {
+        const c = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_";
+        const s = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let translated = '';
+        
+        for (let char of data_x) {
+            let idx = c.indexOf(char);
+            translated += idx > -1 ? s[idx] : char;
+        }
+        
+        const binaryStr = atob(translated);
+        const binary = new Uint8Array(binaryStr.length);
+        for (let i = 0; i < binaryStr.length; i++) {
+            binary[i] = binaryStr.charCodeAt(i);
+        }
+
+        const ds = new DecompressionStream('deflate');
+        const decompressedStream = new Response(binary).body.pipeThrough(ds);
+        return await new Response(decompressedStream).text();
+    }
+
+    findContent(dom) {
+        return dom.querySelector("#chapter-reading-content");
+    }
+
+    extractTitleImpl(dom) {
+        return dom.querySelector(".post-title h1")?.textContent.trim();
+    }
+
+    extractAuthor(dom) {
+        return dom.querySelector(".author-content a")?.textContent.trim() || super.extractAuthor(dom);
+    }
+
+    findCoverImageUrl(dom) {
+        return util.getFirstImgSrc(dom, ".summary_image");
+    }
+
+    findChapterTitle(dom) {
+        let titleNode = dom.querySelector("h1#chapter-heading + h2") || dom.querySelector("h2");
+        return titleNode ? titleNode.textContent.trim() : super.findChapterTitle(dom);
+    }
+
+    extractSubject(dom) {
+        let genres = Array.from(dom.querySelectorAll(".genres-content a"));
+        return genres.map(a => a.textContent.trim()).join(", ");
+    }
+
+    extractDescription(dom) {
+        return dom.querySelector(".summary__content.show-more")?.textContent.trim() || super.extractDescription(dom);
+    }
+}

--- a/plugin/js/parsers/XTruyenParser.js
+++ b/plugin/js/parsers/XTruyenParser.js
@@ -7,10 +7,6 @@ class XTruyenParser extends Parser {
         super();
     }
 
-    get filename() {
-        return this.title + ".epub";
-    }
-
     getTocUrl(dom) {
         let tocLink = dom.querySelector("#chapter-heading a");
         if (tocLink) {
@@ -18,23 +14,25 @@ class XTruyenParser extends Parser {
         }
         return dom.querySelector("link[rel='canonical']")?.href || dom.baseURI;
     }
-    // Handles lazy-loaded chapters //
+
     async getChapterUrls(dom) {
         let chapters = [];
         let tocUrl = this.getTocUrl(dom);
         let tocDom = dom;
-        
+
         if (tocUrl && tocUrl !== dom.baseURI) {
             try {
                 let response = await HttpClient.wrapFetch(tocUrl);
                 tocDom = response.responseXML;
-            } catch (e) {}
+            } catch (e) {
+                // Ignore fetch errors for ToC
+            }
         }
 
         let baseUrl = tocDom.querySelector("link[rel='canonical']")?.href || tocDom.baseURI;
-        baseUrl = baseUrl.split('/chuong-')[0];
-        if (!baseUrl.endsWith('/')) {
-            baseUrl += '/';
+        baseUrl = baseUrl.split("/chuong-")[0];
+        if (!baseUrl.endsWith("/")) {
+            baseUrl += "/";
         }
 
         let firstNum = 1;
@@ -43,15 +41,15 @@ class XTruyenParser extends Parser {
         let volumnsUl = tocDom.querySelector(".volumns");
         if (volumnsUl) {
             let lists = Array.from(tocDom.querySelectorAll("li.has-child"));
-            if(lists.length > 0) {
-               let lastList = lists[lists.length - 1];
-               let dataValue = lastList.getAttribute("data-value");
-               if(dataValue) {
-                   let matches = dataValue.match(/\d+/g);
-                   if(matches && matches.length >= 2) {
-                       lastNum = parseInt(matches[matches.length - 1]);
-                   }
-               }
+            if (lists.length > 0) {
+                let lastList = lists[lists.length - 1];
+                let dataValue = lastList.getAttribute("data-value");
+                if (dataValue) {
+                    let matches = dataValue.match(/\d+/g);
+                    if (matches && matches.length >= 2) {
+                        lastNum = parseInt(matches[matches.length - 1]);
+                    }
+                }
             }
             if (lastNum === 0) {
                 let dataLast = volumnsUl.getAttribute("data-last");
@@ -123,30 +121,32 @@ class XTruyenParser extends Parser {
                     if (contentDiv) {
                         contentDiv.innerHTML = decryptedText;
                     }
-                } catch (e) {}
+                } catch (e) {
+                    // Ignore decryption errors
+                }
             }
         }
         return dom;
     }
 
-    //// Decrypts obfuscated 'data_x' (Anagram) ////
+    // Decrypts obfuscated 'data_x' using custom alphabet and Deflate decompression.
     async decryptContent(data_x) {
         const c = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_";
         const s = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-        let translated = '';
-        
+        let translated = "";
+
         for (let char of data_x) {
             let idx = c.indexOf(char);
             translated += idx > -1 ? s[idx] : char;
         }
-        
+
         const binaryStr = atob(translated);
         const binary = new Uint8Array(binaryStr.length);
         for (let i = 0; i < binaryStr.length; i++) {
             binary[i] = binaryStr.charCodeAt(i);
         }
 
-        const ds = new DecompressionStream('deflate');
+        const ds = new DecompressionStream("deflate");
         const decompressedStream = new Response(binary).body.pipeThrough(ds);
         return await new Response(decompressedStream).text();
     }

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -940,7 +940,6 @@
         <script src="js/parsers/XiaoshuoguiParser.js"></script>
         <script src="js/parsers/XiaxuenovelsParser.js"></script>
         <script src="js/parsers/XklxswParser.js"></script>
-		<script src="js/parsers/XtruyenParser.js"></script>
         <script src="js/parsers/YedugeParser.js"></script>
         <script src="js/parsers/YushuboParser.js"></script>
         <script src="js/parsers/AsianHobbyistParser.js"></script>

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -922,6 +922,7 @@
         <script src="js/parsers/TruyenfullParser.js"></script>
         <script src="js/parsers/TruyenFullVisionParser.js"></script>
         <script src="js/parsers/TruyenyyParser.js"></script>
+        <script src="js/parsers/TruyenmoikkParser.js"></script>
         <script src="js/parsers/TruyenParser.js"></script>
         <script src="js/parsers/TrxsParser.js"></script>
         <script src="js/parsers/TumblrParser.js"></script>

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -940,6 +940,7 @@
         <script src="js/parsers/XiaoshuoguiParser.js"></script>
         <script src="js/parsers/XiaxuenovelsParser.js"></script>
         <script src="js/parsers/XklxswParser.js"></script>
+		<script src="js/parsers/XtruyenParser.js"></script>
         <script src="js/parsers/YedugeParser.js"></script>
         <script src="js/parsers/YushuboParser.js"></script>
         <script src="js/parsers/AsianHobbyistParser.js"></script>
@@ -981,6 +982,7 @@
         <script src="js/parsers/XbiqugeParser.js"></script>
         <script src="js/parsers/XenforoBatchParser.js"></script>
         <script src="js/parsers/XiaoshubaoParser.js"></script>
+        <script src="js/parsers/XtruyenParser.js"></script>
         <script src="js/parsers/ZenithNovelsParser.js"></script>
         <script src="js/parsers/ZenithtlsParser.js"></script>
         <script src="js/parsers/ZeonicrepublicParser.js"></script>

--- a/readme.md
+++ b/readme.md
@@ -815,6 +815,7 @@ Don't forget to give the project a star! Thanks again!
     <li>mobedoor</li>
     <li>nitramkh</li>
     <li>s4daharu</li>
+    <li>meowmereo</li>
   </ul>
 </details>
 


### PR DESCRIPTION
Add XTruyenParser for website xtruyen.vn
Add TruyenmoikkParser for website truyenmoikk.com

Known Limitations (just Xtruyen)
- Chapters not currently visible in any list on the page or not yet visited will fallback to a generic "Chapter X" title format. This is an unavoidable side effect of the site's lazy-loading architecture.
- Tip for chapter titles: To capture all specific chapter titles, simply click on the "Danh sách chương" (Chapter List) section on the story's main page and scroll/load the list before launching WebToEpub.

Check List
Do all existing unit tests pass? - Yes, all existing unit tests pass. 

Have all warnings and errors reported by eslint been fixed? - Yes.

If you've added new behavior, can a user turn it off? - No the new behavior is encapsulated within this parser, it follows the standard extension architecture. It does not change any global extension behavior without warning.

Have you updated the "contributors" section of package.json with your name? - Yes.

Have you updated the "Credits" section of readme.md with your name? - Yes.

Are you committing to the ExperimentalTab branch? - Yes.

Have you rebased your commit? - Yes, I have performed a rebase against the latest upstream ExperimentalTab branch.