### PR TITLE
fix(twkan): wrap chapter text in paragraphs

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,8 @@
     { "name": "kerimmkirac", "email": "kerimmkirac@gmail.com" },
     { "name": "baalthasar"},
     { "name": "David Siewert", "email": "david1gruppenplan@gmail.com" },
-    { "name": "MineRobber9000" }
+    { "name": "MineRobber9000" },
+    { "name": "KitKat31337" }
   ],
   "license": "GPL-3.0-only",
   "bugs": {

--- a/plugin/js/parsers/TwkanParser.js
+++ b/plugin/js/parsers/TwkanParser.js
@@ -43,6 +43,36 @@ class TwkanParser extends Parser {
         return dom.querySelector("#txtcontent0");
     }
 
+    customRawDomToContentStep(webPage, content) { // eslint-disable-line no-unused-vars
+        // TWKAN separates paragraphs with BR elements, leaving the chapter text
+        // directly inside the content DIV.  Wrap each line in a paragraph so the
+        // generated XHTML has block-level markup around all readable text.
+        let paragraph = null;
+        let blockElements = "address, article, aside, blockquote, details, dialog, " +
+            "div, dl, fieldset, figcaption, figure, footer, form, h1, h2, h3, h4, " +
+            "h5, h6, header, hgroup, hr, main, menu, nav, ol, p, pre, section, " +
+            "table, ul";
+
+        for (let node of [...content.childNodes]) {
+            if (node.nodeName === "BR") {
+                paragraph = null;
+                node.remove();
+            } else if ((node.nodeType === Node.TEXT_NODE) &&
+                (node.textContent.trim().length === 0) && (paragraph === null)) {
+                node.remove();
+            } else if ((node.nodeType === Node.ELEMENT_NODE) &&
+                node.matches(blockElements)) {
+                paragraph = null;
+            } else {
+                if (paragraph === null) {
+                    paragraph = content.ownerDocument.createElement("p");
+                    content.insertBefore(paragraph, node);
+                }
+                paragraph.appendChild(node);
+            }
+        }
+    }
+
     extractTitleImpl(dom) {
         // From main book page: .booknav2 h1 a or h1 a
         let titleEl = dom.querySelector(".booknav2 h1 a, .booknav2 h1, h1 a");

--- a/readme.md
+++ b/readme.md
@@ -834,6 +834,7 @@ Don't forget to give the project a star! Thanks again!
     <li>baalthasar</li>
     <li>David Siewert</li>
     <li>MineRobber9000 (Parser for konkon.ink and kuupress.com)</li>
+    <li>KitKat31337 (TWKAN paragraph markup fix)</li>
   </ul>
 </details>
 

--- a/unitTest/Tests.html
+++ b/unitTest/Tests.html
@@ -72,6 +72,7 @@
     <script src="../plugin/js/parsers/TapreadParser.js"></script>
     <script src="../plugin/js/parsers/TruyenfullVisionParser.js"></script>
     <script src="../plugin/js/parsers/TruyenyyParser.js"></script>
+    <script src="../plugin/js/parsers/TwkanParser.js"></script>
     <script src="../plugin/js/parsers/AsianHobbyistParser.js"></script>
     <script src="../plugin/js/parsers/LightNovelsTranslationsParser.js"></script>
     <script src="../plugin/js/parsers/NepustationParser.js"></script>
@@ -142,6 +143,7 @@
     <script src="UtestTapreadParser.js"></script>
     <script src="UtestTruyenfullParser.js"></script>
     <script src="UtestTruyenyyParser.js"></script>
+    <script src="UtestTwkanParser.js"></script>
     <script src="UtestTranslationChickenParser.js"></script>
     <script src="UtestWattpadParser.js"></script>
     <script src="UtestWebNovelOnlineParser.js"></script>

--- a/unitTest/UtestTwkanParser.js
+++ b/unitTest/UtestTwkanParser.js
@@ -1,0 +1,36 @@
+"use strict";
+
+module("TwkanParser");
+
+test("customRawDomToContentStep", function (assert) {
+    let dom = new DOMParser().parseFromString(TwkanChapterSample, "text/html");
+    let parser = new TwkanParser();
+    let content = dom.querySelector("#txtcontent0");
+
+    parser.customRawDomToContentStep(null, content);
+
+    let paragraphs = [...content.children].filter(e => e.nodeName === "P");
+    let looseText = [...content.childNodes]
+        .filter(n => n.nodeType === Node.TEXT_NODE)
+        .some(n => n.textContent.trim().length !== 0);
+
+    assert.equal(paragraphs.length, 3);
+    assert.equal(paragraphs[0].textContent.trim(), "第一段");
+    assert.equal(paragraphs[1].textContent.trim(), "第二段強調");
+    assert.equal(paragraphs[1].querySelector("em").textContent, "強調");
+    assert.equal(paragraphs[2].textContent.trim(), "已經包裹");
+    assert.equal(content.querySelectorAll("br").length, 0);
+    assert.notOk(looseText);
+});
+
+let TwkanChapterSample =
+`<!DOCTYPE html>
+<html lang="zh">
+<body>
+    <div id="txtcontent0">
+        第一段<br /><br />
+        第二段<em>強調</em><br />
+        <p>已經包裹</p>
+    </div>
+</body>
+</html>`;


### PR DESCRIPTION
## Summary

Convert TWKAN chapter content separated by `<br>` elements into properly structured `<p>` elements before generating the EPUB.

## Problem

TWKAN provides chapter content as text nodes separated by `<br>` elements:

```html
<div id="txtcontent0">
    First paragraph<br><br>
    Second paragraph<br><br>
</div>
```

WebToEpub previously copied that structure directly, producing chapter documents similar to:

```html
<body>
    <h1>Chapter title</h1>
    First paragraph<br />
    <br />
    Second paragraph<br />
    <br />
</body>
```

Most ebook readers display this correctly, but the chapter text exists directly under `<body>` rather than inside text-containing elements.

This causes problems for tools that process EPUB content structurally. In particular, the Calibre Ebook Translator plugin looks for translatable text inside elements. Because the TWKAN chapter text is stored as loose text nodes, the plugin detects the chapter headings but skips almost all of the actual book content.

## Standards and interoperability

WebToEpub generates this content as EPUB 2 with an XHTML 1.1 doctype.

The [XHTML 1.1 structure model](https://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_structuremodule) defines the content model of `<body>` as:

```text
(Heading | Block | List)*
```

Raw character data and inline `<br>` elements are therefore not valid direct children of `<body>` under the declared XHTML 1.1 content model. Paragraphs are block elements and provide the appropriate structure for this content.

The corrected output is:

```html
<body>
    <h1>Chapter title</h1>
    <p>First paragraph</p>
    <p>Second paragraph</p>
</body>
```

Besides improving XHTML conformance, explicit paragraph markup makes the generated EPUB more interoperable with translation tools, accessibility software, converters, editors, and other applications that operate on document elements rather than loose text nodes.

## Implementation

Add a TWKAN-specific `customRawDomToContentStep()` that:

- Groups chapter text and inline elements into `<p>` elements.
- Uses `<br>` elements as paragraph boundaries and removes them afterward.
- Preserves inline formatting such as `<em>`.
- Leaves existing block-level elements unchanged.
- Removes formatting-only whitespace outside paragraphs.

The behavior is limited to `TwkanParser` and does not affect EPUBs generated from other sites.

## Testing

Added a TWKAN parser unit test confirming that:

- Loose chapter text is wrapped in paragraphs.
- Inline formatting remains inside the correct paragraph.
- Existing paragraphs are preserved.
- Separator `<br>` elements are removed.
- No meaningful loose text remains in the content container.

The implementation was also tested against a real TWKAN chapter. It produced 87 paragraph elements while preserving all non-whitespace chapter text and leaving no loose body text or `<br>` separators.