### PR TITLE
Update AliceswParser

### DIFF
--- a/plugin/js/parsers/AliceswParser.js
+++ b/plugin/js/parsers/AliceswParser.js
@@ -5,7 +5,7 @@ parserFactory.register("alicesw.com", () => new AliceswParser());
 class AliceswParser extends Parser {
     constructor() {
         super();
-        this.minimumThrottle = 3000;
+        this.minimumThrottle = 5000;
     }
 
     async getChapterUrls(dom) {

--- a/plugin/js/parsers/AliceswParser.js
+++ b/plugin/js/parsers/AliceswParser.js
@@ -5,6 +5,7 @@ parserFactory.register("alicesw.com", () => new AliceswParser());
 class AliceswParser extends Parser {
     constructor() {
         super();
+        this.minimumThrottle = 3000;
     }
 
     async getChapterUrls(dom) {
@@ -16,9 +17,14 @@ class AliceswParser extends Parser {
         return util.hyperlinksToChapterList(menu);
     }
 
+    async fetchChapter(url) {
+        let options = { parser: this };
+        return (await HttpClient.wrapFetch(url, options)).responseXML;
+    }
+
     extractSubject(dom) {
         let genres = [...dom.querySelectorAll(".novel_info > p:nth-child(2) a")];
-        let tags = [...dom.querySelectorAll(".tags_list a")]; 
+        let tags = [...dom.querySelectorAll(".tags_list a")];
         return [...genres, ...tags].map(e => e.textContent).join(", ");
     }
 
@@ -49,5 +55,20 @@ class AliceswParser extends Parser {
 
     extractDescription(dom) {
         return dom.querySelector(".jianjie p").textContent.trim();
+    }
+
+    isCustomError(response) {
+        // First check is for captcha, second one for temporary rate limit.
+        return (response.responseXML.querySelector(".box h2")?.textContent.trim() == "访问验证") || (response.responseXML.body.innerHTML.includes("cuteAlert("));
+    }
+
+    setCustomErrorResponse(url, wrapOptions, checkedresponse) {
+        let newresp = {};
+        newresp.url = url;
+        newresp.wrapOptions = wrapOptions;
+        newresp.response = {};
+        newresp.response.url = checkedresponse.response.url;
+        newresp.response.status = 403;
+        return newresp;
     }
 }

--- a/plugin/js/parsers/Template.js
+++ b/plugin/js/parsers/Template.js
@@ -212,12 +212,12 @@ class TemplateParser extends Parser { // eslint-disable-line no-unused-vars
     // Optional, supply these if site can send challenge pages for some chapters
     /*
     // return true if response is a challenge response
-    isCustomError(response){
+    isCustomError(response) {
         return (response.responseXML.title == "Just a moment...");
     }
 
     // what to do if encounter challenge
-    setCustomErrorResponse(url, wrapOptions){
+    setCustomErrorResponse(url, wrapOptions) {
         let newresp = {};
         newresp.url = url;
         newresp.wrapOptions = wrapOptions;


### PR DESCRIPTION
Added error handling for captcha and rate limit challenge pages.
Tested on: https://www.alicesw.com/novel/52192.html
Approximately a Captcha every 60 ch, and Rate Limit every 3 Captcha (IP Locked, it seems). 
Changing the throttle above 3sec doesn't seem to chance the amount of chapter it takes to get a captcha, nor avoid rate limit.
