### PR TITLE
Update SyosetuOrgParser

### DIFF
--- a/plugin/js/parsers/SyosetuOrgParser.js
+++ b/plugin/js/parsers/SyosetuOrgParser.js
@@ -10,12 +10,14 @@ class SyosetuOrgParser extends Parser {
 
     async getChapterUrls(dom) {
         let baseUrl = this.getBaseUrl(dom);
-        let menu = dom.querySelector("div.ss table");
+        let menu = [...dom.querySelectorAll("div.ss table a[href]")].map(a => util.hyperLinkToChapter(a));
         //Handle oneshot page
-        if (menu.querySelector("caption")) { 
+        let isSingleChapter = false;
+        menu.forEach(item => {if (item.sourceUrl.includes("review")) {isSingleChapter = true}});
+        if (isSingleChapter) { 
             return this.singleChapterStory(baseUrl, dom);
         }
-        return util.hyperlinksToChapterList(menu);
+        return menu;
     }
 
     findContent(dom) {

--- a/plugin/js/parsers/SyosetuOrgParser.js
+++ b/plugin/js/parsers/SyosetuOrgParser.js
@@ -10,10 +10,10 @@ class SyosetuOrgParser extends Parser {
 
     async getChapterUrls(dom) {
         let baseUrl = this.getBaseUrl(dom);
-        let menu = [...dom.querySelectorAll("div.ss table a[href]")].map(a => util.hyperLinkToChapter(a));
+        let menu = [...dom.querySelectorAll("div.ss:nth-child(1) table a[href]")].map(a => util.hyperLinkToChapter(a));
         //Handle oneshot page
         let isSingleChapter = false;
-        menu.forEach(item => {if (item.sourceUrl.includes("review")) {isSingleChapter = true}});
+        menu.forEach(item => {if (item.sourceUrl.includes("review")) {isSingleChapter = true;}});
         if (isSingleChapter) { 
             return this.singleChapterStory(baseUrl, dom);
         }

--- a/plugin/js/parsers/SyosetuOrgParser.js
+++ b/plugin/js/parsers/SyosetuOrgParser.js
@@ -10,7 +10,7 @@ class SyosetuOrgParser extends Parser {
 
     async getChapterUrls(dom) {
         let baseUrl = this.getBaseUrl(dom);
-        let menu = [...dom.querySelectorAll("div.ss:nth-child(1) table a[href]")].map(a => util.hyperLinkToChapter(a));
+        let menu = [...dom.querySelectorAll("div.ss table a[href]")].map(a => util.hyperLinkToChapter(a));
         //Handle oneshot page
         let isSingleChapter = false;
         menu.forEach(item => {if (item.sourceUrl.includes("review")) {isSingleChapter = true;}});


### PR DESCRIPTION
Fix an edge case in getChapterUrls when single story has a table in it's content. 
Assume: Multi chapters page shouldn't have review table.
Edge case: https://syosetu.org/novel/266239/