### PR TITLE
Add Publisher Metadata to Epub

### DIFF
--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -371,6 +371,10 @@
 		"message": "Epub description",
 		"description": "Preview description from the epub in Calibre"
 	},
+	"__MSG_label_Metadata_publisher__": {
+		"message": "Publisher",
+		"description": "Label for Epub publisher"
+	},
 	"__MSG_label_Custom_Filename__": {
 		"message": "Custom Filename",
 		"description": "Custom Filename input"

--- a/plugin/js/EpubMetaInfo.js
+++ b/plugin/js/EpubMetaInfo.js
@@ -23,6 +23,7 @@ class EpubMetaInfo {
         this.fileName = "web.epub";
         this.subject = "";
         this.description = "";
+        this.publisher = "";
         this.seriesName = null;
         this.seriesIndex = null;
         this.styleSheet = EpubMetaInfo.getDefaultStyleSheet();
@@ -164,7 +165,7 @@ class EpubMetaInfo {
             metaAddInfo.description = EpubMetaInfo.addDescriptionNovelupdate(dom);
             metaAddInfo.author = EpubMetaInfo.addAuthorNovelupdate(dom);
         } else {
-            let test = "Error: Fetch of URL '" + url + "' failed to fetch please check if website is novelupdates.com";
+            let test = "Error: Fetch of URL '" + url + "' failed to fetch, please check if website is novelupdates.com";
             ErrorLog.showErrorMessage(test);
         }
         return metaAddInfo;

--- a/plugin/js/EpubPacker.js
+++ b/plugin/js/EpubPacker.js
@@ -98,6 +98,9 @@ class EpubPacker {
         if (!util.isNullOrEmpty(this.metaInfo.description)) {
             this.createAndAppendChildNS(metadata, dc_ns, "dc:description", this.metaInfo.description);
         }
+        if (!util.isNullOrEmpty(this.metaInfo.publisher)) {
+            this.createAndAppendChildNS(metadata, dc_ns, "dc:publisher", this.metaInfo.publisher);
+        }
 
         let author = this.createAndAppendChildNS(metadata, dc_ns, "dc:creator", this.metaInfo.author);
         this.addMetaProperty(metadata, author, "file-as", "creator", this.metaInfo.getFileAuthorAs());

--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -566,6 +566,7 @@ class Library { // eslint-disable-line no-unused-vars
         let LibTemplateMetadataLanguage = document.getElementById("LibTemplateMetadataLanguage").innerHTML;
         let LibTemplateMetadataSubject = document.getElementById("LibTemplateMetadataSubject").innerHTML;
         let LibTemplateMetadataDescription = document.getElementById("LibTemplateMetadataDescription").innerHTML;
+        let LibTemplateMetadataPublisher = document.getElementById("LibTemplateMetadataPublisher").innerHTML;
         let LibRenderResult = document.getElementById("LibRenderMetadata" + objbtn.dataset.libepubid);
         let LibMetadata = await Library.LibGetMetadata(objbtn.dataset.libepubid);
         let LibRenderString = "";
@@ -600,6 +601,11 @@ class Library { // eslint-disable-line no-unused-vars
         LibRenderString += "<td>"+LibTemplateMetadataDescription+"</td>";
         LibRenderString += "<td colspan='2'><textarea  rows='2' cols='60' id='LibDescriptionInput"+objbtn.dataset.libepubid+"' type='text' name='descriptionInput'>"+LibMetadata[4]+"</textarea></td>";
         LibRenderString += "</tr>";
+        LibRenderString += "</tr>";
+        LibRenderString += "<tr id='LibTemplateMetadataPublisher"+objbtn.dataset.libepubid+"'>";
+        LibRenderString += "<td>"+LibTemplateMetadataPublisher+"</td>";
+        LibRenderString += "<td colspan='2'><input id='LibPublisherInput"+objbtn.dataset.libepubid+"' type='text' value='"+LibMetadata[5]+"'></input></td>";
+        LibRenderString += "</tr>";
         LibRenderString += "</tbody>";
         LibRenderString += "</table>";
         LibRenderString += "</div>";
@@ -613,6 +619,7 @@ class Library { // eslint-disable-line no-unused-vars
         let LibLanguageInput = document.getElementById("LibLanguageInput"+obj.dataset.libepubid).value;
         let LibSubjectInput = document.getElementById("LibSubjectInput"+obj.dataset.libepubid).value;
         let LibDescriptionInput = document.getElementById("LibDescriptionInput"+obj.dataset.libepubid).value;
+        let LibPublisherInput = document.getElementById("LibPublisherInput"+obj.dataset.libepubid).value;
         Library.LibShowLoadingText();
         let LibDateCreated = new EpubPacker().getDateForMetaData();
         try {
@@ -641,6 +648,7 @@ class Library { // eslint-disable-line no-unused-vars
             LibSaveMetadataString += "<dc:subject>"+LibSubjectInput+"</dc:subject>";
             LibSaveMetadataString += "<dc:description>"+LibDescriptionInput+"</dc:description>";
             LibSaveMetadataString += "<dc:creator opf:file-as=\""+LibAuthorInput+"\" opf:role=\"aut\">"+LibAuthorInput+"</dc:creator>";
+            LibSaveMetadataString += "<dc:publisher>"+LibPublisherInput+"</dc:publisher>";
 
             opfFile = opfFile.replace(new RegExp("<dc:title>.+?</dc:creator>", "gs"), LibSaveMetadataString);
 
@@ -661,7 +669,7 @@ class Library { // eslint-disable-line no-unused-vars
             let EpubContent =  await EpubZip.getEntries();
             let opfFile = await EpubContent.filter(a => a.filename == "OEBPS/content.opf")[0].getData(new zip.TextWriter());
             
-            let LibMetadataTags = ["dc:title", "dc:creator", "dc:language", "dc:subject", "dc:description"];
+            let LibMetadataTags = ["dc:title", "dc:creator", "dc:language", "dc:subject", "dc:description", "dc:publisher"];
             let opfFileMatch;
             LibMetadataTags.forEach((element, index) => {
                 LibMetadata[index] = "";

--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -308,6 +308,20 @@ class Parser {
     }
 
     /**
+    * default implementation, 
+    * if not available, return ''
+    */
+    extractPublisher(dom) {   // eslint-disable-line no-unused-vars
+        // try metadata extraction
+        let publisher = dom.querySelector("meta[property='og:site_name']");
+        if (publisher !== null) {
+            return publisher.content;
+        }
+
+        return "";
+    }
+
+    /**
     * default implementation, Derived classes will override
     */
     extractSeriesInfo(dom, metaInfo) {  // eslint-disable-line no-unused-vars
@@ -355,6 +369,12 @@ class Parser {
         }
         catch (err) {
             metaInfo.description = "";
+        }
+        try {
+            metaInfo.publisher = this.extractPublisher(dom);
+        }
+        catch (err) {
+            metaInfo.publisher = "";
         }
         this.extractSeriesInfo(dom, metaInfo);
         return metaInfo;

--- a/plugin/js/UIText.js
+++ b/plugin/js/UIText.js
@@ -43,6 +43,7 @@ class UIText { // eslint-disable-line no-unused-vars
         language: chrome.i18n.getMessage("__MSG_label_Language__"),
         subject: chrome.i18n.getMessage("__MSG_label_Metadata_subject__"),
         description: chrome.i18n.getMessage("__MSG_label_Metadata_description__"),
+        publisher: chrome.i18n.getMessage("__MSG_label_Metadata_publisher__"),
         save: chrome.i18n.getMessage("__MSG_label_Metadata_Save__")
     };
     

--- a/plugin/js/main.js
+++ b/plugin/js/main.js
@@ -79,6 +79,7 @@ var main = (function() {
         setUiFieldToValue("fileNameInput", metaInfo.fileName);
         setUiFieldToValue("subjectInput", metaInfo.subject);
         setUiFieldToValue("descriptionInput", metaInfo.description);
+        setUiFieldToValue("publisherInput", metaInfo.publisher);
         if (metaInfo.seriesName !== null) {
             document.getElementById("seriesRow").hidden = false;
             document.getElementById("volumeRow").hidden = false;
@@ -108,6 +109,7 @@ var main = (function() {
         metaInfo.fileName = getValueFromUiField("fileNameInput");
         metaInfo.subject = getValueFromUiField("subjectInput");
         metaInfo.description = getValueFromUiField("descriptionInput");
+        metaInfo.publisher = getValueFromUiField("publisherInput");
 
         if (document.getElementById("seriesRow").hidden === false) {
             metaInfo.seriesName = getValueFromUiField("seriesNameInput");
@@ -135,6 +137,7 @@ var main = (function() {
         if (document.getElementById("noAdditionalMetadataCheckbox").checked == true) {
             setUiFieldToValue("subjectInput", "");
             setUiFieldToValue("descriptionInput", "");
+            setUiFieldToValue("publisherInput", "");
         }
         let metaInfo = metaInfoFromControls();
 

--- a/plugin/js/parsers/NovelfullParser.js
+++ b/plugin/js/parsers/NovelfullParser.js
@@ -257,6 +257,10 @@ class NovelbinParser extends NovelfullParser {
         return [...genres, ...tags].map(e => e.textContent).join(", ");
     }
 
+    extractPublisher() {
+        return "NovelBin";
+    }
+
     removeUnwantedElementsFromContentElement(element) {
         util.removeChildElementsMatchingSelector(element, ".unlock-buttons");
         super.removeUnwantedElementsFromContentElement(element);

--- a/plugin/js/parsers/Template.js
+++ b/plugin/js/parsers/Template.js
@@ -136,6 +136,17 @@ class TemplateParser extends Parser { // eslint-disable-line no-unused-vars
     }
     */
 
+    // Publisher of the story
+    // Optional, Publisher for metadata, if not provided, will default to ""
+    /*
+    extractPublisher(dom) {
+        // Element from dom containing publisher data
+        return dom.querySelector("").textContent.trim();
+
+        return "site_name";
+    }
+    */
+
     // Optional, supply if need to do special manipulation of content
     // e.g. decrypt content
     /*

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -238,6 +238,9 @@
                                 <td id="LibTemplateMetadataDescription">__MSG_label_Metadata_description__</td>
                                 <td id="LibTemplateWarningInProgress">__MSG_label_Lib_Warning_In_Progress___</td>
                                 </tr>
+                                <tr>
+                                    <td id="LibTemplateMetadataPublisher">__MSG_label_Metadata_publisher__</td>
+                                </tr>
                         </tbody>
                     </table>
                 </div>
@@ -285,6 +288,10 @@
                     <tr>
                         <td>__MSG_label_Metadata_description__</td>
                         <td><textarea rows="2" cols="60" id="descriptionInput" type="text" name="descriptionInput"></textarea></td>
+                    </tr>
+                    <tr>
+                        <td>__MSG_label_Metadata_publisher__</td>
+                        <td><input id="publisherInput" type="text" name="publisherInput" /></td>
                     </tr>
                     <tr id="seriesRow">
                         <td>__MSG_label_Series__</td>


### PR DESCRIPTION
Added `dc:publisher` metadata when building an EPUB.
#155

Default implementation is getting the publisher based on the website name from metadata: `og:site_name`.
Else we can use `extractPublisher()` in a Parser to get the name of the publisher as a string or from some elements.
If not implemented, default to ``.

Added input field in `Advanced Options` > `Show more Metadata options`.

Tested and working with Calibre.
Tested and working with Extension Library.

Example of site with `og:site_name`: 
- https://www.webnovel.com/book/35044944208489005
- https://www.scribblehub.com/series/1325911/bofuri-the-strongest-shield-of-tensura/

Example Parser implementation:
- https://novelbin.com/b/i-arrived-at-wizard-world-while-cultivating-immortality