### PR TITLE
feat(readrift): optimize initial load

### DIFF
--- a/plugin/js/parsers/ReadRiftParser.js
+++ b/plugin/js/parsers/ReadRiftParser.js
@@ -74,8 +74,10 @@ class ReadRiftParser extends Parser {
         while (apiUrl) {
             try {
                 apiUrl = await this.getChaptersFromApi(apiUrl, urls);
+                if (apiUrl) {
+                    await util.sleep(150 + Math.random() * 100);
+                }
             } catch (err) {
-                apiUrl = null;
                 throw new Error(
                     `ReadRiftParser failed while scanning novel's chapters: ${err.message}`,
                 );

--- a/plugin/js/parsers/ReadRiftParser.js
+++ b/plugin/js/parsers/ReadRiftParser.js
@@ -77,12 +77,11 @@ class ReadRiftParser extends Parser {
         let apiUrl =
             "https://readrift.net/api/v1/books/" +
             this.novelId +
-            "/chapters/?limit=10&page=1";
+            "/chapters/?limit=30&page=1";
 
         while (apiUrl) {
             try {
                 apiUrl = await this.getChaptersFromApi(apiUrl, urls);
-                await util.sleep(300);
             } catch (err) {
                 apiUrl = null;
                 throw new Error(

--- a/plugin/js/parsers/ReadRiftParser.js
+++ b/plugin/js/parsers/ReadRiftParser.js
@@ -71,16 +71,24 @@ class ReadRiftParser extends Parser {
 
         let apiUrl = `https://readrift.net/api/v1/books/${this.novelId}/chapters/?limit=30&page=1`;
 
+        // Temporarily overwriting throttle for TOC requests. We are overwriting
+        // the `minimumThrottle` this way instead of using a sleep so that users
+        // can manually overwrite the delay if they want
+        const originalThrottle = this.minimumThrottle;
+
         while (apiUrl) {
             try {
                 apiUrl = await this.getChaptersFromApi(apiUrl, urls);
                 if (apiUrl) {
-                    await util.sleep(150 + Math.random() * 100);
+                    this.minimumThrottle = 150 + Math.random() * 100;
+                    await this.rateLimitDelay(); // Handles the sleep logic for us
                 }
             } catch (err) {
                 throw new Error(
                     `ReadRiftParser failed while scanning novel's chapters: ${err.message}`,
                 );
+            } finally {
+                this.minimumThrottle = originalThrottle; // Restoring throttle back to the original delay configured for chapter downloads
             }
         }
 

--- a/plugin/js/parsers/ReadRiftParser.js
+++ b/plugin/js/parsers/ReadRiftParser.js
@@ -67,17 +67,9 @@ class ReadRiftParser extends Parser {
          * ids we need to make an API request to get the chapter urls directly.
          */
         const urls = [];
+        if (!this.novelId) return urls;
 
-        if (!this.novelId) {
-            return urls;
-        }
-
-        // Now we're getting the chapter ids directly from the api so we can
-        // populate the urls
-        let apiUrl =
-            "https://readrift.net/api/v1/books/" +
-            this.novelId +
-            "/chapters/?limit=30&page=1";
+        let apiUrl = `https://readrift.net/api/v1/books/${this.novelId}/chapters/?limit=30&page=1`;
 
         while (apiUrl) {
             try {


### PR DESCRIPTION
### Problem: 
Initial load (populating the chapter list) for a novel with 300 chapters took around 21 seconds, which is pretty bad. Mb guys.

### Solution:
I originally copied the ToC pagination amount of 10, but by pinging the server, turns out the limit is actually 30. I also made the delay between requests a bit smaller at 150 to 250 ms with a jitter compared to the original 300 ms.

Overall, 64.52% less requests and initial load is around 3 times faster.

- Old: 31 requests finished in 21.25 seconds
- New: 11 requests finished in 6.45 seconds
