### PR TITLE
Add https://twbook.cc/ to Novel543Parser

### DIFF
--- a/plugin/js/parsers/Novel543Parser.js
+++ b/plugin/js/parsers/Novel543Parser.js
@@ -1,6 +1,7 @@
 "use strict";
 
 parserFactory.register("novel543.com", () => new Novel543Parser());
+parserFactory.register("twbook.cc", () => new Novel543Parser());
 
 class Novel543Parser extends Parser {
     constructor() {
@@ -30,6 +31,10 @@ class Novel543Parser extends Parser {
         return authorLabel?.textContent ?? super.extractAuthor(dom);
     }
 
+    extractSubject(dom) {
+        return dom.querySelector("p.meta a[href*='bookstack']")?.textContent?.trim();
+    }
+
     extractLanguage() {
         return "zh";
     }
@@ -42,8 +47,17 @@ class Novel543Parser extends Parser {
         return this.walkPagesOfChapter(url, this.moreChapterTextUrl);
     }
 
+    /**
+     * @param { Document } dom 
+     * @param { string } baseUrl 
+     * @private
+     */
     moreChapterTextUrl(dom, baseUrl) {
-        // Extract chapter base from original URL (e.g., "8096_1" from "8096_1.html" or "8096_1_2.html")
+        /**
+         * Extract chapter base from original URL (e.g., "8096_1" from "8096_1.html" or "8096_1_2.html")
+         * 
+         * @param { string  } url 
+         */
         let getChapterBase = (url) => {
             let match = url.match(/\/(\d+_\d+)(?:_\d+)?\.html/);
             return match ? match[1] : null;
@@ -53,7 +67,7 @@ class Novel543Parser extends Parser {
         if (!baseChapter) return null;
         
         // Find the last link in foot-nav (next chapter link)
-        let nextLink = [...dom.querySelectorAll(".foot-nav a")].pop();
+        let nextLink = /** @type { HTMLAnchorElement | undefined } */ ([...dom.querySelectorAll(".foot-nav a")].pop());
         if (!nextLink) return null;
         
         let nextUrl = nextLink.href;


### PR DESCRIPTION
Implementation for #2526.

* https://twbook.cc/ is a clone of https://novel543.com/ and thus just hooks into [Novel543Parser](https://github.com/dteviot/WebToEpub/blob/ExperimentalTabMode/plugin/js/parsers/Novel543Parser.js).

* I added `extractSubject` to get the genre. It is the same across both sites so I saw no reason not to.

* I JSDOC-ified it while I was there because why not.

As always, if there are any issue or wanted changed, I'm happy to fix ;)

<details>

<summary>Pull request checklist</summary>

1. ✅ Do all existing unit tests pass?
2. ✅ Have all warnings and errors reported by eslint been fixed?
3. ❌ Have you added new behaviour?
    1. ⬜ Can you turn it off?
    2. ⬜ Is it off by default?
6. ✅ Are you in the contributors and credits?
7. ✅ Are you committing to the ExperimentalTabMode branch?
8. ✅ Have you ensured you committed all relevant changes?
9. ✅ Have you rebased your commits?
10. ✅ Did you fetch from upstream before rebasing?

</details>