### PR TITLE
fix: NovelfullParser TOC pagination for 1-indexed page param

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,8 @@
     { "name": "bendur"},
     { "name": "Bartuzen", "email": "git@bartuzen.dev" },
     { "name": "kerimmkirac", "email": "kerimmkirac@gmail.com" },
-    { "name": "baalthasar"}
+    { "name": "baalthasar"},
+    { "name": "David Siewert", "email": "david1gruppenplan@gmail.com" }
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/js/parsers/NovelfullParser.js
+++ b/plugin/js/parsers/NovelfullParser.js
@@ -82,13 +82,22 @@ class NovelfullParser extends Parser {
         let urls = [];
         if (link != null) {
             let limit = link.getAttribute("data-page");
-            if (limit == null)
-            {
+            // data-page / page_num are 0-indexed; page is 1-indexed (novelfull.com)
+            let pageIsOneIndexed = false;
+            if (limit == null) {
                 let url = new URL(link.href);
-                limit = url.searchParams.get("page_num") || null;
+                if (url.searchParams.has("page")) {
+                    limit = url.searchParams.get("page");
+                    pageIsOneIndexed = true;
+                } else {
+                    limit = url.searchParams.get("page_num") || null;
+                }
             }
-            limit = parseInt(limit || "-1") + 1;
-            for (let i = 1; i <= limit; ++i) {
+            limit = pageIsOneIndexed
+                ? parseInt(limit || "0")
+                : parseInt(limit || "-1") + 1;
+            // page 1 is already extracted from the initial TOC dom
+            for (let i = 2; i <= limit; ++i) {
                 urls.push(NovelfullParser.buildUrlForTocPage(link, i));
             }
         }

--- a/readme.md
+++ b/readme.md
@@ -830,6 +830,7 @@ Don't forget to give the project a star! Thanks again!
     <li>Bartuzen</li>
     <li>kerimmkirac</li>
     <li>baalthasar</li>
+    <li>David Siewert</li>
   </ul>
 </details>
 


### PR DESCRIPTION
## Summary

Fix `NovelfullParser.getUrlsOfTocPages` so multi-page TOCs work on sites like **novelfull.com**.

### Problem

On novelfull.com, the last TOC link looks like:

```html
<li class="last">
  <a href="/the-legendary-mechanic.html?page=30">Last »</a>
</li>
```

- no `data-page` attribute
- uses query param `page` (1-indexed), not `page_num` (0-indexed)

The old logic only read `data-page` / `page_num`, so `limit` became `0` and only the first TOC page of chapters was collected.

It also started the extra-page loop at `i = 1`, which could re-fetch page 1 (already extracted from the initial TOC DOM) on sites that still use `data-page`.

### Fix

- Treat `?page=` as **1-indexed** last page (use value as-is)
- Keep `data-page` / `page_num` as **0-indexed** (`parseInt(...) + 1`)
- Build extra TOC URLs from page **2..limit**

### Tested with

- `https://novelfull.com/the-legendary-mechanic.html`  
  Last link is `?page=30`, `#total-page` is `30`

Note: `novellive.app` is handled by `NovelliveParser`, not this file.

## Checklist (CONTRIBUTING.md)

- [x] Branch based on `ExperimentalTabMode`
- [x] Rebased on latest `ExperimentalTabMode`
- [x] No eslint warnings/errors on changed file
- [x] No new optional user-facing behavior (bugfix only)
- [x] Updated `package.json` contributors
- [x] Updated Credits in `readme.md`
- Existing unit tests: no automated test for this path; watermark tests in `UtestNovelfullParser.js` are unrelated and unchanged