### PR TITLE
Display the current version of the extension in the popup

### DIFF
--- a/plugin/css/default.css
+++ b/plugin/css/default.css
@@ -30,6 +30,14 @@
     border-bottom: 1px #CCC solid;
 }
 
+#extensionVersionSection {
+    text-align: center;
+}
+
+#spanWebToEpubVersion {
+    display: inline-block;
+    text-align: center;
+}
 
 progress {
     width: 56%;

--- a/plugin/js/Parser.js
+++ b/plugin/js/Parser.js
@@ -208,6 +208,9 @@ class Parser {
     }
 
     populateUI(dom) {
+        let versionElement = document.getElementById("spanExtensionVersion");
+        versionElement.textContent = `WebToEpub v${util.extensionVersion()}`;
+
         CoverImageUI.showCoverImageUrlInput(true);
         let coverUrl = this.findCoverImageUrl(dom);
         CoverImageUI.setCoverImageUrl(coverUrl);

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -10,6 +10,9 @@
 </head>
 <body>
     <div class="container">
+        <section id="extensionVersionSection">
+            <span id="spanExtensionVersion"></span>
+        </section>
         <section id="readingListSection" hidden="true">
             <button id="closeReadingList">__MSG_button_Close_ReadingList__</button>
             <table id="readingListTable">


### PR DESCRIPTION
Add the current version of the extension at the top of the popup.
<img width="690" height="512" alt="image" src="https://github.com/user-attachments/assets/1ca47188-8238-483c-8044-82b08cc658b7" />
