### PR TITLE
Update Sbxh parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     { "name": "fnx4"},
     { "name": "Fox6935"},
     { "name": "ARYAN-9099" },
-    { "name": "Bartuzen" }
+    { "name": "Bartuzen", "email": "git@bartuzen.dev" }
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
     { "name": "ltmerletti"},
     { "name": "fnx4"},
     { "name": "Fox6935"},
-    { "name": "ARYAN-9099" }
+    { "name": "ARYAN-9099" },
+    { "name": "Bartuzen" }
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/js/parsers/experimental/Sbxh1Parser.js
+++ b/plugin/js/parsers/experimental/Sbxh1Parser.js
@@ -1,7 +1,7 @@
 "use strict";
 
 parserFactory.registerUrlRule(
-    (url) => /^https?:\/\/(?:www\.)?sbxh\d+\.com(?:\/|$)/.test(url),
+    (url) => /^https?:\/\/(?:www\.)?(sbxh|toki)\d+\.com(?:\/|$)/.test(url),
     () => new Sbxh1Parser(),
 );
 
@@ -10,17 +10,22 @@ class Sbxh1Parser extends Parser {
         super();
     }
 
-    getChapterUrls(dom) {
+    async getChapterUrls(dom) {
         let novelId = Sbxh1Parser.extractNovelId(dom.baseURI);
         if (novelId == null) {
             return [];
         }
+        let chapterLinks = Sbxh1Parser.parseChapters(dom, novelId);
 
-        let chapterLinks = [
-            ...dom.querySelectorAll(`a.novel-ep-link[href*="/novel/${novelId}/"]`),
-        ];
-        if (chapterLinks.length === 0) {
-            chapterLinks = [...dom.querySelectorAll(`a[href*="/novel/${novelId}/"]`)];
+        let page = 1;
+        while (chapterLinks[chapterLinks.length - 1].querySelector(".ne-num").textContent !== "1화") {
+            page++;
+            const xml = (await HttpClient.wrapFetch(`${dom.baseURI}?epage=${page}`)).responseXML;
+            let newLinks = Sbxh1Parser.parseChapters(xml, novelId);
+            if (newLinks.length === 0) {
+                break;
+            }
+            chapterLinks.push(...newLinks);
         }
 
         let chaptersByUrl = new Map();
@@ -32,9 +37,12 @@ class Sbxh1Parser extends Parser {
                     return;
                 }
                 let normalized = util.normalizeUrlForCompare(a.href);
+                let chapterNumber = a.querySelector(".ne-num").textContent;
+                let chapterTitle = a.querySelector(".ne-title").textContent;
+
                 let chapter = {
                     sourceUrl: a.href,
-                    title: Sbxh1Parser.cleanEpisodeTitle(a.textContent),
+                    title: `${chapterNumber} - ${chapterTitle}`,
                     episodeNumber: episodeNumber,
                 };
                 let existing = chaptersByUrl.get(normalized);
@@ -52,6 +60,16 @@ class Sbxh1Parser extends Parser {
                 sourceUrl: a.sourceUrl,
                 title: a.title,
             }));
+    }
+
+    static parseChapters(dom, novelId) {
+        let chapterLinks = [
+            ...dom.querySelectorAll(`a.novel-ep-link[href*="/novel/${novelId}/"]`),
+        ];
+        if (chapterLinks.length === 0) {
+            chapterLinks = [...dom.querySelectorAll(`a[href*="/novel/${novelId}/"]`)];
+        }
+        return chapterLinks;
     }
 
     findContent(dom) {
@@ -297,15 +315,6 @@ class Sbxh1Parser extends Parser {
             new URL(url).pathname.match(new RegExp(`^/novel/${novelId}/\\d+$`)) !=
             null
         );
-    }
-
-    static cleanEpisodeTitle(title) {
-        return title
-            .replace(/\bNEW\b/g, "")
-            .replace(/\d{2}\.\s*\d{2}\.\s*\d{2}\.?/g, "")
-            .replace(/\s+/g, " ")
-            .replace(/^(\d+\s*화)\1$/, "$1")
-            .trim();
     }
 
     static extractEpisodeNumber(title) {

--- a/plugin/js/parsers/experimental/Sbxh1Parser.js
+++ b/plugin/js/parsers/experimental/Sbxh1Parser.js
@@ -118,7 +118,7 @@ class Sbxh1Parser extends Parser {
     }
 
     findCoverImageUrl(dom) {
-        return dom.querySelector("main img[alt]")?.src ?? null;
+        return dom.querySelector(".nd-thumb img[alt]")?.src ?? null;
     }
 
     findChapterTitle(dom) {

--- a/plugin/js/parsers/experimental/Sbxh1Parser.js
+++ b/plugin/js/parsers/experimental/Sbxh1Parser.js
@@ -15,54 +15,46 @@ class Sbxh1Parser extends Parser {
         if (novelId == null) {
             return [];
         }
-        let chapterLinks = Sbxh1Parser.parseChapters(dom, novelId);
+        let chapterLinks = [];
 
-        let page = 1;
-        while (chapterLinks[chapterLinks.length - 1].querySelector(".ne-num").textContent !== "1화") {
+        let page = 0;
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
             page++;
             const xml = (await HttpClient.wrapFetch(`${dom.baseURI}?epage=${page}`)).responseXML;
-            let newLinks = Sbxh1Parser.parseChapters(xml, novelId);
+            let newLinks = Sbxh1Parser.extractChapterLinks(xml, novelId);
             if (newLinks.length === 0) {
                 break;
             }
-            chapterLinks.push(...newLinks);
-        }
 
-        let chaptersByUrl = new Map();
-        chapterLinks
-            .filter((a) => Sbxh1Parser.isEpisodeUrl(a.href, novelId))
-            .forEach((a) => {
-                let episodeNumber = Sbxh1Parser.extractEpisodeNumber(a.textContent);
-                if (episodeNumber == null) {
-                    return;
-                }
-                let normalized = util.normalizeUrlForCompare(a.href);
+            let newChapters = newLinks.map((a) => {
                 let chapterNumber = a.querySelector(".ne-num").textContent;
                 let chapterTitle = a.querySelector(".ne-title").textContent;
 
-                let chapter = {
+                return {
                     sourceUrl: a.href,
                     title: `${chapterNumber} - ${chapterTitle}`,
-                    episodeNumber: episodeNumber,
                 };
-                let existing = chaptersByUrl.get(normalized);
-                if (
-                    existing == null ||
-                    Sbxh1Parser.isBetterEpisodeTitle(chapter.title, existing.title)
-                ) {
-                    chaptersByUrl.set(normalized, chapter);
-                }
             });
 
-        return [...chaptersByUrl.values()]
-            .sort((a, b) => a.episodeNumber - b.episodeNumber)
-            .map((a) => ({
-                sourceUrl: a.sourceUrl,
-                title: a.title,
-            }));
+            const exists = newChapters.some((newCh) =>
+                chapterLinks.some((ch) => ch.sourceUrl === newCh.sourceUrl)
+            );
+            if (exists) {
+                break;
+            }
+
+            chapterLinks.push(...newChapters);
+
+            if (newChapters[newChapters.length - 1].title.startsWith("1화 -")) {
+                break;
+            }
+        }
+
+        return chapterLinks.reverse();
     }
 
-    static parseChapters(dom, novelId) {
+    static extractChapterLinks(dom, novelId) {
         let chapterLinks = [
             ...dom.querySelectorAll(`a.novel-ep-link[href*="/novel/${novelId}/"]`),
         ];
@@ -308,28 +300,6 @@ class Sbxh1Parser extends Parser {
 
     static extractNovelId(url) {
         return new URL(url).pathname.match(/^\/novel\/(\d+)/)?.[1] ?? null;
-    }
-
-    static isEpisodeUrl(url, novelId) {
-        return (
-            new URL(url).pathname.match(new RegExp(`^/novel/${novelId}/\\d+$`)) !=
-            null
-        );
-    }
-
-    static extractEpisodeNumber(title) {
-        let match = title.match(/(\d+)\s*화/);
-        return match == null ? null : parseInt(match[1], 10);
-    }
-
-    static isBetterEpisodeTitle(candidate, existing) {
-        let candidateHasNumber = /^\d+\s*화\b/.test(candidate);
-        let existingHasNumber = /^\d+\s*화\b/.test(existing);
-        return (
-            (candidateHasNumber && !existingHasNumber) ||
-            (candidateHasNumber === existingHasNumber &&
-                candidate.length > existing.length)
-        );
     }
 
     static extractViewerInfo(dom) {

--- a/plugin/js/parsers/experimental/Sbxh1Parser.js
+++ b/plugin/js/parsers/experimental/Sbxh1Parser.js
@@ -21,7 +21,11 @@ class Sbxh1Parser extends Parser {
         // eslint-disable-next-line no-constant-condition
         while (true) {
             page++;
-            const xml = (await HttpClient.wrapFetch(`${dom.baseURI}?epage=${page}`)).responseXML;
+
+            let nextUrl = new URL(dom.baseURI);
+            nextUrl.searchParams.set("epage", page);
+            const { responseXML: xml } = await HttpClient.wrapFetch(nextUrl.href);
+
             let newLinks = Sbxh1Parser.extractChapterLinks(xml, novelId);
             if (newLinks.length === 0) {
                 break;

--- a/readme.md
+++ b/readme.md
@@ -824,6 +824,7 @@ Don't forget to give the project a star! Thanks again!
     <li>fnx4</li>
     <li>Fox6935</li>
     <li>ARYAN-9099</li>
+    <li>Bartuzen</li>
   </ul>
 </details>
 


### PR DESCRIPTION
Made some improvements to Sbxh parser.
- Added site's mirror domain.
- Chapters are now fetched from all paginated chapter list pages. Previously, only the chapters visible on the currently loaded page were fetched.
- Rather than using a broad selector to get chapter title and parsing it, I instead directly fetched the title which gives a better result.
- Chapter title now always includes both chapter title and chapter count. Sometimes both chapter count and title can be same which results in a title like `1화 - 1화`, but since title format isn't consistent, I kept it like this.