### PR TITLE
Update WanderingInnParser Titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
     { "name": "ltmerletti"},
     { "name": "fnx4"},
     { "name": "Fox6935"},
-    { "name": "ARYAN-9099" }
+    { "name": "ARYAN-9099" },
+    { "name": "bendur"}
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/js/parsers/WanderinginnParser.js
+++ b/plugin/js/parsers/WanderinginnParser.js
@@ -17,7 +17,7 @@ class WanderinginnParser extends WordpressBaseParser {
     }
 
     findChapterTitle(dom) {
-        const titles = [...dom.querySelectorAll("h2.elementor-heading-title, div#reader-content")];
+        const titles = [...dom.querySelectorAll("div.post h2.elementor-heading-title, div#reader-content")];
         let previous = null;
         for (const title of titles) {
             if (title.id === "reader-content") {

--- a/readme.md
+++ b/readme.md
@@ -824,6 +824,7 @@ Don't forget to give the project a star! Thanks again!
     <li>fnx4</li>
     <li>Fox6935</li>
     <li>ARYAN-9099</li>
+    <li>bendur</li>
   </ul>
 </details>
 


### PR DESCRIPTION
This PR fixes the titles for The Wandering Inn chapters that have started picking up an h2 for comments being disabled instead of the chapter title. 

It modifies the title selector to be prepended by `div.post`. 

Example page: https://wanderinginn.com/2017/03/03/rw1-00/ 

Tested on Firefox with several volumes.

Fixes #2528 