### PR TITLE
feat(parser): add ad-bypass for readrift

### DIFF
--- a/plugin/js/parsers/ReadRiftParser.js
+++ b/plugin/js/parsers/ReadRiftParser.js
@@ -134,6 +134,10 @@ class ReadRiftParser extends Parser {
         }
         const chapterId = match[1];
 
+        // They changed the site to block the chapter until you watch an AD, but
+        // I figured out how to bypass
+        await this.bypassAd(chapterId);
+
         // I also found the chapter API so we can just directly request the content
         const apiUrl = `https://readrift.net/api/v1/books/chapter/${chapterId}/`;
 
@@ -145,6 +149,56 @@ class ReadRiftParser extends Parser {
         } catch (err) {
             throw new Error(
                 `ReadRiftParser aborted while fetching chapter: ${err.message}`,
+            );
+        }
+    }
+
+    /**
+     * Bypasses the chapter ad
+     *
+     * Interestingly enough, the way ReadRift implements their ad lock is
+     * by requesting a token using the user session id, then making a POST
+     * request with the token you receive to unlock the chapter for you.
+     * But while the video is around 30 seconds, the api lets you make the
+     * request instantly, allowing us to instantly bypass.
+     *
+     * @param {number} chapterId
+     @ @throws { Error } If either API request fails
+     */
+    async bypassAd(chapterId) {
+        const tokenPayload = await this.obtainAdToken(chapterId);
+        await this.bypassAdWithToken(tokenPayload);
+    }
+
+    async obtainAdToken(chapterId) {
+        const apiUrl = `https://readrift.net/api/v1/books/ad-reward/token/?chapter_no=${chapterId}`;
+
+        try {
+            const adTokenResponse = await HttpClient.fetchJson(apiUrl);
+            const tokenPayload = adTokenResponse.json;
+            return tokenPayload;
+        } catch (err) {
+            throw new Error(
+                `ReadRiftParser aborted while getting ad token: ${err.message}`,
+            );
+        }
+    }
+
+    async bypassAdWithToken(tokenPayload) {
+        const apiUrl = "https://readrift.net/api/v1/books/ad-reward/grant/";
+        const fetchOptions = {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(tokenPayload),
+        };
+
+        try {
+            await HttpClient.fetchJson(apiUrl, fetchOptions);
+        } catch (err) {
+            throw new Error(
+                `ReadRiftParser aborted while bypassing ad: ${err.message}`,
             );
         }
     }


### PR DESCRIPTION
Readrift started blocking the latest chapters until you watch their Ads. They changed their API around this, preventing you from requesting the chapter content.

I figured out how the ad API works and have added a bypass. The bypass works as follows:

- Request ad token for chapter. This uses the user session id.
- Send POST request with token. This unlocks the chapter for your user session id.

Worked perfectly in testing on chromium.