### PR TITLE
add aria-hidden=true to removeUnwantedElementsFromContentElement for all parser

### DIFF
--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -196,7 +196,7 @@ class Parser {
     removeUnwantedElementsFromContentElement(element) {
         util.removeScriptableElements(element);
         util.removeComments(element);
-        util.removeElements(element.querySelectorAll("noscript, input"));
+        util.removeElements(element.querySelectorAll("noscript, input, [aria-hidden=\"true\"]"));
         util.removeUnwantedWordpressElements(element);
         util.removeMicrosoftWordCrapElements(element);
         util.removeShareLinkElements(element);


### PR DESCRIPTION
if an html object has aria-hidden=true set it means that the tts of browsers should ignore it. I think it is save to assume that it can be removed from the ebook.

see: #2858