### PR TITLE
fix novelbin.com #2661

### DIFF
--- a/plugin/js/parsers/NovelfullParser.js
+++ b/plugin/js/parsers/NovelfullParser.js
@@ -109,6 +109,11 @@ class NovelfullParser extends Parser {
     }
 
     extractPartialChapterList(dom) {
+        if (!dom.querySelector("ul")) {
+            let templateElement = dom.querySelector("template");
+            return [...templateElement.content.querySelectorAll("li a")]
+                .map(link => util.hyperLinkToChapter(link));
+        }
         return [...dom.querySelectorAll("ul.list-chapter a")]
             .map(link => util.hyperLinkToChapter(link));
     }


### PR DESCRIPTION
Fix #2661. Checking if ul element exist. Idk how the site and extension didn't get ul element but manually opening fetched url give ul element. Only tested on novelbin.com.