### PR TITLE
Add Konkon/Kuupress support

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,8 @@
     { "name": "Bartuzen", "email": "git@bartuzen.dev" },
     { "name": "kerimmkirac", "email": "kerimmkirac@gmail.com" },
     { "name": "baalthasar"},
-    { "name": "David Siewert", "email": "david1gruppenplan@gmail.com" }
+    { "name": "David Siewert", "email": "david1gruppenplan@gmail.com" },
+    { "name": "MineRobber9000" }
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/js/parsers/KonkonKuupressParser.js
+++ b/plugin/js/parsers/KonkonKuupressParser.js
@@ -4,13 +4,33 @@ parserFactory.register("konkon.ink", () => new KonkonKuupressParser("https://kon
 parserFactory.register("kuupress.com", () => new KonkonKuupressParser("https://kuupress.com", "https://api-kp.kuupress.com", "Kuupress"));
 
 class KKPFetchCache {
-    constructor() {
+    constructor(siteUrl, apiUrl) {
         this.cache = {};
+        this.siteUrl = siteUrl;
+        this.apiUrl = apiUrl;
     }
 
     async fetch(url) {
         url = url.toString();
         if (this.cache[url]) return this.cache[url];
+        await HttpClient.setDeclarativeNetRequestRules([
+            {
+                id: 1,
+                priority: 1,
+                action: {
+                    type: "modifyHeaders",
+                    requestHeaders: [{
+                        header: "Origin",
+                        operation: "set",
+                        value: this.siteUrl
+                    }]
+                },
+                condition: {
+                    requestDomains: [(new URL(this.apiUrl).hostname)],
+                    resourceTypes: ["xmlhttprequest"]
+                }
+            }
+        ]);
         let contents = (await HttpClient.fetchJson(url)).json;
         this.cache[url] = contents;
         return contents;
@@ -23,7 +43,7 @@ class KonkonKuupressParser extends Parser {
         this.siteUrl = siteUrl;
         this.apiUrl = apiUrl;
         this.publisher = publisher;
-        this.fetchCache = new KKPFetchCache();
+        this.fetchCache = new KKPFetchCache(siteUrl, apiUrl);
     }
 
     dispatchOnChapterOrNovel(url, chapterBranch, novelBranch) {

--- a/plugin/js/parsers/KonkonKuupressParser.js
+++ b/plugin/js/parsers/KonkonKuupressParser.js
@@ -86,10 +86,14 @@ class KonkonKuupressParser extends Parser {
     async getChapterUrlsFromChapter(url) {
         // Get chapter JSON object
         let data = await this.fetchCache.fetch(url);
+        // Make sure we have data.data
+        if (!data.data) {
+            throw new Error("Something changed on the site backend (no chapter info)");
+        }
         // Get novel slug
-        let novelSlug = data.data?.novel?.slug;
+        let novelSlug = data.data.novel?.slug;
         if (novelSlug === undefined) {
-            throw new Error("Something changed on the site backend (no volume info in chapter)");
+            throw new Error("Something changed on the site backend (no novel info in chapter)");
         }
         // Converge on novel flow
         return this.getChapterUrlsFromNovel(this.novelAPIFromSlug(novelSlug));
@@ -98,13 +102,17 @@ class KonkonKuupressParser extends Parser {
     async getChapterUrlsFromNovel(url) {
         // Get novel JSON object
         let data = await this.fetchCache.fetch(url);
+        // Make sure we have data.data
+        if (!data.data) {
+            throw new Error("Something changed on the site backend (no novel info)");
+        }
         // Store novel URL and title on parser (used in addFirstPageUrlToWebPages below)
-        this.novelUrl = this.siteUrl + "/read/" + data.data?.slug;
-        this.novelTitle = data.data?.title;
+        this.novelUrl = this.siteUrl + "/read/" + data.data.slug;
+        this.novelTitle = data.data.title;
         // Collect chapters (will be turned into URLs later)
         let chapters = [];
         // First pass: all unlocked chapters
-        let volumes = data.data?.volumes;
+        let volumes = data.data.volumes;
         if (volumes == undefined) {
             throw new Error("Something changed on the site backend (no volumes)");
         }
@@ -190,6 +198,10 @@ class KonkonKuupressParser extends Parser {
     async fetchActualChapter(baseUrl, dataUrl) {
         // Get chapter JSON object
         let data = await this.fetchCache.fetch(dataUrl);
+        // Make sure we have data.data
+        if (!data.data) {
+            throw new Error("Something changed on the site backend (no chapter info)");
+        }
         // Make doc for content
         let doc = Parser.makeEmptyDocForContent(baseUrl);
         // Chapter title
@@ -202,6 +214,10 @@ class KonkonKuupressParser extends Parser {
     async generateTableOfContentsPage(baseUrl, dataUrl) {
         // Get novel JSON object
         let data = await this.fetchCache.fetch(dataUrl);
+        // Make sure we have data.data
+        if (!data.data) {
+            throw new Error("Something changed on the site backend (no novel info)");
+        }
         // Make doc for content
         let doc = Parser.makeEmptyDocForContent(baseUrl);
         // Generate table of contents based on the novel
@@ -285,10 +301,14 @@ class KonkonKuupressParser extends Parser {
         let apiUrl = await this.dispatchOnChapterOrNovel(url.href, async (chapterUrl) => {
             // Get chapter JSON object
             let data = await this.fetchCache.fetch(chapterUrl);
+            // Make sure we have data.data
+            if (!data.data) {
+                throw new Error("Something changed on the site backend (no chapter info)");
+            }
             // Get novel slug
-            let novelSlug = data.data?.novel?.slug;
+            let novelSlug = data.data.novel?.slug;
             if (novelSlug === undefined) {
-                throw new Error("Something changed on the site backend (no volume info in chapter)");
+                throw new Error("Something changed on the site backend (no novel info in chapter)");
             }
             return this.novelAPIFromSlug(novelSlug);
         },async (novelUrl) => novelUrl);

--- a/plugin/js/parsers/KonkonKuupressParser.js
+++ b/plugin/js/parsers/KonkonKuupressParser.js
@@ -1,0 +1,310 @@
+"use strict";
+
+parserFactory.register("konkon.ink", () => new KonkonKuupressParser("https://konkon.ink", "https://api-k.konkon.ink", "Konkon"));
+parserFactory.register("kuupress.com", () => new KonkonKuupressParser("https://kuupress.com", "https://api-kp.kuupress.com", "Kuupress"));
+
+class KKPFetchCache {
+    constructor() {
+        this.cache = {};
+    }
+
+    async fetch(url) {
+        url = url.toString();
+        if (this.cache[url]) return this.cache[url];
+        let contents = (await HttpClient.fetchJson(url)).json;
+        this.cache[url] = contents;
+        return contents;
+    }
+}
+
+class KonkonKuupressParser extends Parser {
+    constructor(siteUrl, apiUrl, publisher) {
+        super();
+        this.siteUrl = siteUrl;
+        this.apiUrl = apiUrl;
+        this.publisher = publisher;
+        this.fetchCache = new KKPFetchCache();
+    }
+
+    dispatchOnChapterOrNovel(url, chapterBranch, novelBranch) {
+        // Make sure we're using a chapter or novel page
+        let urlAsURL = new URL(url);
+        if (!urlAsURL.pathname.startsWith("/read/")) {
+            throw new Error("Must use either a novel page or a chapter page!");
+        }
+        // Logic changes from here depending on whether we have a novel or a chapter
+        // Pass in the URL to the API instead (since otherwise that'd be the first thing we do)
+        if (urlAsURL.pathname.startsWith("/read/chapter/")) {
+            return chapterBranch(this.chapterUrlToAPI(urlAsURL));
+        } else {
+            return novelBranch(this.novelUrlToAPI(urlAsURL));
+        }
+    }
+
+    chapterUrlToAPI(url) {
+        // `<0: empty>/<1: always "read">/<2: always "chapter">/<3: the chapter id>/<4: the slug>`
+        return new URL(this.apiUrl + "/api/public/chapters/" + url.pathname.split("/")[3]);
+    }
+
+    novelAPIFromSlug(slug) {
+        return new URL(this.apiUrl + "/api/public/novels/" + slug);
+    }
+
+    novelUrlToAPI(url) {
+        // `<0: empty>/<1: always "read">/<2: the slug>`
+        return this.novelAPIFromSlug(url.pathname.split("/")[2]);
+    }
+
+    async getChapterUrls() {
+        return this.dispatchOnChapterOrNovel(
+            this.state.chapterListUrl,
+            this.getChapterUrlsFromChapter.bind(this),
+            this.getChapterUrlsFromNovel.bind(this)
+        );
+    }
+
+    async getChapterUrlsFromChapter(url) {
+        // Get chapter JSON object
+        let data = await this.fetchCache.fetch(url);
+        // Get novel slug
+        let novelSlug = data.data?.novel?.slug;
+        if (novelSlug === undefined) {
+            throw new Error("Something changed on the site backend (no volume info in chapter)");
+        }
+        // Converge on novel flow
+        return this.getChapterUrlsFromNovel(this.novelAPIFromSlug(novelSlug));
+    }
+
+    async getChapterUrlsFromNovel(url) {
+        // Get novel JSON object
+        let data = await this.fetchCache.fetch(url);
+        // Store novel URL and title on parser (used in addFirstPageUrlToWebPages below)
+        this.novelUrl = this.siteUrl + "/read/" + data.data?.slug;
+        this.novelTitle = data.data?.title;
+        // Collect chapters (will be turned into URLs later)
+        let chapters = [];
+        // First pass: all unlocked chapters
+        let volumes = data.data?.volumes;
+        if (volumes == undefined) {
+            throw new Error("Something changed on the site backend (no volumes)");
+        }
+        for (const [volumeIndex, volume] of volumes.entries()) {
+            // Set volume ID
+            url.searchParams.set("volume_id", volume.id);
+            // Page by 100s (highest value the site normally lets you)
+            let pageNumber = 1;
+            url.searchParams.set("page", pageNumber);
+            url.searchParams.set("per_page", 100);
+            // Get first page
+            let page = await this.fetchCache.fetch(url);
+            // Extract number of pages
+            let pageCount = page.data?.chapters_pagination?.last_page;
+            if (pageCount === undefined) {
+                throw new Error("Something changed on the site backend (no page count)");
+            }
+            do {
+                let pageChapters = page.data?.volumes[volumeIndex]?.chapters;
+                if (pageChapters === undefined) {
+                    // This *really* shouldn't be possible, since even the volume not being paginated has an empty list here
+                    // So something big must have changed for us to get here
+                    throw new Error("Something changed on the site backend (no chapters in volume)");
+                }
+                pageChapters.forEach((chapter) => {
+                    // If the chapter is locked and we don't have access, skip it
+                    // TODO: the API treats all requests not coming from "Origin: <site>" as unauthenticated meaning
+                    // we can't access the chapters the user has unlocked anyways! barring them changing the way their
+                    // authentication works in order to make us work, we'd need some sort of workaround
+                    if (chapter.is_locked && !chapter.user_has_access) return;
+                    // Store index of volume (used in final sort)
+                    chapter.volume = volumeIndex;
+                    chapters.push(chapter);
+                });
+                // Add 1 to page count
+                pageNumber+=1;
+                // Fetch next page if we're still continuing
+                if (pageNumber<=pageCount) {
+                    url.searchParams.set("page", pageNumber);
+                    page = await this.fetchCache.fetch(url);
+                }
+            } while (pageNumber<=pageCount);
+        }
+        // Final pass: sort the chapters and convert them to URLs we can put in the UI
+        chapters.sort((a, b) => {
+            return (a.volume - b.volume) || (a.sort_order - b.sort_order);
+        });
+        return chapters.map((chapter) => {
+            return {
+                sourceUrl: (this.siteUrl + `/read/chapter/${chapter.id}/${chapter.slug}`),
+                title: chapter.title
+            };
+        });
+    }
+
+    addFirstPageUrlToWebPages(url, firstPageDom, webPages) {
+        // What this is meant to do: add Table of Contents page (if that was our first page)
+        // What we're going to do instead: add the novel URL to the list of pages (which we'll catch in fetchChapter
+        // and handle accordingly)
+        let present = webPages.find(e => e.sourceUrl === this.novelUrl);
+        if (present)
+        {
+            return webPages;
+        } else {
+            return [{
+                sourceUrl: this.novelUrl,
+                title: this.novelTitle
+            }].concat(webPages);
+        }
+    }
+
+    async fetchChapter(url) {
+        return this.dispatchOnChapterOrNovel(
+            url,
+            this.fetchActualChapter.bind(this, url),
+            this.generateTableOfContentsPage.bind(this, url)
+        );
+    }
+
+    static createElementWithTextContent(dom, tagName, textContent) {
+        let element = dom.createElement(tagName);
+        element.textContent = textContent;
+        return element;
+    }
+
+    async fetchActualChapter(baseUrl, dataUrl) {
+        // Get chapter JSON object
+        let data = await this.fetchCache.fetch(dataUrl);
+        // Make doc for content
+        let doc = Parser.makeEmptyDocForContent(baseUrl);
+        // Chapter title
+        doc.dom.title = data.data?.title;
+        // Chapter content into doc
+        doc.content.innerHTML = data.data?.content;
+        return doc.dom;
+    }
+
+    async generateTableOfContentsPage(baseUrl, dataUrl) {
+        // Get novel JSON object
+        let data = await this.fetchCache.fetch(dataUrl);
+        // Make doc for content
+        let doc = Parser.makeEmptyDocForContent(baseUrl);
+        // Generate table of contents based on the novel
+        let createElementWithTextContent = KonkonKuupressParser.createElementWithTextContent.bind(null, doc.dom);
+        // Title
+        doc.dom.title = data.data?.title;
+        // Description (nested in blockquote)
+        let description = createElementWithTextContent("blockquote", "");
+        description.innerHTML = data.data?.description;
+        doc.content.appendChild(description);
+        // Each volume gets a h2 header and a ul of links to chapters.
+        for (const [volumeIndex, volume] of data.data.volumes.entries()) {
+            // Create header and ul
+            doc.content.appendChild(createElementWithTextContent("h2",volume.title));
+            let chaptersUL = createElementWithTextContent("ul", "");
+            // Set volume ID
+            dataUrl.searchParams.set("volume_id", volume.id);
+            // Page by 100s (highest value the site normally lets you)
+            let pageNumber = 1;
+            dataUrl.searchParams.set("page", pageNumber);
+            dataUrl.searchParams.set("per_page", 100);
+            // Get first page
+            let page = await this.fetchCache.fetch(dataUrl);
+            // Extract number of pages
+            let pageCount = page.data?.chapters_pagination?.last_page;
+            if (pageCount === undefined) {
+                throw new Error("Something changed on the site backend (no page count)");
+            }
+            do {
+                let pageChapters = page.data?.volumes[volumeIndex]?.chapters;
+                if (pageChapters === undefined) {
+                    // This *really* shouldn't be possible, since even the volume not being paginated has an empty list here
+                    // So something big must have changed for us to get here
+                    throw new Error("Something changed on the site backend (no chapters in volume)");
+                }
+                pageChapters.forEach((chapter) => {
+                    // Create li (empty for now) and link for chapter
+                    let chapterLI = createElementWithTextContent("li", "");
+                    let chapterA = createElementWithTextContent("a", chapter.title);
+                    // If the chapter is locked, add lock emoji
+                    if (chapter.is_locked) chapterA.innerText += " (🔒)";
+                    chapterA.href = new URL(this.siteUrl + `/read/chapter/${chapter.id}/${chapter.slug}`);
+                    chapterLI.appendChild(chapterA);
+                    chaptersUL.appendChild(chapterLI);
+                });
+                // Add 1 to page count
+                pageNumber+=1;
+                // Fetch next page if we're still continuing
+                if (pageNumber<=pageCount) {
+                    dataUrl.searchParams.set("page", pageNumber);
+                    page = await this.fetchCache.fetch(dataUrl);
+                }
+            } while (pageNumber<=pageCount);
+            doc.content.appendChild(chaptersUL);
+        }
+        return doc.dom;
+    }
+
+    removeNextAndPreviousChapterHyperlinks() {
+        return; // NO-OP: We'll never have previous and next chapter hyperlinks.
+    }
+
+    findContent(dom) {
+        return Parser.findConstrutedContent(dom);
+    }
+
+    findChapterTitle(dom) {
+        return dom.title;
+    }
+
+    async loadEpubMetaInfo(dom) {
+        // Get the canonical URL from the DOM
+        let url = dom.querySelector("link[rel=\"canonical\"]");
+        // Get the API URL for the novel
+        let apiUrl = await this.dispatchOnChapterOrNovel(url.href, async (chapterUrl) => {
+            // Get chapter JSON object
+            let data = await this.fetchCache.fetch(chapterUrl);
+            // Get novel slug
+            let novelSlug = data.data?.novel?.slug;
+            if (novelSlug === undefined) {
+                throw new Error("Something changed on the site backend (no volume info in chapter)");
+            }
+            return this.novelAPIFromSlug(novelSlug);
+        },async (novelUrl) => novelUrl);
+        // Fetch the novel data
+        let response = await this.fetchCache.fetch(apiUrl);
+        if (response.data === undefined) {
+            throw new Error("Something changed on the site backend (no novel info)");
+        }
+        this.noveldata = response.data;
+    }
+
+    extractTitle() {
+        return this.noveldata.title;
+    }
+
+    extractAuthor() {
+        let authorName = this.noveldata.author_name;
+        let authorUserName = this.noveldata.author_user_name;
+        if (authorName == authorUserName) return authorName;
+        return `${authorName} (TL by ${authorUserName})`;
+    }
+
+    extractDescription() {
+        let doc = Parser.makeEmptyDocForContent(this.siteUrl);
+        doc.content.innerHTML = this.noveldata.description;
+        return doc.content.textContent;
+    }
+
+    extractPublisher() {
+        return this.publisher;
+    }
+
+    findCoverImageUrl() {
+        let cover_key = this.noveldata?.featured_image_key;
+        if (cover_key === undefined) {
+            return this.siteUrl + "/images/default-cover.jpg";
+        } else {
+            return this.apiUrl + "/api/media/k/" + btoa(cover_key);
+        }
+    }
+
+}

--- a/plugin/js/parsers/KonkonKuupressParser.js
+++ b/plugin/js/parsers/KonkonKuupressParser.js
@@ -207,7 +207,7 @@ class KonkonKuupressParser extends Parser {
         // Chapter title
         doc.dom.title = data.data?.title;
         // Chapter content into doc
-        doc.content.innerHTML = data.data?.content;
+        util.parseHtmlAndInsertIntoContent(data.data.content, doc.content);
         return doc.dom;
     }
 
@@ -226,7 +226,7 @@ class KonkonKuupressParser extends Parser {
         doc.dom.title = data.data?.title;
         // Description (nested in blockquote)
         let description = createElementWithTextContent("blockquote", "");
-        description.innerHTML = data.data?.description;
+        util.parseHtmlAndInsertIntoContent(data.data.description, description);
         doc.content.appendChild(description);
         // Each volume gets a h2 header and a ul of links to chapters.
         for (const [volumeIndex, volume] of data.data.volumes.entries()) {
@@ -332,9 +332,8 @@ class KonkonKuupressParser extends Parser {
     }
 
     extractDescription() {
-        let doc = Parser.makeEmptyDocForContent(this.siteUrl);
-        doc.content.innerHTML = this.noveldata.description;
-        return doc.content.textContent;
+        let descDom = util.sanitize(this.noveldata.description);
+        return descDom.body.textContent;
     }
 
     extractPublisher() {

--- a/plugin/js/parsers/KonkonKuupressParser.js
+++ b/plugin/js/parsers/KonkonKuupressParser.js
@@ -131,9 +131,6 @@ class KonkonKuupressParser extends Parser {
                 }
                 pageChapters.forEach((chapter) => {
                     // If the chapter is locked and we don't have access, skip it
-                    // TODO: the API treats all requests not coming from "Origin: <site>" as unauthenticated meaning
-                    // we can't access the chapters the user has unlocked anyways! barring them changing the way their
-                    // authentication works in order to make us work, we'd need some sort of workaround
                     if (chapter.is_locked && !chapter.user_has_access) return;
                     // Store index of volume (used in final sort)
                     chapter.volume = volumeIndex;
@@ -244,8 +241,14 @@ class KonkonKuupressParser extends Parser {
                     // Create li (empty for now) and link for chapter
                     let chapterLI = createElementWithTextContent("li", "");
                     let chapterA = createElementWithTextContent("a", chapter.title);
-                    // If the chapter is locked, add lock emoji
-                    if (chapter.is_locked) chapterA.innerText += " (🔒)";
+                    // If the chapter is locked, add lock emoji (open for user unlock, close for still locked)
+                    if (chapter.is_locked) {
+                        if (chapter.user_has_access) {
+                            chapterA.innerText += " (🔓)";
+                        } else {
+                            chapterA.innerText += " (🔒)";
+                        }
+                    }
                     chapterA.href = new URL(this.siteUrl + `/read/chapter/${chapter.id}/${chapter.slug}`);
                     chapterLI.appendChild(chapterA);
                     chaptersUL.appendChild(chapterLI);

--- a/plugin/js/parsers/KonkonKuupressParser.js
+++ b/plugin/js/parsers/KonkonKuupressParser.js
@@ -12,7 +12,9 @@ class KKPFetchCache {
 
     async fetch(url) {
         url = url.toString();
+        // If we already have it, return the cached value
         if (this.cache[url]) return this.cache[url];
+        // Apply "Origin" header (without it, the backend won't let us get chapters the user unlocks)
         await HttpClient.setDeclarativeNetRequestRules([
             {
                 id: 1,

--- a/plugin/js/parsers/KonkonKuupressParser.js
+++ b/plugin/js/parsers/KonkonKuupressParser.js
@@ -204,8 +204,20 @@ class KonkonKuupressParser extends Parser {
         }
         // Make doc for content
         let doc = Parser.makeEmptyDocForContent(baseUrl);
-        // Chapter title
-        doc.dom.title = data.data?.title;
+        // Chapter title (if we can't get the title from the chapter, no big deal)
+        if (data.data.title) doc.dom.title = data.data.title;
+        // Make sure we have chapter content
+        if (data.data.content === undefined) {
+            throw new Error("Something changed on the site backend (no content)");
+        } else if (data.data.content === "") {
+            // Empty content usually means a locked chapter.
+            if (data.data.is_locked && !data.data.user_has_access) {
+                throw new Error("Locked chapter!");
+            } else {
+                // Something else must be causing this, which will need looked into.
+                throw new Error("Something changed on the site backend (empty content)");
+            }
+        }
         // Chapter content into doc
         util.parseHtmlAndInsertIntoContent(data.data.content, doc.content);
         return doc.dom;
@@ -223,11 +235,13 @@ class KonkonKuupressParser extends Parser {
         // Generate table of contents based on the novel
         let createElementWithTextContent = KonkonKuupressParser.createElementWithTextContent.bind(null, doc.dom);
         // Title
-        doc.dom.title = data.data?.title;
+        if (data.data.title) doc.dom.title = data.data.title;
         // Description (nested in blockquote)
-        let description = createElementWithTextContent("blockquote", "");
-        util.parseHtmlAndInsertIntoContent(data.data.description, description);
-        doc.content.appendChild(description);
+        if (data.data.description) {
+            let description = createElementWithTextContent("blockquote","");
+            util.parseHtmlAndInsertIntoContent(data.data.description, description);
+            doc.content.appendChild(description);
+        }
         // Each volume gets a h2 header and a ul of links to chapters.
         for (const [volumeIndex, volume] of data.data.volumes.entries()) {
             // Create header and ul
@@ -332,6 +346,7 @@ class KonkonKuupressParser extends Parser {
     }
 
     extractDescription() {
+        if (!this.noveldata.description) return "";
         let descDom = util.sanitize(this.noveldata.description);
         return descDom.body.textContent;
     }

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -773,6 +773,7 @@
         <script src="js/parsers/KakuyomuParser.js"></script>
         <script src="js/parsers/KaystlsParser.js"></script>
         <script src="js/parsers/KemonopartyParser.js"></script>
+        <script src="js/parsers/KonkonKuupressParser.js"></script>
         <script src="js/parsers/KrytykalParser.js"></script>
         <script src="js/parsers/LanrySpaceParser.js"></script>
         <script src="js/parsers/LeafStudioParser.js"></script>

--- a/readme.md
+++ b/readme.md
@@ -272,7 +272,9 @@ WebToEpub is a browser extension for Firefox and Chrome that converts web novels
     <li>kemono.su</li>
     <li>knoxt.space</li>
     <li>kobatochan.com</li>
+    <li>konkon.ink</li>
     <li>krytykal.org</li>
+    <li>kuupress.com</li>
     <li>lazygirltranslations.com</li>
     <li>liberspark.com</li>
     <li>libread.com</li>
@@ -831,6 +833,7 @@ Don't forget to give the project a star! Thanks again!
     <li>kerimmkirac</li>
     <li>baalthasar</li>
     <li>David Siewert</li>
+    <li>MineRobber9000 (Parser for konkon.ink and kuupress.com)</li>
   </ul>
 </details>
 


### PR DESCRIPTION
[Konkon](https://konkon.ink) and [Kuupress](https://kuupress.com) are novel sharing sites from the team originally behind [ZetroTranslation](https://zetrotranslation.com) (shutting down at the end of this month). They share a similar backend, so I figured I'd PR in support for both of them at the same time.

~~Unfortunately, due to how their API authenticates requests, we can't actually get chapters that aren't completely unlocked to the public (basically, no `Origin` header, no user authentication, even if we have the user's `konkon-`/`kuupress-session` cookie). Still, being able to download all free chapters of a novel is better than nothing.~~ So apparently I completely missed `HttpClient.setDeclarativeNetRequestRules` when I was looking at other parsers... that one's on me, lol. I can now confirm it works (at least, I was able to download a chapter I bought on Konkon; like I said, the two sites are extremely similar on the backend, so I believe it should also work on Kuupress).

One thing to note: currently, all Konkon/Kuupress novels trigger the WEBP "your ePub reader may not be able to render this" warning. This is because all covers are stored as WEBP on the backend (except the default covers, which are stored as JPG).