### PR TITLE
Fix Novel543Parser: clean up split-chapter headings, ads, and promo banners

### DIFF
--- a/plugin/js/parsers/Novel543Parser.js
+++ b/plugin/js/parsers/Novel543Parser.js
@@ -24,7 +24,52 @@ class Novel543Parser extends Parser {
     }
 
     extractTitleImpl(dom) {
-        return dom.querySelector("h1.title");
+        let title = dom.querySelector("div.chapter-content h1") ?? dom.querySelector("h1.title");
+        if (title !== null && title.textContent !== null) {
+            // strip the page part marker of split chapters, e.g. "第1章 xxx (1/2)"
+            title.textContent = title.textContent.replace(/\s*\(\d+\/\d+\)\s*$/, "");
+        }
+        return title;
+    }
+
+    /**
+     * Clean junk out of each fetched chapter page before content extraction and
+     * image collection, so promo banners are not packed as images.
+     * @param { Document } dom
+     */
+    preprocessRawDom(dom) {
+        this.removeNovel543Junk(dom);
+    }
+
+    customRawDomToContentStep(chapter, content) {
+        if (content === null) {
+            return;
+        }
+        // split chapters show a title on every part page,
+        // e.g. "第1章 xxx (1/2)", "第1章 xxx (2/2)": keep only the first one
+        let headings = [...content.querySelectorAll("h1")];
+        let isPagePartTitle = (heading) => /\(\d+\/\d+\)\s*$/.test(heading.textContent ?? "");
+        util.removeElements(headings.slice(1).filter(isPagePartTitle));
+        for (let heading of content.querySelectorAll("h1")) {
+            heading.textContent = heading.textContent.replace(/\s*\(\d+\/\d+\)\s*$/, "");
+        }
+        this.removeNovel543Junk(content);
+    }
+
+    /**
+     * Remove ad slots, the "溫馨提示" site notice text, and the VIP membership
+     * promo banner. Runs on the whole document pre-collection and again on the
+     * extracted content when packing (idempotent).
+     * @param { Element | Document } root
+     */
+    removeNovel543Junk(root) {
+        util.removeElements(root.querySelectorAll("div.adBlock, div.gadBlock"));
+        for (let tip of root.querySelectorAll("p span[style*='ff6666']")) {
+            tip.closest("p")?.remove();
+        }
+        for (let img of root.querySelectorAll("img[src*='vip.png']")) {
+            img.closest("div")?.remove();
+        }
     }
 
     extractAuthor(dom) {

--- a/unitTest/Tests.html
+++ b/unitTest/Tests.html
@@ -56,6 +56,7 @@
     <script src="../plugin/js/parsers/MangadexParser.js"></script>
     <script src="../plugin/js/parsers/MangaHereParser.js"></script>
     <script src="../plugin/js/parsers/MuggleNetParser.js"></script>
+    <script src="../plugin/js/parsers/Novel543Parser.js"></script>
     <script src="../plugin/js/parsers/NovelfullParser.js"></script>
     <script src="../plugin/js/parsers/NovelSpreadParser.js"></script>
     <script src="../plugin/js/parsers/NovelUniverseParser.js"></script>
@@ -126,6 +127,7 @@
     <script src="UtestMangaHereParser.js"></script>
     <script src="UtestMuggleNetParser.js"></script>
     <script src="UtestNepustationParser.js"></script>
+    <script src="UtestNovel543Parser.js"></script>
     <script src="UtestNovelSpreadParser.js"></script>
     <script src="UtestNovelfullParser.js"></script>
     <script src="UtestNovelUpdatesParser.js"></script>

--- a/unitTest/UtestNovel543Parser.js
+++ b/unitTest/UtestNovel543Parser.js
@@ -1,0 +1,131 @@
+
+"use strict";
+
+module("Novel543Parser");
+
+let Novel543MergedChapterSample =
+`<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <title>第1章 危險性武器？神級間諜？ (1/2)</title>
+</head>
+<body>
+    <div class="chapter-content px-3">
+        <h1> 第1章 危險性武器？神級間諜？ (1/2) </h1>
+        <div class="content py-5">
+            <div class="gadBlock" data-ad="clickforce-336x280"><ins class="clickforceads" data-ad-zone="17003"></ins></div>
+            <p>龍國，江城。</p>
+            <p>蘇南猛的從獃滯中回過神來。</p>
+            <div class="adBlock" data-ad="pubfuture-mid"><div id="pf-16164-1"></div></div>
+            <p>現場的兩位嘉賓都很不看好這位16號選手。</p>
+            <div><p><span style="color:#ff6666">溫馨提示: </span>優化了VIP會員的閱讀體驗</p></div>
+            <div style="height: 100px;"><img src="/images/vip.png"><p>應廣大讀者的要求, 現推出VIP會員免廣告功能</p></div>
+        </div>
+        <br>
+        <h1> 第1章 危險性武器？神級間諜？ (2/2) </h1>
+        <div class="content py-5">
+            <p>而社會觀察學家陳露的眉頭，卻不自覺的皺了起來。</p>
+            <div class="adBlock" data-ad="tamedia-banner"></div>
+            <p>他望著手中的鐵鍋和顛勺，陷入了沉思。</p>
+            <div><p><span style="color:#ff6666">溫馨提示: </span>登錄用戶跨設備永久保存書架的數據</p></div>
+        </div>
+    </div>
+    <div class="warp my-5 foot-nav">
+        <a href="/0220699805/8096_1.html">上一章</a><span>|</span>
+        <a href="/0220699805/dir">目錄</a><span>|</span>
+        <a href="/0220699805/8096_1_2.html">下一章</a>
+    </div>
+</body>
+</html>`;
+
+QUnit.test("customRawDomToContentStep", function (assert) {
+    let dom = new DOMParser().parseFromString(Novel543MergedChapterSample, "text/html");
+    let parser = new Novel543Parser();
+    let content = parser.findContent(dom);
+    parser.customRawDomToContentStep({}, content);
+
+    let headings = [...content.querySelectorAll("h1")];
+    assert.equal(headings.length, 1);
+    assert.equal(headings[0].textContent.trim(), "第1章 危險性武器？神級間諜？");
+    assert.equal(content.querySelectorAll("div.adBlock, div.gadBlock").length, 0);
+    assert.equal(content.querySelectorAll("span[style*='ff6666']").length, 0);
+    assert.equal(content.querySelectorAll("img[src*='vip.png']").length, 0);
+    // both parts of the chapter are still present
+    let text = content.textContent;
+    assert.ok(text.includes("龍國，江城。"));
+    assert.ok(text.includes("陷入了沉思。"));
+    assert.ok(!text.includes("溫馨提示"));
+    assert.ok(!text.includes("(1/2)"));
+    assert.ok(!text.includes("(2/2)"));
+});
+
+QUnit.test("preprocessRawDom", function (assert) {
+    // the promo banner can sit outside div.chapter-content; it must be gone
+    // before image collection runs, or it ends up packed as an orphan image
+    let dom = new DOMParser().parseFromString(
+        `<html><body>
+            <div class="chapter-content px-3">
+                <h1> 第1章 測試 (1/2) </h1>
+                <p>正文。</p>
+            </div>
+            <div style="height: 100px;"><img src="/images/vip.png"><p>現推出VIP會員免廣告功能</p></div>
+        </body></html>`,
+        "text/html");
+    let parser = new Novel543Parser();
+    parser.preprocessRawDom(dom);
+
+    assert.equal(dom.querySelectorAll("img[src*='vip.png']").length, 0);
+    assert.equal(dom.body.textContent.includes("VIP會員免廣告"), false);
+    // real chapter text untouched
+    assert.ok(dom.body.textContent.includes("正文。"));
+});
+
+QUnit.test("extractTitleImpl", function (assert) {
+    let dom = new DOMParser().parseFromString(Novel543MergedChapterSample, "text/html");
+    let parser = new Novel543Parser();
+    let title = parser.extractTitle(dom);
+    assert.equal(title, "第1章 危險性武器？神級間諜？");
+});
+
+QUnit.test("extractTitleImpl-bookPage", function (assert) {
+    let dom = new DOMParser().parseFromString(
+        "<html><head><title>Book</title></head><body>" +
+        "<section id='detail'><h1 class='title'>創業整活我最刑，身後全是妖妖靈</h1></section>" +
+        "</body></html>",
+        "text/html"
+    );
+    let parser = new Novel543Parser();
+    assert.equal(parser.extractTitle(dom), "創業整活我最刑，身後全是妖妖靈");
+});
+
+function makeFootNavSample(nextHref) {
+    return new DOMParser().parseFromString(
+        "<html><body><div class='warp my-5 foot-nav'>" +
+        "<a href='https://www.novel543.com/0220699805/8096_1.html'>上一章</a><span>|</span>" +
+        "<a href='https://www.novel543.com/0220699805/dir'>目錄</a><span>|</span>" +
+        `<a href="${nextHref}">下一章</a>` +
+        "</div></body></html>",
+        "text/html"
+    );
+}
+
+QUnit.test("moreChapterTextUrl-continuation", function (assert) {
+    let parser = new Novel543Parser();
+    let dom = makeFootNavSample("https://www.novel543.com/0220699805/8096_1_2.html");
+    let actual = parser.moreChapterTextUrl(dom, "https://www.novel543.com/0220699805/8096_1.html");
+    assert.equal(actual, "https://www.novel543.com/0220699805/8096_1_2.html");
+});
+
+QUnit.test("moreChapterTextUrl-lastPart", function (assert) {
+    let parser = new Novel543Parser();
+    let dom = makeFootNavSample("/0220699805/8096_2.html");
+    let actual = parser.moreChapterTextUrl(dom, "https://www.novel543.com/0220699805/8096_1.html");
+    assert.equal(actual, null);
+});
+
+QUnit.test("moreChapterTextUrl-noSplitUrls", function (assert) {
+    let parser = new Novel543Parser();
+    let dom = makeFootNavSample("/0208599671/105.html");
+    let actual = parser.moreChapterTextUrl(dom, "https://www.twbook.cc/0208599671/104.html");
+    assert.equal(actual, null);
+});


### PR DESCRIPTION
## Problem

novel543.com (and twbook.cc) split long chapters across multiple part pages (`8096_1.html` → `8096_1_2.html`), which `walkPagesOfChapter` merges. This produces several content problems in the packed EPUB:

- Every part page repeats the chapter heading with a page-part marker, so merged chapters contain e.g. `<h1>第1章 xxx (1/2)</h1>` followed by `<h1>第1章 xxx (2/2)</h1>`.
- Ad slots (`div.adBlock`, `div.gadBlock`), red "溫馨提示" site-notice paragraphs, and the VIP membership promo banner are kept as book content.
- The VIP promo banner image is collected by the ImageCollector and packed into the EPUB even after its element is removed from the content, leaving an unused ~12 KB image in the manifest.

## Changes

- `extractTitleImpl`: prefer the chapter heading, and strip the trailing `(1/2)` part marker from titles.
- `customRawDomToContentStep`: keep only the first heading of a merged split chapter and strip the part markers from it.
- New `removeNovel543Junk(root)`: removes ad slots, 溫馨提示 notice paragraphs, and the VIP banner.
  - Called from `preprocessRawDom` on the whole fetched document *before* image collection, so the promo banner is no longer downloaded/packed as an orphaned image.
  - Called again from `customRawDomToContentStep` when packing (idempotent).

Applies to both registered sites: novel543.com, twbook.cc.

## Testing

- Added `unitTest/UtestNovel543Parser.js` (7 QUnit tests: heading dedupe/marker strip, title extraction incl. book pages, continuation-link detection for `moreChapterTextUrl`, and whole-document junk removal via `preprocessRawDom`) and registered it in `Tests.html`.
- All tests pass; `eslint --config eslint/.eslintrc.js plugin/js/parsers/Novel543Parser.js` is clean.
- Verified against live site: converting a real book now yields one clean heading per chapter, no ad/notice/banner content, and no unused VIP banner image in the EPUB.