### PR TITLE
Fixed Pawchive: missing content from unescaped <>-wrapped chapter text

### DIFF
--- a/plugin/js/parsers/PawchiveParser.js
+++ b/plugin/js/parsers/PawchiveParser.js
@@ -70,7 +70,7 @@ class PawchiveParser extends Parser {
         header.textContent = post.title;
         newDoc.content.appendChild(header);
 
-        let content = util.sanitize(post.content);
+        let content = util.sanitize(this.escapeUnknownTags(post.content));
         util.moveChildElements(content.body, newDoc.content);
 
         let attachments = post.attachments;
@@ -96,6 +96,27 @@ class PawchiveParser extends Parser {
         }
 
         return newDoc.dom;
+    }
+
+    escapeUnknownTags(html) {
+        return html.replace(/<([^<>]+)>/g, (match, inner) => {
+            let candidate = inner.trim();
+            if (candidate.startsWith("!--") ||
+                /^!doctype\b/i.test(candidate) ||
+                candidate.startsWith("?")) {
+                return match;
+            }
+            let tag = candidate.match(/^\/?\s*([A-Za-z][\w:-]*)/);
+            if (tag !== null && this.isKnownHtmlTag(tag[1])) {
+                return match;
+            }
+            return `&lt;${inner}&gt;`;
+        });
+    }
+
+    isKnownHtmlTag(tagName) {
+        let element = document.createElement(tagName);
+        return element.constructor.name !== "HTMLUnknownElement";
     }
 
     buildImageUrl(path) {


### PR DESCRIPTION
## Problem

This is not strictly an issue with the parser. Some authors, particularly LitRPG authors, wrap text such as system messages in angle brackets (`<>`).

The API does not always escape these characters correctly. As a result, both the Pawchive website and the WebToEpub parser interpret valid chapter content as HTML tags. This is primarily an API issue, but this change provides a workaround on the parser side.

The following chapter and API links demonstrate the issue. The chapter is supposed to contain numerous angle-bracketed messages, including one at the very beginning. However, the first paragraph is missing from the website because the website is affected by the same issue:

- Chapter:
  https://pawchive.pw/patreon/user/122910394/post/161282828
- API:
  https://pawchive.pw/api/v1/patreon/user/122910394/post/161282828

## Fix

Before sanitizing Pawchive chapter content, detect angle-bracket expressions whose tag names are not recognized HTML elements and escape them as text.

Recognized HTML tags, including tags with attributes, are left unchanged.