### PR TITLE
Trust image bytes over Content-Type when detecting media type

### DIFF
--- a/plugin/js/ImageCollector.js
+++ b/plugin/js/ImageCollector.js
@@ -413,17 +413,22 @@ class ImageCollector {
     }
 
     fixupInvalidMediaType(imageInfo) {
+        // Trust the actual bytes over the server's Content-Type. Some CDNs (e.g. Royal
+        // Road) return a wrong type (image/png for a JPEG), producing an invalid EPUB
+        // image that readers reject. Fall back to the header/extension only when the
+        // bytes are an unrecognised format.
+        let detected = util.detectMimeType(imageInfo.getBase64(25));
+        if (detected != null) {
+            imageInfo.mediaType = detected;
+            return;
+        }
         if (!imageInfo.mediaType?.startsWith("image")) {
-            imageInfo.mediaType = util.detectMimeType(imageInfo.getBase64(25));
-            if (imageInfo.mediaType == null)
-            {
-                let path = new URL(imageInfo.sourceUrl).pathname;
-                let index = path.lastIndexOf(".");
-                let format = (index < 0)
-                    ? "jpeg"
-                    : path.substring(index + 1);
-                imageInfo.mediaType = "image/" + format;
-            }
+            let path = new URL(imageInfo.sourceUrl).pathname;
+            let index = path.lastIndexOf(".");
+            let format = (index < 0)
+                ? "jpeg"
+                : path.substring(index + 1);
+            imageInfo.mediaType = "image/" + format;
         }
     }
 


### PR DESCRIPTION
Some CDNs send a wrong `Content-Type`. Concretely, Royal Road serves cover images with `Content-Type: image/png` when the file is actually a JPEG. WebToEpub trusts the header (`imageInfo.mediaType = xhr.contentType`), so the image ends up stored as `.png` / `image/png` while the bytes are JPEG — an invalid EPUB image that readers reject (no cover, and in strict readers like Apple Books the whole book can render degraded).

### Fix
`fixupInvalidMediaType` now byte-sniffs the real type with `util.detectMimeType()` and prefers it, falling back to the header/extension only when the bytes are an unrecognised format. Correctly-typed images are unaffected because the sniffed type matches the header.

### Repro
`curl -I "https://www.royalroadcdn.com/public/covers-large/<cover>.jpg"` returns `content-type: image/png` for JPEG bytes; the packed EPUB's cover is declared `image/png` but `file` reports JPEG.

### Checklist
- Unit tests: unaffected.
- eslint: clean.
- No new user-facing behavior/toggle (bug fix).
- Base branch: `ExperimentalTabMode`.