### PR TITLE
Update Novelonomicon

### DIFF
--- a/plugin/js/parsers/NovelonomiconParser.js
+++ b/plugin/js/parsers/NovelonomiconParser.js
@@ -17,28 +17,38 @@ class NovelonomiconParser extends Parser {
 
     getUrlsOfTocPages(dom) {
         let urls = [];
-        let lastLink = dom.querySelector(".page-nav a.last")
-            || [...dom.querySelectorAll(".page-nav a.page")].slice(-1)[0];
-        if (lastLink !== null)
-        {
-            let max = parseInt(lastLink.textContent);
+        let lastLink = dom.querySelector(".pages-nav li.last-page a.pages-nav-item")
+            || [...dom.querySelectorAll(".pages-nav a.pages-nav-item")].slice(-1)[0];
+        if (lastLink !== null) {
             let href = lastLink.href;
+            // Extract the max page number safely
+            let match = href.match(/page\/(\d+)\//);
+            let max = match ? parseInt(match[1], 10) : 1;
+
+            // Trim to the base ".../page/"
             let index = href.lastIndexOf("/", href.length - 2);
-            href = href.substring(0, index + 1);
+            let base = href.substring(0, index + 1);
+
+            // Always include the index URL (page 1)
+            // This works no matter what the path is
+            let indexUrl = base.replace(/page\/$/, "");
+            urls.push(indexUrl);
+
+            // Then add page 2 through max
             for (let i = 2; i <= max; ++i) {
-                urls.push(href + i + "/");
+                urls.push(base + i + "/");
             }
         }
         return urls;
     }
 
     extractPartialChapterList(dom) {
-        return [...dom.querySelectorAll(".td-block-span6 h3 a")]
+        return [...dom.querySelectorAll("#masonry-grid .entry-archives-header h2 a")]
             .map(a => util.hyperLinkToChapter(a));
     }
 
     findContent(dom) {
-        return dom.querySelector(".tdi_48 .wpb_wrapper .tdb_single_content");
+        return dom.querySelector("#the-post div.entry-content.entry.clearfix");
     }
 
     extractTitleImpl(dom) {
@@ -52,13 +62,19 @@ class NovelonomiconParser extends Parser {
     findCoverImageUrl(dom) {
         return util.getFirstImgSrc(dom, ".td-module-image a");
     }
-    
+
     getInformationEpubItemChildNodes(dom) {
-        return [...dom.querySelectorAll(".td-category-description")];
+        return [...dom.querySelectorAll(".taxonomy-description")];
+    }
+
+    removeUnwantedElementsFromContentElement(element) {
+        util.removeChildElementsMatchingSelector(element,
+            "#the-post .da-reactions-outer, #the-post .stream-item-below-post-content");
+        super.removeUnwantedElementsFromContentElement(element);
     }
 
     cleanInformationNode(node) {
         util.removeChildElementsMatchingSelector(node, ".su-spoiler");
         return node;
-    }    
+    }
 }


### PR DESCRIPTION
Current problem: doesn't know if i should remove patreon link and text and header words like "free chapters" and "chapters". Current knowledge even with AI only remove elements containing lowercase word of "chapter", which i'm afraid also remove element containing synopsis if synopsis itself containing that word.

Based on tested novel info there's one without that header [1](https://novelonomicon.com/category/novels/frontiers/) , while one using h1 [2](https://novelonomicon.com/category/novels/history-of-the-kingdom-of-the-orcsen/), the rest using h3 [3](https://novelonomicon.com/category/novels/i-built-an-orphanage-to-pick-up-and-sell-slaves-and-orphans/) [4](https://novelonomicon.com/category/novels/the-rural-assignment-of-a-holy-knight/) [5](https://novelonomicon.com/category/novels/i-an-angel-dismantle-humans-to-level-up/) [6](https://novelonomicon.com/category/novels/im-a-reincarnator-cooking-developing-territory-in-a-world-of-nothing-but-salt/)