### PR TITLE
feat: add tts button cleaner to Woopread parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
     { "name": "nitramkh", "email": "nitramkh@gmail.com" },
     { "name": "s4daharu", "email": "s4daharu@gmail.com" },
     { "name": "crn0" },
-    { "name": "meowmereo"}
+    { "name": "meowmereo"},
+    { "name": "Matthew Song", "email": "matthewsong18@gmail.com"}
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/js/parsers/WoopreadParser.js
+++ b/plugin/js/parsers/WoopreadParser.js
@@ -44,6 +44,36 @@ class WoopreadParser extends Parser {
     }
 
     findContent(dom) {
-        return dom.querySelector("div[id^='chapter']");
+        const content = dom.querySelector("div[id^='chapter']");
+
+        if (content) {
+            // Remove Text-to-Speech (TTS) play buttons so they don't clutter the
+            // EPUB.
+
+            // We target the 'aria-label' instead of visual CSS classes because
+            // accessibility tags are much less likely to change during site updates.
+
+            // We also wrap this in a try/catch so that if the site does change, the
+            // parser simply skips the cleanup and returns the original text rather
+            // than crashing the entire download.
+            try {
+                const junkButtons = content.querySelectorAll(
+                    "button[aria-label^=\"Play from paragraph\"]",
+                );
+
+                if (junkButtons && junkButtons.length > 0) {
+                    junkButtons.forEach((currentButton) => {
+                        if (currentButton !== null) currentButton.remove();
+                    });
+                }
+            } catch (_error) {
+                // Push a warning to the extension's UI Error Log instead of the console
+                ErrorLog.log(
+                    "Woopread warning: Could not clean up Text-to-Speech buttons. The site's layout may have changed.",
+                );
+            }
+        }
+
+        return content;
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -817,6 +817,7 @@ Don't forget to give the project a star! Thanks again!
     <li>s4daharu</li>
     <li>crn0</li>
     <li>meowmereo</li>
+    <li>Matthew Song</li>
   </ul>
 </details>
 


### PR DESCRIPTION
### Problem
When downloading from WoopRead, the site injects multiple Text-to-Speech play buttons into the paragraph text. These buttons are currently being captured by the parser and ending up in the final EPUB, looking like the following image where a white button is displayed after every line of the novel.

<img width="269" height="402" alt="image" src="https://github.com/user-attachments/assets/bd85169b-5093-4df1-a396-9f61ae6cfa85" />

### Solution
I updated the `findContent` method in `WoopreadParser.js` to strip these specific buttons out before the content is returned.

I did see mention in the FAQ about being hesitant to add junk removal to WebToEPub, so I made the following decisions to hopefully make it easier to adopt this cleanup function:

- Targeted aria-label: Instead of targeting CSS or Tailwind utility classes, I targeted the `aria-label^="Play from paragraph"` attribute, which is less likely to change. This should make the cleanup more resilient to site redesigns.
- Fails safely: The cleanup logic is wrapped in a try/catch and includes strict null checking. If the site's DOM changes completely, the parser will bypass the cleanup, log a warning to the user via `ErrorLog.log()`, and safely return the original content without crashing the download.

### Checklist
- [x] Do all existing unit tests pass?  (FYI, I find it easier to get the unit tests to run under Firefox, instead of Chrome.)
- [x] Have all warnings and errors reported by eslint been fixed?
- [x] Have you updated the "contributors" section of packages.json with your name? (and ideally email, so I can contact you easily.)
- [x] Have you updated the "Credits" section of readme.md with your name?
- [x] Are you committing to the ExperimentalTab branch?
- [x] Have you rebased your commit?
> I believe this doesn't apply considering the change only affects one site's parser
- [ ] If you've added new behavior, 
    - [ ]     Can a user turn it off?  
    - [ ]     Is it off by default?  Note, users don't like it when behavior changes without warning.