### PR TITLE
Fix Ranobes chapter title fallback

### DIFF
--- a/plugin/js/parsers/RanobesParser.js
+++ b/plugin/js/parsers/RanobesParser.js
@@ -89,9 +89,9 @@ class RanobesParser extends Parser {
     }
 
     findChapterTitle(dom) {
-        let title = dom.querySelector("h1.title");
+        let title = dom.querySelector("h1.title, div#arrticle h1, div#arrticle h2, div#arrticle h3");
         util.removeChildElementsMatchingSelector(title, "span, div");
-        return title.textContent;
+        return title ? title.textContent : super.findChapterTitle(dom);
     }
 
     findCoverImageUrl(dom) {


### PR DESCRIPTION
Sometimes the Ranobes reader pages put the chapter title inside `div#arrticle` instead of `h1.title`. This fix checks the existing `h1.title` selector first, then falls back to article headings, so normal Ranobes pages keep their current behavior. Without this, the download would never happen, due to a crash (from the failure parsing).