### PR TITLE
Enhance content parsing for 'faloo' book host

### DIFF
--- a/.github/workflows/AutoRelease.yml
+++ b/.github/workflows/AutoRelease.yml
@@ -4,7 +4,7 @@ name: Auto release developer-build
 
 on:
   push:
-    branches: [ ExperimentalTabMode ] 
+    branches: [ thanhlouis-patch-1 ] 
   workflow_dispatch:
     inputs:
       version:
@@ -43,8 +43,8 @@ jobs:
         git status
         git branch --show-current > git_branch.txt
         set /p var_git_branch=<git_branch.txt
-        if NOT "ExperimentalTabMode"=="%var_git_branch%" (
-          echo this workflow only works in the ExperimentalTabMode branch
+        if NOT "thanhlouis-patch-1"=="%var_git_branch%" (
+          echo this workflow only works in the thanhlouis-patch-1 branch
           exit 1
         )
 
@@ -159,7 +159,7 @@ jobs:
           echo **Full Changelog**: https://github.com/dteviot/WebToEpub/compare/%var_old_change_log_version%...%var_build% >> output.txt
 
           echo create %var_build% release:
-          gh release create %var_build% --latest -t "Release %var_build%" --target "ExperimentalTabMode" -F output.txt
+          gh release create %var_build% --latest -t "Release %var_build%" --target "thanhlouis-patch-1" -F output.txt
           
           echo add files to release.
           gh release upload %var_build% eslint/WebToEpub%var_build%.Firefox.zip
@@ -171,7 +171,7 @@ jobs:
           echo * WebToEpub%var_build%.Firefox.zip for Firefox >> output.txt
           echo * WebToEpub%var_build%.Chrome.zip for Chrome >> output.txt
           echo.>> output.txt
-          echo follow the "How to install from Source (for people who are not developers)" instructions at: https://github.com/dteviot/WebToEpub/tree/ExperimentalTabMode#user-content-installation>> output.txt
+          echo follow the "How to install from Source (for people who are not developers)" instructions at: https://github.com/dteviot/WebToEpub/tree/thanhlouis-patch-1#user-content-installation>> output.txt
           echo.>> output.txt
           echo **Full Changelog**: https://github.com/dteviot/WebToEpub/compare/%var_old_change_log_version%...developer-build >> output.txt
 
@@ -179,7 +179,7 @@ jobs:
           gh release delete developer-build --cleanup-tag
 
           echo create developer-build release:
-          gh release create developer-build -p -t "Latest developer build" --target "ExperimentalTabMode" -F output.txt
+          gh release create developer-build -p -t "Latest developer build" --target "thanhlouis-patch-1" -F output.txt
           
           echo add files to release.
           gh release upload developer-build eslint/WebToEpub%var_build%.Firefox.zip

--- a/plugin/js/parsers/SangtacvietParser.js
+++ b/plugin/js/parsers/SangtacvietParser.js
@@ -115,10 +115,10 @@ class SangtacvietParser extends Parser {
 
         let rawData = json.data;
 
-        if (json.bookhost === 'faloo') {
-            rawData = rawData.split('\n').map(line => {
+        if (json.bookhost === "faloo") {
+            rawData = rawData.split("\n").map(line => {
                 let trimmedLine = line.trim();
-                if (trimmedLine.length > 0 && !trimmedLine.startsWith('<p>')) {
+                if (trimmedLine.length > 0 && !trimmedLine.startsWith("<p>")) {
                     return `<p>${trimmedLine}</p>`;
                 }
                 return trimmedLine;

--- a/plugin/js/parsers/SangtacvietParser.js
+++ b/plugin/js/parsers/SangtacvietParser.js
@@ -122,7 +122,7 @@ class SangtacvietParser extends Parser {
                     return `<p>${trimmedLine}</p>`;
                 }
                 return trimmedLine;
-            }).join('\n');
+            }).join("\n");
         }
         
         let content = util.sanitize(rawData);

--- a/plugin/js/parsers/SangtacvietParser.js
+++ b/plugin/js/parsers/SangtacvietParser.js
@@ -112,7 +112,20 @@ class SangtacvietParser extends Parser {
         let title = newDoc.dom.createElement("h1");
         title.textContent = json.chaptername;
         newDoc.content.appendChild(title);
-        let content = util.sanitize(json.data);
+
+        let rawData = json.data;
+
+        if (json.bookhost === 'faloo') {
+            rawData = rawData.split('\n').map(line => {
+                let trimmedLine = line.trim();
+                if (trimmedLine.length > 0 && !trimmedLine.startsWith('<p>')) {
+                    return `<p>${trimmedLine}</p>`;
+                }
+                return trimmedLine;
+            }).join('\n');
+        }
+        
+        let content = util.sanitize(rawData);
         util.moveChildElements(content.body, newDoc.content);
         return newDoc.dom;
     }

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebToEpub",
-  "version": "1.0.12.58",
+  "version": "1.0.12.59",
   "default_locale": "en",
   "icons": {
     "128": "book128.png"


### PR DESCRIPTION
Hi,

I found a rendering issue in the `SangtacvietParser` specifically concerning the `faloo` host. The content in some later chapters is rendered as a single continuous block of text without proper line breaks in the final EPUB.

**Root Cause:**
The API response from the `faloo` host is inconsistent. While early chapters return properly formatted HTML with `<p>` tags, later chapters (usually from around chapter 50 onwards) return raw text using only `\n\t` for line breaks. Because `util.sanitize()` doesn't convert raw `\n` to HTML breaks, the EPUB renders these unformatted chapters as one huge block of text.

**Proposed Fix:**
I have added a specific condition for `json.bookhost === 'faloo'` in the `buildChapter` function. It processes the raw data line-by-line and wraps any unformatted lines (lines that do not already start with `<p>`) in `<p>` tags before passing them to `util.sanitize()`. This fixes the broken chapters, safely maintains the structure of the already correct ones, and prevents any side effects on other hosts.

**Evidence (Attached File):**
Due to GitHub's character limit, I have attached a `.txt` file to this PR. The attached file contains:
1. The source URL of the novel for testing.
2. The full raw JSON API response for **Chapter 1** (Working - natively has `<p>` tags).
3. The full raw JSON API response for **Chapter 216** (Failing - missing `<p>` tags, only has `\n\t`).

[new 15.txt](https://github.com/user-attachments/files/27857111/new.15.txt)