### PR TITLE
Fix typo in `Parser.js` function and 63 other Parsers

### DIFF
--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -780,7 +780,7 @@ class Parser {
         };
     }
 
-    static findConstrutedContent(dom) {
+    static findConstructedContent(dom) {
         return dom.querySelector("div." + Parser.WEB_TO_EPUB_CLASS_NAME);
     }
 

--- a/plugin/js/debugging/FakeParser.js
+++ b/plugin/js/debugging/FakeParser.js
@@ -26,7 +26,7 @@ class FakeParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/AppYoruWorldParser.js
+++ b/plugin/js/parsers/AppYoruWorldParser.js
@@ -36,7 +36,7 @@ class AppYoruWorldParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl() {

--- a/plugin/js/parsers/BabelChainParser.js
+++ b/plugin/js/parsers/BabelChainParser.js
@@ -46,7 +46,7 @@ class BabelChainParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     findCoverImageUrl(dom) {

--- a/plugin/js/parsers/BotitranslationParser.js
+++ b/plugin/js/parsers/BotitranslationParser.js
@@ -27,7 +27,7 @@ class BotitranslationParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/ChikariParser.js
+++ b/plugin/js/parsers/ChikariParser.js
@@ -79,6 +79,6 @@ class ChikariParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 }

--- a/plugin/js/parsers/ChyoaParser.js
+++ b/plugin/js/parsers/ChyoaParser.js
@@ -128,7 +128,7 @@ class ChyoaParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     findCoverImageUrl(dom) {

--- a/plugin/js/parsers/CrimsontranslationsParser.js
+++ b/plugin/js/parsers/CrimsontranslationsParser.js
@@ -13,7 +13,7 @@ class CrimsontranslationsParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/DaoDivineTlParser.js
+++ b/plugin/js/parsers/DaoDivineTlParser.js
@@ -55,7 +55,7 @@ class DaoDivineTlParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl() {

--- a/plugin/js/parsers/DarkNovelsParser.js
+++ b/plugin/js/parsers/DarkNovelsParser.js
@@ -14,7 +14,7 @@ class DarkNovelsParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/DiurnisParser.js
+++ b/plugin/js/parsers/DiurnisParser.js
@@ -40,7 +40,7 @@ class DiurnisParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/EstarParser.js
+++ b/plugin/js/parsers/EstarParser.js
@@ -48,7 +48,7 @@ class EstarParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/FanFicParadiseParser.js
+++ b/plugin/js/parsers/FanFicParadiseParser.js
@@ -21,7 +21,7 @@ class FanFicParadiseParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/FanficusParser.js
+++ b/plugin/js/parsers/FanficusParser.js
@@ -13,7 +13,7 @@ class FanficusParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/FictionreadParser.js
+++ b/plugin/js/parsers/FictionreadParser.js
@@ -159,7 +159,7 @@ class FictionreadParser extends Parser { // eslint-disable-line no-unused-vars
      * @param { Document } dom 
      */
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     /**

--- a/plugin/js/parsers/FlyingLinesParser.js
+++ b/plugin/js/parsers/FlyingLinesParser.js
@@ -13,7 +13,7 @@ class FlyingLinesParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/FoxtellerParser.js
+++ b/plugin/js/parsers/FoxtellerParser.js
@@ -13,7 +13,7 @@ class FoxtellerParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/FuhuzzParser.js
+++ b/plugin/js/parsers/FuhuzzParser.js
@@ -16,7 +16,7 @@ class FuhuzzParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/GenesiStudioParser.js
+++ b/plugin/js/parsers/GenesiStudioParser.js
@@ -95,6 +95,6 @@ class GenesiStudioParser extends Parser {
     }
     
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 }

--- a/plugin/js/parsers/GlobalNovelpiaParser.js
+++ b/plugin/js/parsers/GlobalNovelpiaParser.js
@@ -29,7 +29,7 @@ class GlobalNovelpiaParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/JadeScrollsParser.js
+++ b/plugin/js/parsers/JadeScrollsParser.js
@@ -49,7 +49,7 @@ class JadeScrollsParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl() {

--- a/plugin/js/parsers/KemonopartyParser.js
+++ b/plugin/js/parsers/KemonopartyParser.js
@@ -134,7 +134,7 @@ class KemonopartyParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     copyImagesIntoContent(dom) {

--- a/plugin/js/parsers/KonkonKuupressParser.js
+++ b/plugin/js/parsers/KonkonKuupressParser.js
@@ -303,7 +303,7 @@ class KonkonKuupressParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     findChapterTitle(dom) {

--- a/plugin/js/parsers/LanrySpaceParser.js
+++ b/plugin/js/parsers/LanrySpaceParser.js
@@ -72,7 +72,7 @@ class LanrySpaceParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl() {

--- a/plugin/js/parsers/LightnovelasiaParser.js
+++ b/plugin/js/parsers/LightnovelasiaParser.js
@@ -79,7 +79,7 @@ class LightnovelasiaParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl() {

--- a/plugin/js/parsers/MangaHereParser.js
+++ b/plugin/js/parsers/MangaHereParser.js
@@ -17,7 +17,7 @@ class MangaHereParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     convertSelectToImgTagsToFollow(dom, content, select) {

--- a/plugin/js/parsers/MangaReadParser.js
+++ b/plugin/js/parsers/MangaReadParser.js
@@ -13,7 +13,7 @@ class MangaReadParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/MangadexParser.js
+++ b/plugin/js/parsers/MangadexParser.js
@@ -39,7 +39,7 @@ class MangadexParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     findCoverImageUrl(dom) {

--- a/plugin/js/parsers/MistmintHavenParser.js
+++ b/plugin/js/parsers/MistmintHavenParser.js
@@ -69,7 +69,7 @@ class MistmintHavenParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/MottruyenParser.js
+++ b/plugin/js/parsers/MottruyenParser.js
@@ -51,7 +51,7 @@ class MottruyenParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
 

--- a/plugin/js/parsers/MtlBooksParser.js
+++ b/plugin/js/parsers/MtlBooksParser.js
@@ -68,7 +68,7 @@ class MtlBooksParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     jsonToHtml(url, apiJson) {

--- a/plugin/js/parsers/MtlarchiveParser.js
+++ b/plugin/js/parsers/MtlarchiveParser.js
@@ -63,7 +63,7 @@ class MtlarchiveParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/NeobookParser.js
+++ b/plugin/js/parsers/NeobookParser.js
@@ -13,7 +13,7 @@ class NeobookParser extends Parser { // eslint-disable-line no-unused-vars
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/NovelArchiveParser.js
+++ b/plugin/js/parsers/NovelArchiveParser.js
@@ -63,6 +63,6 @@ class NovelArchiveParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 }

--- a/plugin/js/parsers/NovelSpreadParser.js
+++ b/plugin/js/parsers/NovelSpreadParser.js
@@ -21,7 +21,7 @@ class NovelSpreadParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/NovelarrowParser.js
+++ b/plugin/js/parsers/NovelarrowParser.js
@@ -32,7 +32,7 @@ class NovelarrowParser extends Parser { // eslint-disable-line no-unused-vars
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/NovelightParser.js
+++ b/plugin/js/parsers/NovelightParser.js
@@ -81,7 +81,7 @@ class NovelightParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     async fetchChapter(url) {

--- a/plugin/js/parsers/NovelsectParser.js
+++ b/plugin/js/parsers/NovelsectParser.js
@@ -54,7 +54,7 @@ class NovelsectParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/PatreonParser.js
+++ b/plugin/js/parsers/PatreonParser.js
@@ -66,7 +66,7 @@ class PatreonParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     async fetchChapter(url) {

--- a/plugin/js/parsers/PawchiveParser.js
+++ b/plugin/js/parsers/PawchiveParser.js
@@ -175,7 +175,7 @@ class PawchiveParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/PeachygardensBlogspotParser.js
+++ b/plugin/js/parsers/PeachygardensBlogspotParser.js
@@ -48,7 +48,7 @@ class PeachygardensBlogspotParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     findCoverImageUrl(dom) {

--- a/plugin/js/parsers/RaeitranslationsParser.js
+++ b/plugin/js/parsers/RaeitranslationsParser.js
@@ -20,7 +20,7 @@ class RaeitranslationsParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/RandomtranslatorParser.js
+++ b/plugin/js/parsers/RandomtranslatorParser.js
@@ -57,7 +57,7 @@ class RandomtranslatorParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     async fetchChapter(url) {

--- a/plugin/js/parsers/RanobelibParser.js
+++ b/plugin/js/parsers/RanobelibParser.js
@@ -164,7 +164,7 @@ class RanobelibParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     async loadMetadata() {

--- a/plugin/js/parsers/ReadComicOnlineParser.js
+++ b/plugin/js/parsers/ReadComicOnlineParser.js
@@ -72,7 +72,7 @@ class ReadComicOnlineParser extends Parser {
     }
 
     findContent(dom) {
-        let content = Parser.findConstrutedContent(dom);
+        let content = Parser.findConstructedContent(dom);
         if (content === null) {
             content = dom.createElement("div");
             content.className = Parser.WEB_TO_EPUB_CLASS_NAME;

--- a/plugin/js/parsers/RequiemtlsParser.js
+++ b/plugin/js/parsers/RequiemtlsParser.js
@@ -23,7 +23,7 @@ class RequiemtlsParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractSubject(dom) {

--- a/plugin/js/parsers/RuversParser.js
+++ b/plugin/js/parsers/RuversParser.js
@@ -23,7 +23,7 @@ class RuversParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/SakurazeParser.js
+++ b/plugin/js/parsers/SakurazeParser.js
@@ -82,7 +82,7 @@ class SakurazeParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     // Chapter content from the API has no heading, so use the title from the chapter list

--- a/plugin/js/parsers/SangtacvietParser.js
+++ b/plugin/js/parsers/SangtacvietParser.js
@@ -41,7 +41,7 @@ class SangtacvietParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/SnoutandcoParser.js
+++ b/plugin/js/parsers/SnoutandcoParser.js
@@ -19,7 +19,7 @@ class SnoutandcoParser extends Parser { // eslint-disable-line no-unused-vars
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/SpacebattlesParser.js
+++ b/plugin/js/parsers/SpacebattlesParser.js
@@ -28,7 +28,7 @@ class SpacebattlesParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/StellarRealmParser.js
+++ b/plugin/js/parsers/StellarRealmParser.js
@@ -43,7 +43,7 @@ class StellarRealmParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl() {

--- a/plugin/js/parsers/TapreadParser.js
+++ b/plugin/js/parsers/TapreadParser.js
@@ -41,7 +41,7 @@ class TapreadParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/WebNovelOnlineParser.js
+++ b/plugin/js/parsers/WebNovelOnlineParser.js
@@ -15,7 +15,7 @@ class WebNovelOnlineParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/WetriedTlsParser.js
+++ b/plugin/js/parsers/WetriedTlsParser.js
@@ -115,7 +115,7 @@ class WetriedTlsParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl() {

--- a/plugin/js/parsers/WfxsParser.js
+++ b/plugin/js/parsers/WfxsParser.js
@@ -20,7 +20,7 @@ class WfxsParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);        
+        return Parser.findConstructedContent(dom);        
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/WnmtlOrgParser.js
+++ b/plugin/js/parsers/WnmtlOrgParser.js
@@ -47,7 +47,7 @@ class WnmtlOrgParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/WtrlabParser.js
+++ b/plugin/js/parsers/WtrlabParser.js
@@ -86,7 +86,7 @@ class WtrlabParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/WuxiaTranslateParser.js
+++ b/plugin/js/parsers/WuxiaTranslateParser.js
@@ -125,7 +125,7 @@ class WuxiaTranslateParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     removeUnwantedElementsFromContentElement(element) {

--- a/plugin/js/parsers/YushuboParser.js
+++ b/plugin/js/parsers/YushuboParser.js
@@ -16,7 +16,7 @@ class YushuboParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl(dom) {

--- a/plugin/js/parsers/ZenithtlsParser.js
+++ b/plugin/js/parsers/ZenithtlsParser.js
@@ -32,7 +32,7 @@ class ZenithtlsParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     extractTitleImpl() {

--- a/plugin/js/parsers/ZirusMusingsParser.js
+++ b/plugin/js/parsers/ZirusMusingsParser.js
@@ -58,7 +58,7 @@ class ZirusMusingsParser extends Parser {
     }
 
     findContent(dom) {
-        return Parser.findConstrutedContent(dom);
+        return Parser.findConstructedContent(dom);
     }
 
     async fetchChapter(url) {

--- a/plugin/js/parsers/experimental/Sbxh1Parser.js
+++ b/plugin/js/parsers/experimental/Sbxh1Parser.js
@@ -70,7 +70,7 @@ class Sbxh1Parser extends Parser {
 
     findContent(dom) {
         return (
-            Parser.findConstrutedContent(dom) ??
+            Parser.findConstructedContent(dom) ??
             dom.querySelector("article.novel-viewer")
         );
     }

--- a/unitTest/UtestTapreadParser.js
+++ b/unitTest/UtestTapreadParser.js
@@ -5,7 +5,7 @@ module("TapreadParser");
 
 QUnit.test("jsonToHtml", function (assert) {
     let dom = TapreadParser.jsonToHtml(TapreadSampleChapterJson);
-    let content = Parser.findConstrutedContent(dom);
+    let content = Parser.findConstructedContent(dom);
     assert.equal(content.innerHTML, "<h1>Chapter 1-Marry Me</h1><p>\"Dear, marry me!\"  </p><p>Fastening his buttons, </p>");
 });
 


### PR DESCRIPTION
Fixed a minor typo in the function `findConstrutedContent` in `Parser.js`
`Construted` was missing the `c` before the `t` to make it `Constructed`