### PR TITLE
feat: add Smart Rule engine for auto-detecting CSS selectors

### DIFF
--- a/plugin/js/DefaultParserUI.js
+++ b/plugin/js/DefaultParserUI.js
@@ -87,7 +87,9 @@ class DefaultParserSiteSettings {
                         for (let e of element.querySelectorAll(config.removeCss)) {
                             e.remove();
                         }
-                    } catch (e) {}
+                    } catch (e) {
+                        // Ignore invalid CSS selector errors
+                    }
                 };
             }
         }

--- a/plugin/js/DefaultParserUI.js
+++ b/plugin/js/DefaultParserUI.js
@@ -1,12 +1,10 @@
 "use strict";
 
-/** Keep track of how to user tells us to parse different sites */
 class DefaultParserSiteSettings {
     constructor() {
         this.loadSiteConfigs();
     }
 
-    /** @private */
     loadSiteConfigs() {
         let config = window.localStorage.getItem(DefaultParserSiteSettings.storageName);
         this.configs = new Map();
@@ -40,7 +38,6 @@ class DefaultParserSiteSettings {
         }
     }
 
-    /** @private */
     isConfigChanged(hostname, contentCss, titleCss, removeCss, testUrl) {
         let config = this.configs.get(hostname);
         return (config === undefined) || 
@@ -62,17 +59,31 @@ class DefaultParserSiteSettings {
         };
         let config = this.getConfigForSite(hostname);
         if (config != null) {
-            logic.findContent = dom => dom.querySelector(config.contentCss);
+            logic.findContent = dom => {
+                try {
+                    return dom.querySelector(config.contentCss);
+                } catch (e) {
+                    return null; 
+                }
+            };
             if (!util.isNullOrEmpty(config.titleCss))
             {
-                logic.findChapterTitle = dom => dom.querySelector(config.titleCss);
+                logic.findChapterTitle = dom => {
+                    try {
+                        return dom.querySelector(config.titleCss);
+                    } catch (e) {
+                        return null;
+                    }
+                };
             }
             if (!util.isNullOrEmpty(config.removeCss))
             {
                 logic.removeUnwanted = (element) => {
-                    for (let e of element.querySelectorAll(config.removeCss)) {
-                        e.remove();
-                    }
+                    try {
+                        for (let e of element.querySelectorAll(config.removeCss)) {
+                            e.remove();
+                        }
+                    } catch (e) {}
                 };
             }
         }
@@ -81,15 +92,15 @@ class DefaultParserSiteSettings {
 }
 DefaultParserSiteSettings.storageName = "DefaultParserConfigs";
 
-/** Class that handles UI for configuring the Default Parser */
-class DefaultParserUI { // eslint-disable-line no-unused-vars
+class DefaultParserUI {
     constructor() {
     }
 
-    static setupDefaultParserUI(hostname, parser) {
+    static setupDefaultParserUI(hostname, parser, dom) {
         DefaultParserUI.copyInstructions();
         DefaultParserUI.setDefaultParserUiVisibility(true);
-        DefaultParserUI.populateDefaultParserUI(hostname, parser);
+        // Pass the preloaded live DOM down to the populate method
+        DefaultParserUI.populateDefaultParserUI(hostname, parser, dom);
         document.getElementById("testDefaultParserButton").onclick = DefaultParserUI.testDefaultParser.bind(null, parser);
         document.getElementById("finisheddefaultParserButton").onclick = DefaultParserUI.onFinishedClicked.bind(null, parser);
     }
@@ -109,7 +120,7 @@ class DefaultParserUI { // eslint-disable-line no-unused-vars
         parser.siteConfigs.saveSiteConfig(hostname, contentCss, titleCss, removeCss, testUrl);
     }
 
-    static populateDefaultParserUI(hostname, parser) {
+    static populateDefaultParserUI(hostname, parser, dom) {
         DefaultParserUI.getDefaultParserHostnameInput().value = hostname;
 
         DefaultParserUI.getContentCssInput().value = "body";
@@ -118,16 +129,91 @@ class DefaultParserUI { // eslint-disable-line no-unused-vars
         DefaultParserUI.getTestChapterUrlInput().value = "";
 
         let config = parser.siteConfigs.getConfigForSite(hostname);
+        let activeUrl = document.getElementById("startingUrlInput").value;
+
         if (config != null) {
             DefaultParserUI.getContentCssInput().value = config.contentCss;
             DefaultParserUI.getChapterTitleCssInput().value = config.titleCss;
             DefaultParserUI.getUnwantedElementsCssInput().value = config.removeCss;
             DefaultParserUI.getTestChapterUrlInput().value = config.testUrl;
         }
+
+        // Always ensure the Test URL is filled out, falling back to activeUrl
+        if (!DefaultParserUI.getTestChapterUrlInput().value) {
+            DefaultParserUI.getTestChapterUrlInput().value = activeUrl;
+        }
+
+        DefaultParserUI.bindSmartScanner();
+
+        // Proactively scan using the live DOM to avoid network/403 issues.
+        // This will override the old/default config purely in the UI if successful.
+        if (dom && activeUrl) {
+            DefaultParserUI.executeSmartScan(activeUrl, dom);
+        }
+    }
+
+    static bindSmartScanner() {
+        const testUrlInput = DefaultParserUI.getTestChapterUrlInput();
+        
+        if (!testUrlInput) return;
+        if (testUrlInput.dataset.smartBound === "true") return;
+        testUrlInput.dataset.smartBound = "true";
+
+        let debounceTimer = null;
+
+        testUrlInput.addEventListener("input", () => {
+            clearTimeout(debounceTimer);
+            let url = testUrlInput.value.trim();
+            
+            if (!url) {
+                const statusSpan = document.getElementById("smartDetectStatus");
+                if (statusSpan) statusSpan.textContent = "";
+                return;
+            }
+
+            const statusSpan = document.getElementById("smartDetectStatus");
+            if (statusSpan) {
+                statusSpan.textContent = "\u23F3 Detecting...";
+                statusSpan.style.color = "#666";
+            }
+
+            // User manually typed a URL, we cannot use preloaded DOM anymore.
+            debounceTimer = setTimeout(() => {
+                DefaultParserUI.executeSmartScan(url, null);
+            }, 500);
+        });
+    }
+
+    static async executeSmartScan(url, preloadedDom = null) {
+        const statusSpan = document.getElementById("smartDetectStatus");
+        if (!statusSpan) return;
+
+        statusSpan.textContent = "\u23F3 Detecting...";
+        statusSpan.style.color = "#666";
+
+        try {
+            // Pass the preloaded DOM directly to the scanner
+            let result = await HeuristicScanner.scan(url, preloadedDom);
+            
+            if (result.status === "success") {
+                DefaultParserUI.getContentCssInput().value = result.contentCss;
+                DefaultParserUI.getChapterTitleCssInput().value = result.titleCss;
+                statusSpan.textContent = "\u2705 Detection Successful";
+                statusSpan.style.color = "green";
+            } else if (result.status === "toc_detected") {
+                statusSpan.textContent = "\u26A0\uFE0F Seems to be ToC. Please use the ToC flow.";
+                statusSpan.style.color = "orange";
+            } else {
+                statusSpan.textContent = "\u274C Detection Failed. Please enter CSS manually.";
+                statusSpan.style.color = "red";
+            }
+        } catch (err) {
+            statusSpan.textContent = "\u274C Detection Failed. Please enter CSS manually.";
+            statusSpan.style.color = "red";
+        }
     }
 
     static setDefaultParserUiVisibility(isVisible) {
-        // toggle mode
         ChapterUrlsUI.setVisibleUI(!isVisible);
         if (isVisible) {
             ChapterUrlsUI.getEditChaptersUrlsInput().hidden = true;
@@ -207,4 +293,3 @@ class DefaultParserUI { // eslint-disable-line no-unused-vars
         return document.getElementById("defaultParserVewResult");
     }
 }
-

--- a/plugin/js/DefaultParserUI.js
+++ b/plugin/js/DefaultParserUI.js
@@ -9,11 +9,15 @@ class DefaultParserSiteSettings {
         let config = window.localStorage.getItem(DefaultParserSiteSettings.storageName);
         this.configs = new Map();
         if (config != null) {
-            for (let e of JSON.parse(config)) {
-                let selectors = e[1];
-                if (DefaultParserSiteSettings.isConfigValid(selectors)) {
-                    this.configs.set(e[0], selectors);
+            try {
+                for (let e of JSON.parse(config)) {
+                    let selectors = e[1];
+                    if (DefaultParserSiteSettings.isConfigValid(selectors)) {
+                        this.configs.set(e[0], selectors);
+                    }
                 }
+            } catch (e) {
+                window.localStorage.removeItem(DefaultParserSiteSettings.storageName);
             }
         }
     }
@@ -136,6 +140,7 @@ class DefaultParserUI {
             DefaultParserUI.getChapterTitleCssInput().value = config.titleCss;
             DefaultParserUI.getUnwantedElementsCssInput().value = config.removeCss;
             DefaultParserUI.getTestChapterUrlInput().value = config.testUrl;
+            return;
         }
 
         // Always ensure the Test URL is filled out, falling back to activeUrl

--- a/plugin/js/HeuristicScanner.js
+++ b/plugin/js/HeuristicScanner.js
@@ -1,0 +1,156 @@
+"use strict";
+
+class HeuristicScanner {
+    static async scan(url, preloadedDoc = null) {
+        try {
+            let doc = preloadedDoc;
+            
+            if (!doc) {
+                let xhr = await HttpClient.fetchHtml(url);
+                doc = xhr.responseXML;
+            }
+
+            if (!doc) {
+                return { status: "failed", error: "Failed to parse DOM" };
+            }
+
+            let walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, null, false);
+            let node;
+            let totalTextLength = 0;
+            let linkTextLength = 0;
+
+            while ((node = walker.nextNode())) {
+                let text = node.textContent.trim();
+                if (text.length === 0) continue;
+                totalTextLength += text.length;
+                
+                let parent = node.parentElement;
+                while (parent && parent !== doc.body) {
+                    if (parent.tagName.toLowerCase() === "a") {
+                        linkTextLength += text.length;
+                        break;
+                    }
+                    parent = parent.parentElement;
+                }
+            }
+
+            if (totalTextLength > 0 && (linkTextLength / totalTextLength) > 0.4) {
+                return { status: "toc_detected" };
+            }
+
+            let contentNode = HeuristicScanner.findContentNode(doc);
+            let contentCss = contentNode ? HeuristicScanner.generateSelector(contentNode) : "body";
+
+            let titleNode = HeuristicScanner.findTitleNode(doc, contentNode);
+            let titleCss = titleNode ? HeuristicScanner.generateSelector(titleNode) : "";
+
+            return {
+                status: "success",
+                contentCss: contentCss,
+                titleCss: titleCss
+            };
+
+        } catch (error) {
+            return { status: "failed", error: error.message };
+        }
+    }
+
+    static findContentNode(doc) {
+        let candidates = [];
+        let walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT, null, false);
+        let node;
+        
+        const badPatterns = /comment|footer|sidebar|menu|nav|ad|promo|widget|\u8BC4\u8BBA|\u63A8\u8350|\u7559\u8A00|\u30B3\u30E1\u30F3\u30C8|\uB313\uAE00/i;
+        const goodPatterns = /content|chapter|article|text|body|\u6B63\u6587|\u5185\u5BB9|\u672C\u7DE8|\u672C\u6587/i;
+
+        while ((node = walker.nextNode())) {
+            let tag = node.tagName.toLowerCase();
+            if (["script", "style", "nav", "header", "footer"].includes(tag)) continue;
+
+            let pCount = node.getElementsByTagName("p").length;
+            let brCount = node.getElementsByTagName("br").length;
+            
+            if (pCount > 2 || brCount > 4) {
+                let className = node.className || "";
+                let id = node.id || "";
+                let attrString = `${className} ${id}`;
+
+                if (badPatterns.test(attrString)) continue;
+
+                let score = pCount * 2 + brCount;
+                if (goodPatterns.test(attrString)) {
+                    score += 50; 
+                }
+                candidates.push({ node, score });
+            }
+        }
+
+        if (candidates.length === 0) return null;
+        
+        // Sort by score descending
+        candidates.sort((a, b) => b.score - a.score);
+        
+        // Innermost Node Wins logic (Child > Parent)
+        let bestCandidate = candidates[0];
+        
+        for (let i = 1; i < candidates.length; i++) {
+            let challenger = candidates[i];
+            
+            // If the challenger has the same or very similar score (e.g., >= 80% of best score)
+            if (challenger.score >= bestCandidate.score * 0.8) {
+                // If the current best candidate contains the challenger, the challenger is deeper.
+                // It means the parent is just an outer wrapper. We prefer the deeper node.
+                if (bestCandidate.node.contains(challenger.node)) {
+                    bestCandidate = challenger;
+                }
+            } else {
+                // Since candidates are sorted by score, we can break early if scores drop too low.
+                break;
+            }
+        }
+
+        return bestCandidate.node;
+    }
+
+    static findTitleNode(doc, contentNode) {
+        // Added h1, h2 to match patterns like "style_h1"
+        const titlePatterns = /title|heading|chapter-title|h1|h2|\u6807\u9898|\u30BF\u30A4\u30C8\u30EB|\uC81C\uBAA9/i;
+        
+        let h1 = doc.querySelector("h1");
+        if (h1) return h1;
+
+        let candidates = [];
+        // Added p to the selector
+        let headers = doc.querySelectorAll("h2, h3, div, span, strong, p");
+        for (let node of headers) {
+            let text = node.textContent.trim();
+            
+            // Added length restriction: titles should not be empty and shouldn't be too long
+            if (text.length === 0 || text.length > 100) continue;
+
+            let className = node.className || "";
+            let id = node.id || "";
+            let attrString = `${className} ${id}`;
+
+            if (titlePatterns.test(attrString)) {
+                candidates.push(node);
+            }
+        }
+
+        if (candidates.length > 0) return candidates[0];
+        return null;
+    }
+
+    static generateSelector(node) {
+        if (node.id) {
+            return `#${CSS.escape(node.id)}`;
+        }
+        if (node.className && typeof node.className === "string") {
+            let classes = node.className.trim().split(/\s+/).filter(c => c).map(c => CSS.escape(c));
+            if (classes.length > 0) {
+                return `.${classes.join(".")}`;
+            }
+        }
+        return node.tagName.toLowerCase();
+    }
+}

--- a/plugin/js/HeuristicScanner.js
+++ b/plugin/js/HeuristicScanner.js
@@ -22,7 +22,7 @@ class HeuristicScanner {
             let contentNode = HeuristicScanner.findContentNode(doc);
             let contentCss = contentNode ? HeuristicScanner.generateSelector(contentNode) : "body";
 
-            let titleNode = HeuristicScanner.findTitleNode(doc, contentNode);
+            let titleNode = HeuristicScanner.findTitleNode(doc);
             let titleCss = titleNode ? HeuristicScanner.generateSelector(titleNode) : "";
 
             return {
@@ -112,7 +112,7 @@ class HeuristicScanner {
         return bestCandidate.node;
     }
 
-    static findTitleNode(doc, contentNode) {
+    static findTitleNode(doc) {
         // Added h1, h2 to match patterns like "style_h1"
         const titlePatterns = /title|heading|chapter-title|h1|h2|\u6807\u9898|\u30BF\u30A4\u30C8\u30EB|\uC81C\uBAA9/i;
         

--- a/plugin/js/HeuristicScanner.js
+++ b/plugin/js/HeuristicScanner.js
@@ -14,27 +14,8 @@ class HeuristicScanner {
                 return { status: "failed", error: "Failed to parse DOM" };
             }
 
-            let walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, null, false);
-            let node;
-            let totalTextLength = 0;
-            let linkTextLength = 0;
-
-            while ((node = walker.nextNode())) {
-                let text = node.textContent.trim();
-                if (text.length === 0) continue;
-                totalTextLength += text.length;
-                
-                let parent = node.parentElement;
-                while (parent && parent !== doc.body) {
-                    if (parent.tagName.toLowerCase() === "a") {
-                        linkTextLength += text.length;
-                        break;
-                    }
-                    parent = parent.parentElement;
-                }
-            }
-
-            if (totalTextLength > 0 && (linkTextLength / totalTextLength) > 0.4) {
+            // Check whether the page is a table of contents.
+            if (HeuristicScanner.isTableOfContents(doc)) {
                 return { status: "toc_detected" };
             }
 
@@ -53,6 +34,25 @@ class HeuristicScanner {
         } catch (error) {
             return { status: "failed", error: error.message };
         }
+    }
+
+    static isTableOfContents(doc) {
+        let walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, null, false);
+        let node;
+        let totalTextLength = 0;
+        let linkTextLength = 0;
+
+        while ((node = walker.nextNode())) {
+            let text = node.textContent.trim();
+            if (text.length === 0) continue;
+            totalTextLength += text.length;
+
+            if (node.parentElement && node.parentElement.closest("a")) {
+                linkTextLength += text.length;
+            }
+        }
+
+        return totalTextLength > 0 && (linkTextLength / totalTextLength) > 0.4;
     }
 
     static findContentNode(doc) {

--- a/plugin/js/parsers/DefaultParser.js
+++ b/plugin/js/parsers/DefaultParser.js
@@ -1,6 +1,3 @@
-/*
-  Parser used when can't match a parser for the document
-*/
 "use strict";
 
 parserFactory.registerManualSelect(
@@ -28,10 +25,10 @@ class DefaultParser extends Parser {
     populateUI(dom) {
         super.populateUI(dom);
         let hostname = util.extractHostName(dom.baseURI);
-        DefaultParserUI.setupDefaultParserUI(hostname, this);
+        // Pass the preloaded live DOM to the UI initialization
+        DefaultParserUI.setupDefaultParserUI(hostname, this, dom);
     }
 
-    // override default (keep nearly everything, may be wanted)
     removeUnwantedElementsFromContentElement(element) {
         util.removeElements(element.querySelectorAll("script[src], iframe"));
         util.removeComments(element);

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -45,6 +45,7 @@
                     <td>__MSG_label_Default_Parser_Test_Chapter_Url__</td>
                     <td>
                         <input id="defaultParserTestChapterUrl" type="text" name="defaultParserTestChapterUrlInput" size="30" value="" />
+                        <span id="smartDetectStatus" style="font-size:12px; margin-left:8px;"></span>
                     </td>
                 </tr>
                 <tr>
@@ -626,6 +627,7 @@
         <script src="js/Firefox.js"></script>
         <script src="js/Download.js"></script>
         <script src="js/HttpClient.js"></script>
+        <script src="js/HeuristicScanner.js"></script>
         <script src="js/EpubItem.js"></script>
         <script src="js/ParserFactory.js"></script>
         <script src="js/ImageCollector.js"></script>


### PR DESCRIPTION
### Summary
This PR introduces a heuristic engine (`HeuristicScanner`) to automatically detect Chapter Title and Content CSS selectors for unknown websites, reducing manual configuration effort.

### Key Changes:
*   **Auto-detection**: Scans pre-loaded DOM using `TreeWalker` to find content and titles (supports EN, CN, JP, KR naming conventions).
*   **Zero Extra Network Overhead**: Reuses the live `dom` object provided by `main.js` (no extra `fetch` calls).
*   **Robustness**: 
    *   Added `CSS.escape()` for modern CSS frameworks (like TailwindCSS with colons).
    *   Added `try-catch` safety blocks when reading cached CSS from LocalStorage to prevent crashes.

### Testing:
Tested locally with various sites (e.g., Qidian, QuShuWang), working smoothly.

*P.S. I actually have 3 more PRs in my local pipeline (a No-ToC Chain Crawler, UI/UX Enhancements, and i18n Localization), but I wanted to submit this one first to ensure my code style and approach align with your standards. Let me know if any changes are needed! 😄*