### PR TITLE
Add support to EPUB 3 series and series number

### DIFF
--- a/plugin/js/EpubPacker.js
+++ b/plugin/js/EpubPacker.js
@@ -137,6 +137,14 @@ class EpubPacker {
         if (this.metaInfo.seriesName !== null) {
             this.appendMetaContent(metadata, opf_ns, "calibre:series", this.metaInfo.seriesName);
             this.appendMetaContent(metadata, opf_ns, "calibre:series_index", this.metaInfo.seriesIndex);
+            if (this.version === EpubPacker.EPUB_VERSION_3) {
+                let series = this.createAndAppendChildNS(metadata, opf_ns, "meta");
+                series.setAttributeNS(null, "property", "belongs-to-collection");
+                series.setAttributeNS(null, "id", "series");
+                series.textContent = this.metaInfo.seriesName;
+                this.addMetaProperty(metadata, series, "collection-type", "series", "series");
+                this.addMetaProperty(metadata, series, "group-position", "series", this.metaInfo.seriesIndex);
+            }
         }
 
         for (let i of epubItemSupplier.manifestItems()) {


### PR DESCRIPTION
Adding support to EPUB 3 series and series number when `Create EPUB 3` is selected. Both `calibre:series` and `calibre:series_index` still retained in EPUB 3 version for compatibility reason.

The result of new additions for EPUB 3 content.opf:

```html
<meta name="calibre:series" content="Whatever It Is" />
<meta name="calibre:series_index" content="4" />
<meta property="belongs-to-collection" id="series">Whatever It Is</meta>
<meta refines="#series" property="collection-type">series</meta>
<meta refines="#series" property="group-position">4</meta>
```

Tested by packing EPUB with `Create EPUB 3` is selected and Series and Volume filled out to make sure.

# References
- https://www.w3.org/TR/epub-33/#sec-belongs-to-collection
- https://www.w3.org/TR/epub-33/#sec-collection-type
- https://www.w3.org/TR/epub-33/#sec-group-position