### PR TITLE
Fix builds on Linux and macOS

### DIFF
--- a/eslint/pack.js
+++ b/eslint/pack.js
@@ -145,9 +145,9 @@ var addPopupHtmlToZip = function(zip) {
     return readFilePromise("../plugin/popup.html")
         .then(function(data) {
             let htmlAsString = data.toString()
-                .split("\r")
+                .split("\n")
                 .filter(s => !s.includes("/experimental/"))
-                .join("\r");
+                .join("\n");
             zip.add("popup.html", new zipjs.TextReader(htmlAsString));
         });
 };


### PR DESCRIPTION
Currently, if you build the extension on Linux or macOS, extension's popup won't open which makes the extension unusable. Using the correct line separator fixes the issue on both Linux and macOS. I haven't tested it on Windows, but it should work there as well.