### PR TITLE
fix(images): drop failed image fetches and prune dead tags from epub

### DIFF
--- a/eslint/.eslintrc.js
+++ b/eslint/.eslintrc.js
@@ -70,6 +70,7 @@ module.exports = {
         "FetchErrorHandler": "readonly",
         "FetchImageErrorHandler": "readonly",
         "Firefox": "readonly",
+        "FontInfo": "readonly",
         "FootnoteExtractor": "readonly",
         "HttpClient": "readonly",
         "ImageCollector": "readonly",

--- a/plugin/js/EpubItem.js
+++ b/plugin/js/EpubItem.js
@@ -175,6 +175,7 @@ class ImageInfo extends EpubItem { // eslint-disable-line no-unused-vars
         this.width = null;
         this.dataOrigFileUrl = dataOrigFileUrl;
         this.queuedForFetch = false;
+        this.isFailed = false;
     }
 
     getZipHref() {
@@ -207,8 +208,10 @@ class ImageInfo extends EpubItem { // eslint-disable-line no-unused-vars
     }
 
     packInEpub(zipWriter) {
-        zipWriter.add(this.getZipHref(),
-            new zip.BlobReader(new Blob([this.arraybuffer])));
+        if (this.arraybuffer != null) {
+            zipWriter.add(this.getZipHref(),
+                new zip.BlobReader(new Blob([this.arraybuffer])));
+        }
     }
 
     findImageSuffix(wrappingUrl) {
@@ -321,14 +324,16 @@ class ImageInfo extends EpubItem { // eslint-disable-line no-unused-vars
     }
 }
 
-class FontInfo extends ImageInfo {
+class FontInfo extends ImageInfo { // eslint-disable-line no-unused-vars
     constructor(fontName) {
         super();
         this.fontName = fontName;
     }
 
     packInEpub(zipWriter) {
-        zipWriter.add("OEBPS/Fonts/"+this.fontName,
-            new zip.BlobReader(new Blob([this.arraybuffer])));
+        if (this.arraybuffer != null) {
+            zipWriter.add("OEBPS/Fonts/"+this.fontName,
+                new zip.BlobReader(new Blob([this.arraybuffer])));
+        }
     }
 }

--- a/plugin/js/EpubItemSupplier.js
+++ b/plugin/js/EpubItemSupplier.js
@@ -53,6 +53,6 @@ class EpubItemSupplier { // eslint-disable-line no-unused-vars
     }
 
     hasCoverImageFile() {
-        return (this.coverImageInfo != null);
+        return (this.coverImageInfo != null && !this.coverImageInfo.isFailed && (this.coverImageInfo.arraybuffer != null));
     }
 }

--- a/plugin/js/ImageCollector.js
+++ b/plugin/js/ImageCollector.js
@@ -439,8 +439,11 @@ class ImageCollector {
         }
         catch (error)
         {
-            // ToDo, implement error handler.
-            this.imagesToPack.push(imageInfo);
+            imageInfo.isFailed = true;
+            if (this.coverImageInfo === imageInfo) {
+                this.coverImageInfo = null;
+            }
+            progressIndicator();
             ErrorLog.log(error);
         }
     }
@@ -644,8 +647,8 @@ class ImageTagReplacer {
     replaceTag(imageInfo) {
         // replace tag with nested <img> tag, with new <img> tag
         let parent = this.wrappingElement.parentElement;
-        if ((imageInfo != null) && (parent != null)) {
-            if (this.isDuplicateImageToRemove(imageInfo)) {
+        if (parent != null) {
+            if ((imageInfo == null) || imageInfo.isFailed || this.isDuplicateImageToRemove(imageInfo)) {
                 this.wrappingElement.remove();
             } else {
                 this.insertImageInLegalParent(parent, imageInfo);

--- a/unitTest/UtestEpubItem.js
+++ b/unitTest/UtestEpubItem.js
@@ -76,3 +76,32 @@ test("ChapterEpubItem_chapterInfo_noNewArc", function (assert) {
     let ci = [...item.chapterInfo()];
     assert.equal(ci.length, 1);
 });
+
+QUnit.test("packInEpub with null arraybuffer does not call zipWriter.add on ImageInfo and FontInfo", function (assert) {
+    let zipWriter = {
+        addCalls: 0,
+        entries: [],
+        add: function (href, reader) {
+            this.addCalls++;
+            this.entries.push({ href: href, reader: reader });
+        }
+    };
+
+    let imageInfo = new ImageInfo("http://dummy.com/img.jpg", 0, "http://dummy.com/img.jpg");
+    imageInfo.arraybuffer = null;
+    imageInfo.packInEpub(zipWriter);
+    assert.equal(zipWriter.addCalls, 0);
+
+    let fontInfo = new FontInfo("customFont.woff2");
+    fontInfo.arraybuffer = null;
+    fontInfo.packInEpub(zipWriter);
+    assert.equal(zipWriter.addCalls, 0);
+
+    imageInfo.arraybuffer = new ArrayBuffer(16);
+    imageInfo.packInEpub(zipWriter);
+    assert.equal(zipWriter.addCalls, 1);
+
+    fontInfo.arraybuffer = new ArrayBuffer(16);
+    fontInfo.packInEpub(zipWriter);
+    assert.equal(zipWriter.addCalls, 2);
+});

--- a/unitTest/UtestImageCollector.js
+++ b/unitTest/UtestImageCollector.js
@@ -307,3 +307,81 @@ QUnit.test("findHighestResImage", function (assert) {
     let actual = new ImageCollector().findHighestResImage(img);
     assert.equal(actual, "https://i0.wp.com/graverobbertl.site/wp-content/uploads/2019/08/d9s1e0ybizb43otviytn8jqbjw2t_15g0_1f3_1z4_che9.jpg?w=1839&ssl=1");
 });
+
+QUnit.test("fetchImage failure drops image from pack list, sets isFailed, calls progress, and clears cover", async function (assert) {
+    let imageCollector = new ImageCollector();
+    let preferences = new UserPreferences();
+    imageCollector.userPreferences = preferences;
+
+    let imageInfo = imageCollector.addImageInfo("http://test.com/fail.jpg", "http://test.com/fail.jpg", null, false);
+    imageCollector.setCoverImageUrl("http://test.com/fail.jpg");
+    assert.equal(imageCollector.coverImageInfo, imageInfo);
+
+    let oldWrapFetch = HttpClient.wrapFetch;
+    let oldLog = ErrorLog.log;
+    let loggedError = null;
+    ErrorLog.log = function (err) {
+        loggedError = err;
+    };
+    HttpClient.wrapFetch = function () {
+        return Promise.reject(new Error("Network fetch failed"));
+    };
+
+    let progressCount = 0;
+    try {
+        await imageCollector.fetchImage(imageInfo, () => {
+            progressCount++;
+        }, "http://test.com/page.html");
+    } finally {
+        HttpClient.wrapFetch = oldWrapFetch;
+        ErrorLog.log = oldLog;
+    }
+
+    assert.equal(imageInfo.isFailed, true);
+    assert.equal(imageInfo.arraybuffer, null);
+    assert.equal(imageCollector.imagesToPack.length, 0);
+    assert.equal(imageCollector.coverImageInfo, null);
+    assert.equal(progressCount, 1);
+    assert.ok(loggedError != null);
+});
+
+QUnit.test("replaceImageTags with failed image or null imageInfo cleanly removes wrapping element and img tag", function (assert) {
+    let dom = TestUtils.makeDomWithBody(
+        "<div>" +
+            "<p id=\"p1\">Paragraph 1 <img id=\"img_fail\" src=\"http://test.com/fail.jpg\"></p>" +
+            "<p id=\"p2\">Paragraph 2 <img id=\"img_unregistered\" src=\"http://test.com/unregistered.jpg\"></p>" +
+            "<div id=\"wrap_fail\" class=\"thumb\"><a href=\"http://test.com/fail_wrap.jpg\"><img id=\"img_fail_wrap\" src=\"http://test.com/fail_wrap.jpg\"></a></div>" +
+            "<a id=\"wrap_unregistered\" href=\"http://test.com/unregistered_wrap.jpg\"><img id=\"img_unregistered_wrap\" src=\"http://test.com/unregistered_wrap.jpg\"></a>" +
+            "<p id=\"p3\">Paragraph 3 <img id=\"img_ok\" src=\"http://test.com/ok.jpg\"></p>" +
+        "</div>"
+    );
+
+    let imageCollector = new ImageCollector();
+    let preferences = new UserPreferences();
+    imageCollector.userPreferences = preferences;
+
+    let failInfo = imageCollector.addImageInfo("http://test.com/fail.jpg", "http://test.com/fail.jpg", null, false);
+    failInfo.isFailed = true;
+
+    let failWrapInfo = imageCollector.addImageInfo("http://test.com/fail_wrap.jpg", "http://test.com/fail_wrap.jpg", null, false);
+    failWrapInfo.isFailed = true;
+
+    let okInfo = imageCollector.addImageInfo("http://test.com/ok.jpg", "http://test.com/ok.jpg", null, false);
+    okInfo.isFailed = false;
+    okInfo.mediaType = "image/jpeg";
+    okInfo.height = 100;
+    okInfo.width = 100;
+    okInfo.arraybuffer = new ArrayBuffer(8);
+
+    imageCollector.replaceImageTags(dom.body);
+
+    assert.equal(dom.getElementById("img_fail"), null);
+    assert.equal(dom.getElementById("img_unregistered"), null);
+    assert.equal(dom.getElementById("wrap_fail"), null);
+    assert.equal(dom.getElementById("img_fail_wrap"), null);
+    assert.equal(dom.getElementById("wrap_unregistered"), null);
+    assert.equal(dom.getElementById("img_unregistered_wrap"), null);
+    let p3 = dom.getElementById("p3");
+    assert.ok(p3.querySelector("img") != null);
+    assert.equal(p3.querySelector("img").src.includes("Images/"), true);
+});


### PR DESCRIPTION
## Description
When image fetches fail (network timeouts, HTTP errors, blocked hosts), `ImageCollector.fetchImage` caught the error but unconditionally pushed the unpopulated `ImageInfo` to `imagesToPack`. Because its `arraybuffer` remained `null`, `ImageInfo.packInEpub` packed a 4-byte string `"null"` (`new Blob([null])`) into the EPUB zip, while OPF manifest, spine, and chapter XHTML referenced the missing/corrupted file.

This change:
- Drops failed image fetches from `imagesToPack` in the `fetchImage` catch block and marks `imageInfo.isFailed = true`.
- Resets `this.coverImageInfo = null` if a cover image fetch fails, and guards `EpubItemSupplier.hasCoverImageFile()`.
- Updates `ImageTagReplacer.replaceTag` to prune wrapper/image elements from chapter XHTML when image fetch failed or `imageInfo` is missing.
- Advances the progress indicator on fetch failure so the UI progress counter remains accurate.
- Adds defensive guards in `ImageInfo.packInEpub` and `FontInfo.packInEpub` preventing null buffers from being added to the zip writer.
- Adds `"FontInfo": "readonly"` to ESLint globals and disables unused var warning on class declaration.
- Adds regression unit tests in `UtestImageCollector.js` and `UtestEpubItem.js`.

## Testing
- `cd eslint && node pack.js && eslint *.js` passes with 0 errors.
- Unit tests added and verified for `fetchImage` failure handling, `replaceImageTags` element pruning, and `packInEpub` null buffer guards.