### PR TITLE
change loadReadingListFromJson

### DIFF
--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -263,9 +263,9 @@ class UserPreferences { // eslint-disable-line no-unused-vars
     loadReadingListFromJson(json) {
         let val = json[ReadingList.storageName];
         if (val !== undefined) {
-            let serialized = JSON.stringify(val);
-            this.readingList = ReadingList.fromJson(serialized);
-            window.localStorage.setItem(ReadingList.storageName, serialized);
+            for (let i = 0; i < val.epubs.length; i++) {
+                this.readingList.setEpub(val.epubs[i].toc, val.epubs[i].lastUrl);
+            }
         }
     }
 


### PR DESCRIPTION
#2254

I changed how userpreferences imports a reading list.

Before the change it was a simple override. All old reading list progress got deleted and only the progress from the json file was kept.

I changed the behavior as i think it is wrong.

Someone uses WebToEpub for a while and than remembers that he had the reading progress from a few novels on an old laptop. If he now reads the option file from file all his current progress gets lost and he only has the progress from his old laptop.

I think that is wrong. I changed it so that the json file gets merged with the already existing reading list. If there are two different lastChapter for the same toc the json file has priority. (It is a simple set.add(tocURL, lastChapterURL))