### PR TITLE
Add new option to change `no content found error` into `HTTP 403 error`

### DIFF
--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -467,6 +467,10 @@
 		"message": "Skip chapters that return HTTP 404 error",
 		"description": "Label in front of checkbox for skipping chapters that can't be fetched"
 	},
+	"__MSG_label_No_Content_To_Error_403_Page__": {
+		"message": "Treat 'no content found error' as 'HTTP 403 error'.",
+		"description": "Label in front of checkbox for treating 'no content found' error as 'HTTP 403 error'"
+	},
 	"__MSG_label_Stylesheet__": {
 		"message": "Stylesheet:",
 		"description": "Label in front of edit field for setting the stylesheet (in Advanced settings)."
@@ -759,7 +763,7 @@
 		"description": "Internal message for developer."
 	},
 	"warning403ErrorResponse": {
-		"message": "WARNING: Site '$host$' has sent an Access Denied (403) error.\nYou may need to logon to site, or browse site normally\nuntil you get a Cloudflare \"Are you a human\" page or satisfy some other CAPTCHA\nbefore WebToEpub can continue.\nThis happens if you are downloading to fast try to increase 'Advanced Options -> Delay per chapter in ms'\n",
+		"message": "WARNING: Site '$host$' has sent an Access Denied (403) error.\nYou may need to logon to site, or browse site normally\nuntil you get a Cloudflare \"Are you a human\" page or satisfy some other CAPTCHA\nbefore WebToEpub can continue.\nThis happens if you are downloading too fast, try to increase 'Advanced Options -> Delay per chapter in ms'\n",
 		"description": "Warning message for user when site sends a 403 response.",
 		"placeholders": {
 			"host": {

--- a/plugin/js/HttpClient.js
+++ b/plugin/js/HttpClient.js
@@ -214,6 +214,10 @@ class HttpClient {
         {
             let response = await fetch(url, wrapOptions.fetchOptions);
             let ret = await HttpClient.checkResponseAndGetData(url, wrapOptions, response);
+            if (wrapOptions.parser?.isNoContentToError403AndContentNull(ret)) {
+                let CustomNoContentToError403Response = wrapOptions.parser.setNoContentToError403Response(url, wrapOptions, ret);
+                return wrapOptions.errorHandler.onResponseError(CustomNoContentToError403Response.url, CustomNoContentToError403Response.wrapOptions, CustomNoContentToError403Response. response, CustomNoContentToError403Response.errorMessage);
+            }
             if (wrapOptions.parser?.isCustomError(ret)) {
                 let CustomErrorResponse = wrapOptions.parser.setCustomErrorResponse(url, wrapOptions, ret);
                 return wrapOptions.errorHandler.onResponseError(CustomErrorResponse.url, CustomErrorResponse.wrapOptions, CustomErrorResponse.response, CustomErrorResponse.errorMessage);

--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -95,6 +95,26 @@ class Parser {
         return {};
     }
 
+    isNoContentToError403AndContentNull(response) {
+        if (this.userPreferences.noContentToError403.value) {
+            let content = this.findContent(response.responseXML);
+            return (content == null);
+        }
+        else {
+            return false;
+        }
+    }
+
+    setNoContentToError403Response(url, wrapOptions, checkedresponse) {
+        let ret = {};
+        ret.url = url;
+        ret.wrapOptions = wrapOptions;
+        ret.response = {};
+        ret.response.url = checkedresponse.response.url;
+        ret.response.status = 403;
+        return ret;
+    }
+
     onUserPreferencesUpdate(userPreferences) {
         this.userPreferences = userPreferences;
         this.imageCollector.onUserPreferencesUpdate(userPreferences);
@@ -598,8 +618,14 @@ class Parser {
             pageParser.removeUnusedElementsToReduceMemoryConsumption(webPageDom);
             let content = pageParser.findContent(webPage.rawDom);
             if (content == null) {
-                let errorMsg = UIText.Error.errorContentNotFound(webPage.sourceUrl);
-                throw new Error(errorMsg);
+                if (this.userPreferences.noContentToError403.value) {
+                    let errorMsg = UIText.Warning.warning403ErrorResponse(new URL(webPage.sourceUrl).hostname);
+                    throw new Error(errorMsg);
+                }
+                else {
+                    let errorMsg = UIText.Error.errorContentNotFound(webPage.sourceUrl);
+                    throw new Error(errorMsg);
+                }
             }
             return pageParser.fetchImagesUsedInDocument(content, webPage);
         } catch (error) {
@@ -634,7 +660,13 @@ class Parser {
 
     // Hook if need to chase hyperlinks in page to get all chapter content
     async fetchChapter(url) {
-        return (await HttpClient.wrapFetch(url)).responseXML;
+        if (this.userPreferences.noContentToError403.value) {
+            let options = { parser: this };
+            return (await HttpClient.wrapFetch(url, options)).responseXML;
+        }
+        else {
+            return (await HttpClient.wrapFetch(url)).responseXML;
+        }
     }
 
     updateReadingList() {

--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -106,6 +106,7 @@ class UserPreferences { // eslint-disable-line no-unused-vars
         this.selectRetryLonger = this.addPreference("selectRetryLonger", "selectRetryLongerCheckbox", false);
         this.removeTranslated = this.addPreference("removeTranslated", "removeTranslatedCheckbox", false);
         this.skipChaptersThatFailFetch = this.addPreference("skipChaptersThatFailFetch", "skipChaptersThatFailFetchCheckbox", false);
+        this.noContentToError403 = this.addPreference("noContentToError403", "noContentToError403Checkbox", false);
         this.maxChaptersPerEpub = this.addPreference("maxChaptersPerEpub", "maxChaptersPerEpubTag", "10,000");
         this.manualDelayPerChapter = this.addPreference("manualDelayPerChapter", "manualDelayPerChapterTag", "0");
         this.overrideMinimumDelay = this.addPreference("overrideMinimumDelay", "overrideMinimumDelayCheckbox", false);

--- a/plugin/js/parsers/Template.js
+++ b/plugin/js/parsers/Template.js
@@ -200,9 +200,11 @@ class TemplateParser extends Parser { // eslint-disable-line no-unused-vars
     // or site can send challenge pages for some chapters
     /*
     async fetchChapter(url) {
+        // NoContentToError403 option will not be able to handle challenge pages
         return (await HttpClient.wrapFetch(url)).responseXML;
 
         // Handling to catch sites that send challenge pages
+        // needed for the NoContentToError403 option to work
         // Note, need to implement isCustomError() and setCustomErrorResponse()
         let options = { parser: this };
         return (await HttpClient.wrapFetch(url, options)).responseXML;

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -459,6 +459,10 @@
                         <td><input id="skipChaptersThatFailFetchCheckbox" type="checkbox" name="skipChaptersThatFailFetchCheckbox" value="false"></td>
                         <td>__MSG_label_Skip_Chapters_That_Fail_Fetch__</td>
                     </tr>
+                    <tr id="noContentToError403">
+                        <td><input id="noContentToError403Checkbox" type="checkbox" name="noContentToError403Checkbox" value="false"></td>
+                        <td>__MSG_label_No_Content_To_Error_403_Page__</td>
+                    </tr>
                     <tr id="maxChaptersPerEpub">
                         <td>
                             <select id="maxChaptersPerEpubTag">


### PR DESCRIPTION
Add the option to turn `no content found error` into an `HTTP 403 error`.
It is useful as a workaround when `isCustomError` and `setCustomErrorResponse` are not implemented in a parser.
When a site gives the wrong error code when giving the user a challenge page (captcha, Cloudflare, rate limit, etc...).
It allows the user to clear the challenge page and resume downloading from where they were, instead of losing all progress or ending up with multiple fragmented EPUBs when downloading a single book.

Tested and working on alicesw.com, with and without `isCustomError` and `setCustomErrorResponse` implemented in the AliceswParser.

Only issue is the fact that this implementation doesn't work if a custom parser already include `fetchChapter` without passing a reference to the `parser` in the `wrapOptions`.
If it fails in this way and the `NoContentToError403 option` is selected, it will now throw an `HTTP 403 error` instead of a `no content found error`, before aborting the download.

Tested and failing (has expected) on alicesw.com, without passing a reference to the `parser` in `wrapOptions` when `fetchChapter` implemented in the AliceswParser.
Tested and working on alicesw.com, while passing a reference to the `parser` in `wrapOptions` when `fetchChapter` implemented in the AliceswParser.

#2785