### PR TITLE
[ImageCollector] Add missing return keyword after refactor

### DIFF
--- a/plugin/js/ImageCollector.js
+++ b/plugin/js/ImageCollector.js
@@ -458,7 +458,7 @@ class ImageCollector {
 
     async findImageFileUrlUsingDataOrigFileUrl(imageInfo) {
         let xhr = await HttpClient.wrapFetch(imageInfo.dataOrigFileUrl);
-        await this.findImageFileUrl(xhr, imageInfo, null);
+        return await this.findImageFileUrl(xhr, imageInfo, null);
     }
     
     imagesToPackInEpub() {


### PR DESCRIPTION
While reading through some of the codebase I found something odd which I believe to be a slight error from a previous refactor.

I have cut out the relevant parts from the current state:

```javascript
// Call-site, for which all other paths returns a promise of a `wrapFetch` return
async findImageFileUrl(xhr, imageInfo, dataOrigFileUrl, fetchOptions) {
    ...
    return await this.findImageFileUrlUsingDataOrigFileUrl(imageInfo);
    ...
}

// Function implementation
async findImageFileUrlUsingDataOrigFileUrl(imageInfo) {
    let xhr = await HttpClient.wrapFetch(imageInfo.dataOrigFileUrl);
    await this.findImageFileUrl(xhr, imageInfo, null);
}
```

The second function does not have a return statement, which stuck out to me as weird when I was looking around; especially since it seems like the call-site expects a very specific return. So I checked the last commit to touch it and found what I expect to be a small oversight. The commit in question 2d1e40e, line 459 through 462.

Below is the function implementation from the commit prior ([ImageCollector#459](https://github.com/dteviot/WebToEpub/blob/82c2712efaadb8f491a5785527f1e29b7925a4bf/plugin/js/ImageCollector.js#L459)):

```javascript
findImageFileUrlUsingDataOrigFileUrl(imageInfo) {
    return HttpClient.wrapFetch(imageInfo.dataOrigFileUrl).then(
        xhr => this.findImageFileUrl(xhr, imageInfo, null)
    );
}
```

As you can see, it previously had a return which makes much more sense. I don't know if anyone actually noticed something broken or not, but regardless I'm pretty sure I'm right on this one.

This commit is comically small but as always, if there are any issues or any changes are wanted I'm happy to fix ;)

<details>

<summary>Pull request checklist</summary>

1. ✅ Do all existing unit tests pass?
2. ✅ Have all warnings and errors reported by eslint been fixed?
3. ❌ Have you added new behaviour?
    1. ⬜ Can you turn it off?
    2. ⬜ Is it off by default?
6. ✅ Are you in the contributors and credits?
7. ✅ Are you committing to the ExperimentalTabMode branch?
8. ✅ Have you rebased your commits?
9. ✅ Have you ensured you committed all relevant changes?

</details>