### PR TITLE
Trim lines (elements) from chapter body before packing into EPUB file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ package-lock.json
 .vscode
 /plugin/dompurify/
 /plugin/@zip.js/
+mise.toml
+bun.lock

--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
     { "name": "possibletoactual" },
     { "name": "kuwoyuki", "email": "kuwoyuki.gh@cock.li" },
     { "name": "bendur"},
-    { "name": "Bartuzen", "email": "git@bartuzen.dev" }
+    { "name": "Bartuzen", "email": "git@bartuzen.dev" },
+    { "name": "g-play01", "email": "41573585+g-play01@users.noreply.github.com"}
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -367,6 +367,14 @@
 		"message": "Delay per chapter in ms",
 		"description": "Delay per chapter in ms"
 	},
+	"__MSG_label_Remove_First_Lines_Of_Chapter__": {
+		"message": "Number of lines to remove from start of chapter body",
+		"description": "Label for numeric input that strips the first N lines from each chapter's content"
+	},
+	"__MSG_label_Remove_Last_Lines_Of_Chapter__": {
+		"message": "Number of lines to remove from end of chapter body",
+		"description": "Label for numeric input that strips the last N lines from each chapter's content"
+	},
 	"__MSG_label_Manually_Select_Parser__": {
 		"message": "Manually Select Parser:",
 		"description": "Label for menu to change parser (in advanced options section)"

--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -144,6 +144,7 @@ class Parser {
         util.removeEmptyAttributes(content);
         util.removeSpansWithNoAttributes(content);
         util.removeEmptyDivElements(content);
+        this.trimContentLines(content);
         util.removeTrailingWhiteSpace(content);
         if (util.isElementWhiteSpace(content)) {
             let errorMsg = UIText.Warning.warningNoVisibleContent(webPage.sourceUrl);
@@ -201,6 +202,43 @@ class Parser {
         util.removeMicrosoftWordCrapElements(element);
         util.removeShareLinkElements(element);
         util.removeLeadingWhiteSpace(element);
+    }
+
+    // Remove the first/last N top-level "lines" (elements) from the chapter body,
+    // per the removeFirstLinesOfChapter / removeLastLinesOfChapter user preferences.
+    trimContentLines(content) {
+        // parseInt matches the existing manualDelayPerChapter convention (see getRateLimit).
+        // The (0 < n) guards below treat blank/garbage (NaN) and any negative as "disabled".
+        let firstN = parseInt(this.userPreferences.removeFirstLinesOfChapter.value);
+        let lastN = parseInt(this.userPreferences.removeLastLinesOfChapter.value);
+        let hasFirstN = !isNaN(firstN) && (0 < firstN);
+        let hasLastN = !isNaN(lastN) && (0 < lastN);
+        if (!hasFirstN && !hasLastN) {
+            return;
+        }
+        let titleElement = this.findTitleElement(content);
+        let lines = [...content.children].filter(e => e !== titleElement);
+        if (hasFirstN) {
+            util.removeElements(lines.slice(0, firstN));
+            lines = lines.slice(firstN);
+        }
+        if (hasLastN) {
+            util.removeElements(lines.slice(Math.max(0, lines.length - lastN)));
+        }
+    }
+
+    // The chapter title is the first heading in content (same identification as
+    // titleAlreadyPresent). Walk up to its top-level child of content so it's
+    // excluded from the trim even when nested in a wrapper div.
+    findTitleElement(content) {
+        let heading = content.querySelector("h1, h2, h3, h4, h5, h6");
+        if (heading == null) {
+            return null;
+        }
+        while (heading.parentElement !== content) {
+            heading = heading.parentElement;
+        }
+        return heading;
     }
 
     customRawDomToContentStep(chapter, content) { // eslint-disable-line no-unused-vars

--- a/plugin/js/UserPreferences.js
+++ b/plugin/js/UserPreferences.js
@@ -109,6 +109,8 @@ class UserPreferences { // eslint-disable-line no-unused-vars
         this.noContentToError403 = this.addPreference("noContentToError403", "noContentToError403Checkbox", false);
         this.maxChaptersPerEpub = this.addPreference("maxChaptersPerEpub", "maxChaptersPerEpubTag", "10,000");
         this.manualDelayPerChapter = this.addPreference("manualDelayPerChapter", "manualDelayPerChapterTag", "0");
+        this.removeFirstLinesOfChapter = this.addPreference("removeFirstLinesOfChapter", "removeFirstLinesOfChapterTag", "0");
+        this.removeLastLinesOfChapter = this.addPreference("removeLastLinesOfChapter", "removeLastLinesOfChapterTag", "0");
         this.overrideMinimumDelay = this.addPreference("overrideMinimumDelay", "overrideMinimumDelayCheckbox", false);
         this.skipImages = this.addPreference("skipImages", "skipImagesCheckbox", false);
         this.compressImages = this.addPreference("compressImages", "compressImagesCheckbox", false);

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -490,6 +490,18 @@
                         <td><input id="overrideMinimumDelayCheckbox" type="checkbox" name="overrideMinimumDelayCheckbox" value="false"></td>
                         <td>__MSG_label_Override_Default_Minimum_Delay__</td>
                     </tr>
+                    <tr id="removeFirstLinesOfChapter">
+                        <td>
+                            <input id="removeFirstLinesOfChapterTag" type="number" name="removeFirstLinesOfChapterTag" min="0" step="1" style="width: 61px;">
+                        </td>
+                        <td>__MSG_label_Remove_First_Lines_Of_Chapter__</td>
+                    </tr>
+                    <tr id="removeLastLinesOfChapter">
+                        <td>
+                            <input id="removeLastLinesOfChapterTag" type="number" name="removeLastLinesOfChapterTag" min="0" step="1" style="width: 61px;">
+                        </td>
+                        <td>__MSG_label_Remove_Last_Lines_Of_Chapter__</td>
+                    </tr>
                     <tr id="IncludeInReadingListRow">
                         <td><input id="includeInReadingListCheckbox" type="checkbox" name="includeInReadingListCheckbox" value="false"></td>
                         <td>__MSG_label_Include_in_Reading_List__</td>

--- a/readme.md
+++ b/readme.md
@@ -828,6 +828,7 @@ Don't forget to give the project a star! Thanks again!
     <li>kuwoyuki</li>
     <li>bendur</li>
     <li>Bartuzen</li>
+    <li>g-play01</li>
   </ul>
 </details>
 


### PR DESCRIPTION
Ran into cases where sites add content like number of words per chapter, the chapter title again, a please report if any issues at the start / end of a chapter and that ends up getting packed into the epub and can get annoying especially when you use a TTS reader created this advanced option that defaults to 0 i.e so off by default that removes a specified number of elements from the processed chapter bodies in convertRawDomToContent. Tested a local build on firefox on 2 sites works as expected. 

Let me know if ya'll want anything else changed on this.