### PR TITLE
fix: make Novel543Parser toc URL construction idempotent

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
     { "name": "ltmerletti"},
     { "name": "fnx4"},
     { "name": "Fox6935"},
-    { "name": "ARYAN-9099" }
+    { "name": "ARYAN-9099" },
+    { "name": "kuwoyuki", "email": "kuwoyuki.gh@cock.li" }
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/js/parsers/Novel543Parser.js
+++ b/plugin/js/parsers/Novel543Parser.js
@@ -9,11 +9,12 @@ class Novel543Parser extends Parser {
     }
 
     async getChapterUrls(dom) {
-        let tocUrl = dom.baseURI;
-        tocUrl += tocUrl.endsWith("/")
-            ? "dir"
-            : "/dir";
-        let nextDom = (await HttpClient.wrapFetch(tocUrl)).responseXML;
+        let tocUrl = new URL(dom.baseURI);
+        let [bookId] = tocUrl.pathname.split("/").filter(Boolean);
+        tocUrl.pathname = `/${bookId}/dir`;
+        tocUrl.hash = "";
+        tocUrl.search = "";
+        let nextDom = (await HttpClient.wrapFetch(tocUrl.href)).responseXML;
         let menu = nextDom.querySelector("div.chaplist ul:nth-of-type(2)");
         return util.hyperlinksToChapterList(menu);
     }

--- a/readme.md
+++ b/readme.md
@@ -824,6 +824,7 @@ Don't forget to give the project a star! Thanks again!
     <li>fnx4</li>
     <li>Fox6935</li>
     <li>ARYAN-9099</li>
+    <li>kuwoyuki</li>
   </ul>
 </details>
 


### PR DESCRIPTION
First path segment on those websites is always the book ID, so just take the first segment and append `/dir` to it.
This avoids confusing errors if you open WebToEpub on the TOC or chapter page